### PR TITLE
Improve drug calculator validation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -43,6 +43,7 @@
       outline: none; transition: border-color .2s ease, box-shadow .2s ease; box-shadow: inset 0 1px 0 rgba(255,255,255,.03);
     }
     input:focus, select:focus, textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(79,140,255,.25); }
+    input.invalid, select.invalid, textarea.invalid { border-color: var(--bad); box-shadow: 0 0 0 3px rgba(255,90,95,.25); }
 
     button { border:1px solid var(--border); background: #13224a; color: var(--text); padding:10px 14px; border-radius:12px; cursor:pointer; transition: transform .05s ease, background .2s ease, border-color .2s ease; }
     button:hover { background:#183066; border-color:#35549c; }

--- a/js/app.js
+++ b/js/app.js
@@ -119,7 +119,28 @@ state.autosave = inputs.autosave.value || 'on';
       const type = inputs.drugType.value;
       const w = Number((inputs.calcWeight.value || inputs.weight.value || '').replace(',','.'));
       const conc = Number((inputs.drugConc.value||'').replace(',','.'));
-      if(!w || !conc){ alert('Įveskite svorį ir koncentraciją.'); return; }
+      const wValid = Number.isFinite(w) && w > 0;
+      const cValid = Number.isFinite(conc) && conc > 0;
+
+      [inputs.calcWeight, inputs.weight, inputs.drugConc].forEach(el => {
+        el.classList.remove('invalid');
+        if(el.setCustomValidity) el.setCustomValidity('');
+      });
+
+      if(!wValid || !cValid){
+        if(!wValid){
+          const target = inputs.calcWeight.value ? inputs.calcWeight : inputs.weight;
+          target.classList.add('invalid');
+          if(target.setCustomValidity) target.setCustomValidity('Įveskite teisingą svorį.');
+          if(target.reportValidity) target.reportValidity();
+        }
+        if(!cValid){
+          inputs.drugConc.classList.add('invalid');
+          if(inputs.drugConc.setCustomValidity) inputs.drugConc.setCustomValidity('Įveskite teisingą koncentraciją.');
+          if(inputs.drugConc.reportValidity) inputs.drugConc.reportValidity();
+        }
+        return;
+      }
 
       let totalMg = 0;
       if(type==='tnk'){

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {};
+function createEl(){
+  return {
+    value: '',
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(...cs){ cs.forEach(c => this.classes.add(c)); },
+      remove(...cs){ cs.forEach(c => this.classes.delete(c)); },
+      contains(c){ return this.classes.has(c); }
+    },
+    addEventListener: ()=>{},
+    setCustomValidity: ()=>{},
+    reportValidity: ()=>{}
+  };
+}
+function getEl(key){ if(!elements[key]) elements[key] = createEl(); return elements[key]; }
+
+const documentStub = {
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#'+id),
+  addEventListener: () => {},
+  createElement: () => createEl()
+};
+
+const sandbox = {
+  document: documentStub,
+  alert: ()=>{},
+  confirm: ()=>true,
+  localStorage: { setItem: ()=>{}, getItem: ()=>null },
+  URL: { createObjectURL: ()=>'', revokeObjectURL: ()=>{} },
+  Blob: function(){},
+  FileReader: function(){ this.readAsText = ()=>{}; },
+  setInterval: ()=>{}
+};
+
+vm.createContext(sandbox);
+const code = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(code, sandbox);
+vm.runInContext('this.inputs = inputs; this.calcDrugs = calcDrugs;', sandbox);
+
+// invalid weight
+sandbox.inputs.calcWeight.value = '0';
+sandbox.inputs.weight.value = '';
+sandbox.inputs.drugConc.value = '5';
+sandbox.inputs.drugType.value = 'tnk';
+
+sandbox.calcDrugs();
+assert(sandbox.inputs.calcWeight.classList.contains('invalid'), 'calcWeight should be marked invalid');
+assert.strictEqual(sandbox.inputs.doseTotal.value, '', 'doseTotal should remain empty when weight invalid');
+
+// invalid concentration
+sandbox.inputs.calcWeight.value = '70';
+sandbox.inputs.calcWeight.classList.remove('invalid');
+sandbox.inputs.drugConc.value = '0';
+sandbox.inputs.drugConc.classList.remove('invalid');
+sandbox.inputs.doseTotal.value = '';
+
+sandbox.calcDrugs();
+assert(sandbox.inputs.drugConc.classList.contains('invalid'), 'drugConc should be marked invalid');
+assert.strictEqual(sandbox.inputs.doseTotal.value, '', 'doseTotal should remain empty when concentration invalid');
+
+console.log('calcDrugs handles invalid inputs');


### PR DESCRIPTION
## Summary
- validate weight and concentration fields with explicit numeric checks
- highlight invalid drug calculator inputs instead of blocking alert
- test drug calculator handling of invalid inputs

## Testing
- `node test/updateDrugDefaults.test.js`
- `node test/calcDrugs.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a31ff85a648320b246c99610dab32e