### PR TITLE
refactor: scope grid layout to dedicated class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -101,9 +101,13 @@ main {
   max-width: 1200px;
   margin: 12px auto;
   padding: 0 16px;
+}
+
+.layout-main {
   display: grid;
-  grid-template-columns: 220px 1fr;
+  grid-template-columns: 1fr 220px;
   gap: 12px;
+  align-items: start;
 }
 nav {
   position: sticky;
@@ -490,7 +494,7 @@ select.invalid {
     display: inline-block;
     margin-bottom: 8px;
   }
-  main {
+  .layout-main {
     grid-template-columns: 1fr;
   }
   nav {

--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
       </div>
     </header>
 
-    <div class="wrap split">
-      <main class="wrap px-0">
+    <div class="wrap layout-main">
+      <main class="px-0">
         <!-- Paciento informacija -->
         <section class="card">
           <h2>Paciento informacija</h2>
@@ -377,7 +377,7 @@
       </main>
 
       <!-- Šoninis informacinis stulpelis -->
-      <aside class="wrap px-0">
+      <aside class="px-0">
         <section class="card">
           <h2>Gyvas laikmatis</h2>
           <div id="liveTimers" class="grid-3">


### PR DESCRIPTION
## Summary
- move grid layout properties from `main` selector into new `.layout-main` class
- apply `.layout-main` in index and remove `wrap` from `main`/`aside` for vertical stacking

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a374f1d5ac83208891ee744969abab