### PR TITLE
Reset validation state for new patient inputs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -550,6 +550,8 @@ function bind() {
           !el.matches('#goal_ct,#goal_n,#goal_g,#autosave')
         )
           el.value = '';
+        el.classList.remove('invalid');
+        if (el.setCustomValidity) el.setCustomValidity('');
       });
       updateKPIs();
       updateDrugDefaults();


### PR DESCRIPTION
## Summary
- remove invalid styling when clearing fields for a new patient
- reset custom validity to avoid lingering validation errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a356bb19408320b53e3ea2d1825008