### PR TITLE
Remove unused default drug concentration state

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,7 +6,6 @@
 
     const state = {
       goals: { d2ct: 20, d2n: 60, d2g: 90 },
-      defaultConc: { tnk: 5, tpa: 1 },
       autosave: 'on'
     };
 

--- a/test/updateDrugDefaults.test.js
+++ b/test/updateDrugDefaults.test.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {};
+function createEl(){ return { value: '', style: {}, addEventListener: ()=>{} }; }
+function getEl(key){ if(!elements[key]) elements[key] = createEl(); return elements[key]; }
+
+const documentStub = {
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#'+id),
+  addEventListener: () => {},
+  createElement: () => createEl()
+};
+
+const sandbox = {
+  document: documentStub,
+  alert: ()=>{},
+  confirm: ()=>true,
+  localStorage: { setItem: ()=>{}, getItem: ()=>null },
+  URL: { createObjectURL: ()=>'', revokeObjectURL: ()=>{} },
+  Blob: function(){},
+  FileReader: function(){ this.readAsText = ()=>{}; },
+  setInterval: ()=>{}
+};
+
+vm.createContext(sandbox);
+const code = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(code, sandbox);
+vm.runInContext('this.inputs = inputs; this.updateDrugDefaults = updateDrugDefaults;', sandbox);
+
+// When inputs for defaults are empty, updateDrugDefaults should
+// populate drug concentration with hard-coded defaults (5 for TNK, 1 for tPA).
+sandbox.inputs.def_tnk.value = '';
+sandbox.inputs.def_tpa.value = '';
+
+sandbox.inputs.drugType.value = 'tnk';
+sandbox.updateDrugDefaults();
+assert.strictEqual(sandbox.inputs.drugConc.value, '5');
+
+sandbox.inputs.drugType.value = 'tpa';
+sandbox.updateDrugDefaults();
+assert.strictEqual(sandbox.inputs.drugConc.value, '1');
+
+console.log('updateDrugDefaults sets default concentrations correctly');
+


### PR DESCRIPTION
## Summary
- remove unused `defaultConc` from application state
- add unit test to ensure default drug concentrations populate correctly for TNK and tPA

## Testing
- `node test/updateDrugDefaults.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a30d55d04c83209d4ad3c2d153f1c8