### PR TITLE
Clarify split layout classes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -882,13 +882,13 @@ details summary::-webkit-details-marker {
 details .card {
   margin-top: 8px;
 }
-.split {
+.split-grid {
   display: grid;
   gap: 16px;
   grid-template-columns: 1fr;
 }
 @media (min-width: 880px) {
-  .split {
+  .split-grid {
     grid-template-columns: 1.2fr 0.8fr;
   }
 }


### PR DESCRIPTION
## Summary
- rename grid-based `.split` styles to `.split-grid`
- leave `.split` solely for flex layouts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a415762f108320a78e722b102cec95