### PR TITLE
Use Clipboard API for summary copy

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -193,10 +193,17 @@
       inputs.summary.value = parts.join('\n');
     }
 
-    function copySummary(){
-      inputs.summary.select();
-      document.execCommand('copy');
-    }
+      function copySummary(){
+        if(window.isSecureContext && navigator.clipboard){
+          navigator.clipboard.writeText(inputs.summary.value).catch(err => {
+            alert('Nepavyko nukopijuoti: ' + err);
+          });
+        } else {
+          inputs.summary.select();
+          const ok = document.execCommand('copy');
+          if(!ok) alert('Nepavyko nukopijuoti');
+        }
+      }
 
     // ------------------------------
     // Išsaugojimas / atkūrimas


### PR DESCRIPTION
## Summary
- replace deprecated `document.execCommand('copy')` with modern Clipboard API
- handle clipboard promise rejections and provide fallback for insecure contexts
- check for secure contexts so copy only uses clipboard when HTTPS is available

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a30d48eed883209615c7c723c4b7dc