### PR TITLE
Add VM sandbox tests for KPI and summary generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "scripts": {
     "format": "prettier --write js/app.js",
-    "test": "node test/calcDrugs.test.js && node test/updateDrugDefaults.test.js"
+    "test": "node test/calcDrugs.test.js && node test/updateDrugDefaults.test.js && node test/updateKPIs.test.js && node test/genSummary.test.js"
   }
 }

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -1,0 +1,86 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {};
+function createEl(){
+  return {
+    value: '',
+    textContent: '',
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(...cs){ cs.forEach(c => this.classes.add(c)); },
+      remove(...cs){ cs.forEach(c => this.classes.delete(c)); },
+      contains(c){ return this.classes.has(c); }
+    },
+    querySelector: () => ({ textContent: '' }),
+    addEventListener: () => {},
+    checked: false
+  };
+}
+function getEl(key){ if(!elements[key]) elements[key] = createEl(); return elements[key]; }
+
+const documentStub = {
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#'+id),
+  addEventListener: () => {},
+  createElement: () => createEl(),
+};
+
+const sandbox = {
+  document: documentStub,
+  alert: () => {},
+  confirm: () => true,
+  localStorage: { setItem: () => {}, getItem: () => null },
+  URL: { createObjectURL: () => '', revokeObjectURL: () => {} },
+  Blob: function(){},
+  FileReader: function(){ this.readAsText = () => {}; },
+  setInterval: () => {},
+};
+
+vm.createContext(sandbox);
+const code = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(code, sandbox);
+vm.runInContext('this.inputs = inputs; this.genSummary = genSummary;', sandbox);
+
+// populate typical inputs
+sandbox.inputs.name.value = 'Jonas';
+sandbox.inputs.id.value = '123';
+sandbox.inputs.dob.value = '1980-01-01';
+sandbox.inputs.sex.value = 'M';
+sandbox.inputs.weight.value = '80';
+sandbox.inputs.bp.value = '120/80';
+sandbox.inputs.nih0.value = '10';
+sandbox.inputs.nih24.value = '5';
+
+sandbox.inputs.lkw.value = '2024-01-01T07:00';
+sandbox.inputs.onset.value = '2024-01-01T07:30';
+sandbox.inputs.door.value = '2024-01-01T08:00';
+sandbox.inputs.ct.value = '2024-01-01T08:20';
+sandbox.inputs.needle.value = '2024-01-01T08:50';
+sandbox.inputs.groin.value = '2024-01-01T09:30';
+sandbox.inputs.reperf.value = '2024-01-01T10:00';
+
+sandbox.inputs.drugType.value = 'tnk';
+sandbox.inputs.drugConc.value = '5';
+sandbox.inputs.doseTotal.value = '20';
+sandbox.inputs.doseVol.value = '4';
+
+sandbox.inputs.i_ct.checked = true;
+sandbox.inputs.i_tl.checked = true;
+sandbox.inputs.i_tici.value = '2b';
+
+sandbox.inputs.i_decision.value = 'Gydymas tęsti';
+sandbox.inputs.notes.value = 'No issues';
+
+sandbox.genSummary();
+
+const summary = sandbox.inputs.summary.value;
+assert(summary.includes('PACIENTAS: Jonas, ID: 123, gim. data: 1980-01-01, lytis: M, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 h: 5.'));
+assert(summary.includes('RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 h 30 min, O2N 1 h 20 min.'));
+assert(summary.includes('TYRIMAI/INTERVENCIJOS: KT galvos, IV trombolizė, TICI: 2b.'));
+assert(summary.includes('VAISTAI: Tenekteplazė. Koncentracija: 5 mg/ml. Bendra dozė: 20 mg (4 ml).'));
+
+console.log('genSummary generates summary text correctly');

--- a/test/updateKPIs.test.js
+++ b/test/updateKPIs.test.js
@@ -1,0 +1,65 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {};
+function createEl(){
+  return {
+    value: '',
+    textContent: '',
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(...cs){ cs.forEach(c => this.classes.add(c)); },
+      remove(...cs){ cs.forEach(c => this.classes.delete(c)); },
+      contains(c){ return this.classes.has(c); }
+    },
+    querySelector: () => ({ textContent: '' }),
+    addEventListener: () => {},
+    checked: false
+  };
+}
+function getEl(key){ if(!elements[key]) elements[key] = createEl(); return elements[key]; }
+
+const documentStub = {
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#'+id),
+  addEventListener: () => {},
+  createElement: () => createEl(),
+};
+
+const sandbox = {
+  document: documentStub,
+  alert: () => {},
+  confirm: () => true,
+  localStorage: { setItem: () => {}, getItem: () => null },
+  URL: { createObjectURL: () => '', revokeObjectURL: () => {} },
+  Blob: function(){},
+  FileReader: function(){ this.readAsText = () => {}; },
+  setInterval: () => {},
+};
+
+vm.createContext(sandbox);
+const code = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(code, sandbox);
+vm.runInContext('this.inputs = inputs; this.updateKPIs = updateKPIs;', sandbox);
+
+// set goal values
+sandbox.inputs.goal_ct.value = '20';
+sandbox.inputs.goal_n.value = '60';
+sandbox.inputs.goal_g.value = '90';
+
+// set times
+sandbox.inputs.door.value = '2024-01-01T00:00';
+sandbox.inputs.ct.value = '2024-01-01T00:15'; // 15 min -> good
+sandbox.inputs.needle.value = '2024-01-01T01:10'; // 70 min -> warn
+sandbox.inputs.groin.value = '2024-01-01T02:00'; // 120 min -> bad
+
+sandbox.updateKPIs();
+
+assert(getEl('#kpi_d2ct').classList.contains('good'), 'D2CT should be classified good');
+assert(getEl('#kpi_d2n').classList.contains('warn'), 'D2N should be classified warn');
+assert(getEl('#kpi_d2g').classList.contains('bad'), 'D2G should be classified bad');
+
+console.log('updateKPIs classifies KPIs correctly');


### PR DESCRIPTION
## Summary
- add VM-based tests for `updateKPIs` classification logic
- add VM-based tests verifying `genSummary` output
- run new tests via updated npm `test` script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a35486352083208396428578d26edd