### PR TITLE
Remove patient name field and auto-generate report

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,15 +57,7 @@
           <form>
             <fieldset class="grid-2">
               <div>
-                <label for="p_name">Vardas Pavardė</label>
-                <input
-                  id="p_name"
-                  type="text"
-                  placeholder="Vardenis Pavardenis"
-                />
-              </div>
-              <div>
-                <label for="p_id">Asmens kodas / ID</label>
+                <label for="p_id">Ligos istorijos Nr.</label>
                 <input id="p_id" type="text" placeholder="(nebūtina)" />
               </div>
               <div>
@@ -76,9 +68,9 @@
                 <label for="p_sex">Lytis</label>
                 <select id="p_sex">
                   <option value="">—</option>
-                  <option>Vyras</option>
-                  <option>Moteris</option>
-                  <option>Kita / nenurodyta</option>
+                  <option value="Vyras">Vyras</option>
+                  <option value="Moteris">Moteris</option>
+                  <option value="Kita / nenurodyta">Kita / nenurodyta</option>
                 </select>
               </div>
               <div>
@@ -319,12 +311,9 @@
           <textarea
             id="summary"
             class="summary mono"
-            placeholder="Spauskite „Generuoti“"
+            placeholder="Santrauka generuojama automatiškai"
           ></textarea>
           <div class="sticky-actions">
-            <button id="genSummaryBtn" class="btn primary">
-              🧾 Generuoti santrauką
-            </button>
             <button id="copySummaryBtn" class="btn">📋 Kopijuoti</button>
           </div>
         </section>
@@ -437,8 +426,8 @@
               dozę ir tūrius.
             </li>
             <li>
-              Pažymėkite atliktas intervencijas ir spauskite „Generuoti
-              santrauką“ → „Kopijuoti“.
+              Pažymėkite atliktas intervencijas, atverkite santrauką – ji
+              generuojama automatiškai – ir spauskite „Kopijuoti“.
             </li>
             <li>
               „Išsaugoti/Atkurti“ naudoja vietinę naršyklės atmintį

--- a/js/app.js
+++ b/js/app.js
@@ -22,7 +22,6 @@ const state = {
 };
 
 const inputs = {
-  name: $('#p_name'),
   id: $('#p_id'),
   dob: $('#p_dob'),
   sex: $('#p_sex'),
@@ -258,7 +257,6 @@ function round1(n) {
 // ------------------------------
 function genSummary() {
   const get = (el) => (el && el.value ? el.value : null);
-  const name = get(inputs.name) || 'Pacientas';
   const dob = get(inputs.dob) || '—';
   const sex = get(inputs.sex) || '—';
   const id = get(inputs.id) || '—';
@@ -301,7 +299,7 @@ function genSummary() {
 
   const parts = [];
   parts.push(
-    `PACIENTAS: ${name}, ID: ${id}, gim. data: ${dob}, lytis: ${sex}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}, po 24 h: ${nih24}.`,
+    `PACIENTAS: Ligos istorijos Nr. ${id}, gim. data: ${dob}, lytis: ${sex}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}, po 24 h: ${nih24}.`,
   );
   parts.push(
     `LAIKAI: LKW: ${tLKW || '—'}, Onset: ${tOnset || '—'}, Door: ${tDoor || '—'}, KT: ${tCT || '—'}, Needle: ${tN || '—'}, Groin: ${tG || '—'}, Reperfuzija: ${tR || '—'}.`,
@@ -341,6 +339,7 @@ function genSummary() {
 }
 
 function copySummary() {
+  genSummary();
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {
       alert('Nepavyko nukopijuoti: ' + err);
@@ -359,7 +358,6 @@ const LS_KEY = 'strokeTeamDraft_v1';
 
 function getPayload() {
   return {
-    p_name: inputs.name.value,
     p_id: inputs.id.value,
     p_dob: inputs.dob.value,
     p_sex: inputs.sex.value,
@@ -397,7 +395,6 @@ function getPayload() {
 
 function setPayload(p) {
   if (!p) return;
-  inputs.name.value = p.p_name || '';
   inputs.id.value = p.p_id || '';
   inputs.dob.value = p.p_dob || '';
   inputs.sex.value = p.p_sex || '';
@@ -487,7 +484,7 @@ function bind() {
   $('#calcBtn').addEventListener('click', calcDrugs);
 
   // Summary
-  $('#genSummaryBtn').addEventListener('click', genSummary);
+  $('#summary').addEventListener('focus', genSummary);
   $('#copySummaryBtn').addEventListener('click', copySummary);
 
   // Save/Load/Export/Import

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -3,28 +3,37 @@ const vm = require('vm');
 const assert = require('assert');
 
 const elements = {};
-function createEl(){
+function createEl() {
   return {
     value: '',
     textContent: '',
     style: {},
     classList: {
       classes: new Set(),
-      add(...cs){ cs.forEach(c => this.classes.add(c)); },
-      remove(...cs){ cs.forEach(c => this.classes.delete(c)); },
-      contains(c){ return this.classes.has(c); }
+      add(...cs) {
+        cs.forEach((c) => this.classes.add(c));
+      },
+      remove(...cs) {
+        cs.forEach((c) => this.classes.delete(c));
+      },
+      contains(c) {
+        return this.classes.has(c);
+      },
     },
     querySelector: () => ({ textContent: '' }),
     addEventListener: () => {},
-    checked: false
+    checked: false,
   };
 }
-function getEl(key){ if(!elements[key]) elements[key] = createEl(); return elements[key]; }
+function getEl(key) {
+  if (!elements[key]) elements[key] = createEl();
+  return elements[key];
+}
 
 const documentStub = {
   querySelector: (sel) => getEl(sel),
   querySelectorAll: () => [],
-  getElementById: (id) => getEl('#'+id),
+  getElementById: (id) => getEl('#' + id),
   addEventListener: () => {},
   createElement: () => createEl(),
 };
@@ -35,8 +44,10 @@ const sandbox = {
   confirm: () => true,
   localStorage: { setItem: () => {}, getItem: () => null },
   URL: { createObjectURL: () => '', revokeObjectURL: () => {} },
-  Blob: function(){},
-  FileReader: function(){ this.readAsText = () => {}; },
+  Blob: function () {},
+  FileReader: function () {
+    this.readAsText = () => {};
+  },
   setInterval: () => {},
 };
 
@@ -46,10 +57,9 @@ vm.runInContext(code, sandbox);
 vm.runInContext('this.inputs = inputs; this.genSummary = genSummary;', sandbox);
 
 // populate typical inputs
-sandbox.inputs.name.value = 'Jonas';
 sandbox.inputs.id.value = '123';
 sandbox.inputs.dob.value = '1980-01-01';
-sandbox.inputs.sex.value = 'M';
+sandbox.inputs.sex.value = 'Vyras';
 sandbox.inputs.weight.value = '80';
 sandbox.inputs.bp.value = '120/80';
 sandbox.inputs.nih0.value = '10';
@@ -78,9 +88,25 @@ sandbox.inputs.notes.value = 'No issues';
 sandbox.genSummary();
 
 const summary = sandbox.inputs.summary.value;
-assert(summary.includes('PACIENTAS: Jonas, ID: 123, gim. data: 1980-01-01, lytis: M, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 h: 5.'));
-assert(summary.includes('RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 h 30 min, O2N 1 h 20 min.'));
-assert(summary.includes('TYRIMAI/INTERVENCIJOS: KT galvos, IV trombolizė, TICI: 2b.'));
-assert(summary.includes('VAISTAI: Tenekteplazė. Koncentracija: 5 mg/ml. Bendra dozė: 20 mg (4 ml).'));
+assert(
+  summary.includes(
+    'PACIENTAS: Ligos istorijos Nr. 123, gim. data: 1980-01-01, lytis: Vyras, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 h: 5.',
+  ),
+);
+assert(
+  summary.includes(
+    'RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 h 30 min, O2N 1 h 20 min.',
+  ),
+);
+assert(
+  summary.includes(
+    'TYRIMAI/INTERVENCIJOS: KT galvos, IV trombolizė, TICI: 2b.',
+  ),
+);
+assert(
+  summary.includes(
+    'VAISTAI: Tenekteplazė. Koncentracija: 5 mg/ml. Bendra dozė: 20 mg (4 ml).',
+  ),
+);
 
 console.log('genSummary generates summary text correctly');


### PR DESCRIPTION
## Summary
- Remove patient name input and relabel ID field as "Ligos istorijos Nr." with explicit gender option for "Kita / nenurodyta"
- Drop the manual "Generuoti santrauką" button and generate the report automatically when the summary field is opened or copied
- Update summary generation, storage payloads and tests to match new fields

## Testing
- `npm run format`
- `npx prettier --write test/genSummary.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a37a47be508320ba1266dbdd98e597