### PR TITLE
Add responsive navigation menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -132,7 +132,7 @@ main {
 
 .layout-main {
   display: grid;
-  grid-template-columns: 1fr 220px;
+  grid-template-columns: 220px 1fr 220px;
   gap: 12px;
   align-items: start;
 }

--- a/index.html
+++ b/index.html
@@ -57,9 +57,17 @@
     </header>
 
     <div class="wrap layout-main">
+      <button id="navToggle" class="btn">☰ Meniu</button>
+      <nav>
+        <a href="#patient" class="tab"><span class="tab-icon">🧍</span>Paciento informacija</a>
+        <a href="#times" class="tab"><span class="tab-icon">⏱️</span>Laikai ir tikslai</a>
+        <a href="#drugs" class="tab"><span class="tab-icon">💊</span>Vaistų skaičiuoklės</a>
+        <a href="#interventions" class="tab"><span class="tab-icon">🛠️</span>Tyrimai ir intervencijos</a>
+        <a href="#summarySec" class="tab"><span class="tab-icon">📄</span>Santrauka</a>
+      </nav>
       <main class="px-0">
         <!-- Paciento informacija -->
-        <section class="card">
+        <section id="patient" class="card">
           <h2>Paciento informacija</h2>
           <form>
             <fieldset class="grid-2">
@@ -108,7 +116,7 @@
         </section>
 
         <!-- Laikai -->
-        <section class="card">
+        <section id="times" class="card">
           <h2>Laikai ir tikslai</h2>
           <form>
             <fieldset class="grid-2">
@@ -196,7 +204,7 @@
         </section>
 
         <!-- Vaistų skaičiuoklės -->
-        <section class="card">
+        <section id="drugs" class="card">
           <h2>Vaistų skaičiuoklės</h2>
           <div class="grid-2">
             <div>
@@ -262,7 +270,7 @@
         </section>
 
         <!-- Intervencijos ir tyrimai -->
-        <section class="card">
+        <section id="interventions" class="card">
           <h2>Tyrimai ir intervencijos</h2>
           <div class="grid-2">
             <div>
@@ -313,7 +321,7 @@
         </section>
 
         <!-- Santrauka HIS sistemai -->
-        <section class="card full-span">
+        <section id="summarySec" class="card full-span">
           <h2>Santrauka (kopijavimui į HIS)</h2>
           <textarea
             id="summary"

--- a/js/app.js
+++ b/js/app.js
@@ -112,6 +112,16 @@ function bind() {
     reader.readAsText(file);
   });
 
+  // Navigation
+  $('#navToggle').addEventListener('click', () => {
+    document.body.classList.toggle('nav-open');
+  });
+  $$('nav .tab').forEach((tab) =>
+    tab.addEventListener('click', () =>
+      document.body.classList.remove('nav-open'),
+    ),
+  );
+
   // Clear times
   $('#clearTimes').addEventListener('click', () => {
     TIME_FIELDS.forEach((id) => {


### PR DESCRIPTION
## Summary
- Add nav toggle button and vertical navigation tabs
- Adjust layout grid for sidebar navigation
- Toggle body `nav-open` class on button click for small viewports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a41d09043083209e0940f60dcd74cd