### PR TITLE
Apply box-sizing to pseudo-elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -13,7 +13,7 @@
   --green: #00c853;
   --ink2: #d7ecff;
 }
-* {
+*, *::before, *::after {
   box-sizing: border-box;
 }
 body {


### PR DESCRIPTION
## Summary
- Include pseudo-elements in global border-box sizing rule

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a42b6b81f483209ab81b33e5ca82a7