### PR TITLE
Improve cross-browser CSS compatibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -171,8 +171,8 @@ nav .tab {
     color 0.2s;
 }
 nav .tab:hover {
-  background: color-mix(in srgb, #152231, white 10%);
-  color: color-mix(in srgb, var(--ink), white 10%);
+  background: #2c3846;
+  color: #ebf3fb;
 }
 nav .tab.active {
   background: #1f2e44;
@@ -187,7 +187,7 @@ nav .tab:focus-visible {
 section.card {
   background: rgba(18, 26, 36, 0.6);
   backdrop-filter: blur(10px);
-  border: 1px solid color-mix(in srgb, var(--line), white 20%);
+  border: 1px solid #576272;
   border-radius: 14px;
   padding: 14px;
   color: var(--ink);
@@ -293,11 +293,11 @@ textarea {
   color: #fff;
   font-weight: 700;
 }
-.pill:has(input:checked) {
+.pill.checked {
   background: var(--accent);
   border-color: #2d74b8;
 }
-.pill.red:has(input:checked) {
+.pill.red.checked {
   background: var(--red);
   border-color: #a52623;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -41,6 +41,14 @@ function bind() {
   $('#summary').addEventListener('focus', genSummary);
   $('#copySummaryBtn').addEventListener('click', copySummary);
 
+  // Pill checked state
+  document.querySelectorAll('.pill input').forEach((input) => {
+    const pill = input.closest('.pill');
+    const update = () => pill.classList.toggle('checked', input.checked);
+    input.addEventListener('change', update);
+    update();
+  });
+
   // Save/Load/Export/Import
   $('#saveBtn').addEventListener('click', () => {
     const existing = inputs.draftSelect.value;


### PR DESCRIPTION
## Summary
- Replace `color-mix` usages with fixed hex colors
- Swap `:has` selectors for `.checked` class and manage state via JS
- Add script to toggle `.checked` on pill inputs

## Testing
- `npm test`
- `npx playwright screenshot index.html /tmp/chromium.png --browser=chromium` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a42703aac883208aedeb746e790695