### PR TITLE
feat: add brand logo styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,12 +52,34 @@ header {
   align-items: center;
   gap: 8px;
 }
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.logo {
+  width: 32px;
+  height: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--accent);
+  color: var(--bg);
+  border-radius: 6px;
+  font-weight: 700;
+  font-size: 18px;
+}
+.logo::before {
+  content: "ST";
+}
 .header-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
   justify-content: flex-end;
   text-align: right;
+  margin-left: auto;
+  align-items: center;
 }
 .header-actions .toolbar {
   display: flex;
@@ -863,12 +885,6 @@ details .card {
 .mini {
   font-size: 11px;
   color: var(--muted);
-}
-.header-actions {
-  margin-left: auto;
-  display: flex;
-  gap: 8px;
-  align-items: center;
 }
 .px-0 {
   padding-left: 0;

--- a/index.html
+++ b/index.html
@@ -8,13 +8,15 @@
   </head>
   <body>
     <header>
-      <div class="wrap brand">
-        <div class="logo" aria-hidden="true"></div>
-        <div>
-          <h1>Stroke Team · Greito įvedimo aplikacija</h1>
-          <div class="subtle">
-            Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
-            santrauka HIS sistemai
+      <div class="wrap">
+        <div class="brand">
+          <div class="logo" aria-hidden="true"></div>
+          <div>
+            <h1>Stroke Team · Greito įvedimo aplikacija</h1>
+            <div class="subtle">
+              Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
+              santrauka HIS sistemai
+            </div>
           </div>
         </div>
         <div class="header-actions">


### PR DESCRIPTION
## Summary
- group logo and title with new `.brand`
- style `.logo` with accent background and text mark
- keep header actions aligned

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a37760284c83208e3d91aa74ffeade