### PR TITLE
feat: support multiple local drafts

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,8 +30,15 @@
           >
             💾 Išsaugoti
           </button>
-          <button id="loadBtn" title="Atkurti paskutinį" class="btn">
+          <select id="draftSelect" title="Išsaugoti juodraščiai" class="btn"></select>
+          <button id="loadBtn" title="Atkurti pasirinktą" class="btn">
             📂 Atkurti
+          </button>
+          <button id="renameDraftBtn" title="Pervardyti juodraštį" class="btn">
+            ✏️ Pervardyti
+          </button>
+          <button id="deleteDraftBtn" title="Ištrinti juodraštį" class="btn">
+            🗑️ Trinti
           </button>
           <button id="exportBtn" title="Eksportuoti JSON" class="btn">
             ⬇️ Eksportuoti

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   },
   "scripts": {
     "format": "prettier --write js/app.js",
-    "test": "node test/calcDrugs.test.js && node test/updateDrugDefaults.test.js && node test/updateKPIs.test.js && node test/genSummary.test.js"
+    "test": "node test/calcDrugs.test.js && node test/updateDrugDefaults.test.js && node test/updateKPIs.test.js && node test/genSummary.test.js && node test/localStorage.test.js"
   }
 }

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+const elements = {};
+function createEl() {
+  return {
+    value: '',
+    textContent: '',
+    innerHTML: '',
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(...cs) {
+        cs.forEach((c) => this.classes.add(c));
+      },
+      remove(...cs) {
+        cs.forEach((c) => this.classes.delete(c));
+      },
+      contains(c) {
+        return this.classes.has(c);
+      },
+    },
+    querySelector: () => ({ textContent: '' }),
+    addEventListener: () => {},
+    checked: false,
+    appendChild: function (child) {
+      (this.children || (this.children = [])).push(child);
+    },
+  };
+}
+function getEl(key) {
+  if (!elements[key]) elements[key] = createEl();
+  return elements[key];
+}
+
+const documentStub = {
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#' + id),
+  addEventListener: () => {},
+  createElement: () => createEl(),
+};
+
+const localStorageStub = {
+  store: {},
+  setItem(k, v) {
+    this.store[k] = v;
+  },
+  getItem(k) {
+    return this.store[k] || null;
+  },
+  removeItem(k) {
+    delete this.store[k];
+  },
+};
+
+const sandbox = {
+  document: documentStub,
+  alert: () => {},
+  confirm: () => true,
+  prompt: () => '',
+  localStorage: localStorageStub,
+  URL: { createObjectURL: () => '', revokeObjectURL: () => {} },
+  Blob: function () {},
+  FileReader: function () { this.readAsText = () => {}; },
+  setInterval: () => {},
+};
+
+vm.createContext(sandbox);
+const code = fs.readFileSync('js/app.js', 'utf8');
+vm.runInContext(code, sandbox);
+vm.runInContext(
+  'this.inputs = inputs; this.saveLS = saveLS; this.loadLS = loadLS; this.deleteLS = deleteLS;',
+  sandbox,
+);
+
+sandbox.inputs.id.value = 'p1';
+const id1 = sandbox.saveLS();
+sandbox.inputs.id.value = 'p2';
+const id2 = sandbox.saveLS();
+assert.notStrictEqual(id1, id2, 'IDs should be unique');
+const rec1 = sandbox.loadLS(id1);
+const rec2 = sandbox.loadLS(id2);
+assert.strictEqual(rec1.p_id, 'p1', 'First record should be retrievable');
+assert.strictEqual(rec2.p_id, 'p2', 'Second record should be retrievable');
+
+sandbox.deleteLS(id1);
+assert.strictEqual(sandbox.loadLS(id1), null, 'Deleted record should not load');
+assert.strictEqual(sandbox.loadLS(id2).p_id, 'p2', 'Other record remains');
+
+console.log('localStorage handles multiple records');


### PR DESCRIPTION
## Summary
- Store patient drafts in localStorage using unique IDs instead of a single key
- Add UI controls to pick, rename, and delete drafts
- Test saving, loading, and deleting multiple drafts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4083868e48320b81584879006152e