### PR TITLE
Clear invalid localStorage entries on load

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -448,6 +448,8 @@ function loadLS() {
   try {
     return JSON.parse(raw);
   } catch (e) {
+    console.error(e);
+    localStorage.removeItem(LS_KEY);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Remove corrupt localStorage data when parsing fails and log the error for debugging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a34f52ed648320a4f191fa7911ee07