### PR TITLE
Remove duplicate .mt-8 class

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -903,9 +903,6 @@ details .card {
 .h-10 {
   height: 10px;
 }
-.mt-8 {
-  margin-top: 8px;
-}
 .mt-10 {
   margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- eliminate redundant `.mt-8` margin-top declaration in CSS
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4178bd3888320a03892a8bf576a22