### PR TITLE
fix: ensure aside stacks vertically

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -47,6 +47,11 @@ header {
   align-items: center;
   justify-content: space-between;
 }
+.container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 14px 16px;
+}
 .header-left {
   display: flex;
   align-items: center;
@@ -130,6 +135,11 @@ main {
   grid-template-columns: 1fr 220px;
   gap: 12px;
   align-items: start;
+}
+.layout-main > aside {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 nav {
   position: sticky;

--- a/index.html
+++ b/index.html
@@ -379,7 +379,7 @@
       </main>
 
       <!-- Šoninis informacinis stulpelis -->
-      <aside class="px-0">
+      <aside class="container px-0">
         <section class="card">
           <h2>Gyvas laikmatis</h2>
           <div id="liveTimers" class="grid-3">


### PR DESCRIPTION
## Summary
- add `.container` class for width/padding without flex
- stack `<aside>` sections vertically with flex column

## Testing
- `npm test`
- `node -e "const puppeteer=require('puppeteer');(async()=>{const browser=await puppeteer.launch();const page=await browser.newPage();const filePath='file://'+process.cwd()+'/index.html';await page.goto(filePath);await page.setViewport({width:1200,height:800});const resLarge=await page.evaluate(()=>({display:getComputedStyle(document.querySelector('aside')).display,flexDirection:getComputedStyle(document.querySelector('aside')).flexDirection,positions:Array.from(document.querySelectorAll('aside > section')).map(el=>el.getBoundingClientRect().top)}));console.log('large',resLarge);await page.setViewport({width:600,height:800});const resSmall=await page.evaluate(()=>({display:getComputedStyle(document.querySelector('aside')).display,flexDirection:getComputedStyle(document.querySelector('aside')).flexDirection,positions:Array.from(document.querySelectorAll('aside > section')).map(el=>el.getBoundingClientRect().top)}));console.log('small',resSmall);await browser.close();})()" (fails: libatk-1.0.so.0 missing)


------
https://chatgpt.com/codex/tasks/task_e_68a379624e78832088da31734fba601f