### PR TITLE
Use global comma replacement for numeric inputs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -198,9 +198,9 @@ function updateDrugDefaults() {
 function calcDrugs() {
   const type = inputs.drugType.value;
   const w = Number(
-    (inputs.calcWeight.value || inputs.weight.value || '').replace(',', '.'),
+    (inputs.calcWeight.value || inputs.weight.value || '').replace(/,/g, '.'),
   );
-  const conc = Number((inputs.drugConc.value || '').replace(',', '.'));
+  const conc = Number((inputs.drugConc.value || '').replace(/,/g, '.'));
   const wValid = Number.isFinite(w) && w > 0;
   const cValid = Number.isFinite(conc) && conc > 0;
 


### PR DESCRIPTION
## Summary
- Convert comma-to-dot replacement to regex in calcDrugs so all commas are handled for weight and concentration.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34bc2263c8320b49fe9672b5ca2a6