### PR TITLE
feat: add grid utility classes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -618,6 +618,26 @@ section[data-tab='Intervencijos'] h3 {
   pointer-events: none;
   cursor: default;
 }
+.grid-2,
+.grid-3 {
+  display: grid;
+  gap: 10px;
+}
+
+.grid-2 {
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.grid-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+@media (max-width: 600px) {
+  .grid-2,
+  .grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
 .cols-2 {
   grid-template-columns: repeat(2, 1fr);
 }


### PR DESCRIPTION
## Summary
- add `.grid-2` and `.grid-3` utility classes for two and three column layouts
- ensure grids collapse into a single column on narrow screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a373c10aa48320bb6fcb221a6cf4c1