### PR TITLE
Reset dosing outputs on invalid inputs

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -209,6 +209,10 @@ function calcDrugs() {
   });
 
   if (!wValid || !cValid) {
+    inputs.doseTotal.value = '';
+    inputs.doseVol.value = '';
+    inputs.tpaBolus.value = '';
+    inputs.tpaInf.value = '';
     if (!wValid) {
       const target = inputs.calcWeight.value
         ? inputs.calcWeight

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -106,4 +106,37 @@ assert.strictEqual(sandbox.inputs.doseVol.value, 90);
 assert.strictEqual(sandbox.inputs.tpaBolus.value, '9 mg (9 ml)');
 assert.strictEqual(sandbox.inputs.tpaInf.value, '81 mg (81 ml) · ~81 ml/val');
 
-console.log('calcDrugs handles dosing correctly and validates inputs');
+// reset outputs when inputs become invalid after a valid calculation
+sandbox.inputs.calcWeight.value = '70';
+sandbox.inputs.drugConc.value = '1';
+
+sandbox.calcDrugs();
+assert.strictEqual(sandbox.inputs.doseTotal.value, 63);
+assert.notStrictEqual(sandbox.inputs.doseTotal.value, '', 'doseTotal should be populated after valid calc');
+
+// invalidate weight
+sandbox.inputs.calcWeight.value = '0';
+
+sandbox.calcDrugs();
+assert.strictEqual(sandbox.inputs.doseTotal.value, '', 'doseTotal should clear when weight invalid');
+assert.strictEqual(sandbox.inputs.doseVol.value, '', 'doseVol should clear when weight invalid');
+assert.strictEqual(sandbox.inputs.tpaBolus.value, '', 'tpaBolus should clear when weight invalid');
+assert.strictEqual(sandbox.inputs.tpaInf.value, '', 'tpaInf should clear when weight invalid');
+
+// restore valid inputs
+sandbox.inputs.calcWeight.value = '70';
+sandbox.inputs.drugConc.value = '1';
+
+sandbox.calcDrugs();
+assert.strictEqual(sandbox.inputs.doseTotal.value, 63);
+
+// invalidate concentration
+sandbox.inputs.drugConc.value = '0';
+
+sandbox.calcDrugs();
+assert.strictEqual(sandbox.inputs.doseTotal.value, '', 'doseTotal should clear when concentration invalid');
+assert.strictEqual(sandbox.inputs.doseVol.value, '', 'doseVol should clear when concentration invalid');
+assert.strictEqual(sandbox.inputs.tpaBolus.value, '', 'tpaBolus should clear when concentration invalid');
+assert.strictEqual(sandbox.inputs.tpaInf.value, '', 'tpaInf should clear when concentration invalid');
+
+console.log('calcDrugs handles dosing correctly, validates inputs, and resets outputs');


### PR DESCRIPTION
## Summary
- Clear dose result fields when weight or concentration inputs are invalid
- Test calcDrugs to ensure outputs reset after valid calculations followed by invalid inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a406aadecc832096d7510539a70094