### PR TITLE
feat: show inline errors for drug calculation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -77,3 +77,4 @@
     @media (min-width: 880px) { .split { grid-template-columns: 1.2fr .8fr; } }
 
     .mini { font-size: 11px; color: var(--muted); }
+    .error { color: var(--bad); }

--- a/index.html
+++ b/index.html
@@ -175,6 +175,7 @@
             <input id="tpa_infusion" type="text" readonly />
           </div>
         </div>
+        <div id="calc_error" class="mini error" style="display:none; margin-top:10px;"></div>
         <div class="section-actions" style="margin-top:10px;">
           <button id="calcBtn" class="btn-accent">🧮 Skaičiuoti</button>
           <span class="mini">Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši skaičiuoklė – pagalbinė.</span>

--- a/js/app.js
+++ b/js/app.js
@@ -19,6 +19,7 @@
       drugType: $('#drug_type'),  drugConc: $('#drug_conc'),
       calcWeight: $('#calc_weight'), doseTotal: $('#dose_total'), doseVol: $('#dose_volume'),
       tpaBolus: $('#tpa_bolus'),  tpaInf: $('#tpa_infusion'),
+      calcError: $('#calc_error'),
       i_ct: $('#i_ct'), i_cta: $('#i_cta'), i_tl: $('#i_thrombolysis'), i_mt: $('#i_thrombectomy'),
       i_tici: $('#i_tici'), i_decision: $('#i_decision'), notes: $('#notes'),
       goal_ct: $('#goal_ct'), goal_n: $('#goal_n'), goal_g: $('#goal_g'),
@@ -116,7 +117,13 @@
       const type = inputs.drugType.value;
       const w = Number((inputs.calcWeight.value || inputs.weight.value || '').replace(',','.'));
       const conc = Number((inputs.drugConc.value||'').replace(',','.'));
-      if(!w || !conc){ alert('Įveskite svorį ir koncentraciją.'); return; }
+      if(!Number.isFinite(w) || !Number.isFinite(conc)){
+        inputs.calcError.textContent = 'Įveskite svorį ir koncentraciją.';
+        inputs.calcError.style.display = 'block';
+        return;
+      }
+      inputs.calcError.textContent = '';
+      inputs.calcError.style.display = 'none';
 
       let totalMg = 0;
       if(type==='tnk'){


### PR DESCRIPTION
## Summary
- use `Number.isFinite` to validate weight and concentration
- display validation errors inline instead of alert

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a30d58e438832083b3e9bc929d3fc1