### PR TITLE
Fix sticky navigation and add NIHSS calculator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -143,8 +143,11 @@ main {
 }
 nav {
   position: sticky;
-  top: 68px;
+  top: 0;
+  margin-top: 68px;
   align-self: start;
+  max-height: calc(100vh - 68px);
+  overflow-y: auto;
 }
 #navToggle {
   display: none;
@@ -885,6 +888,26 @@ details summary::-webkit-details-marker {
   display: none;
 }
 details .card {
+  margin-top: 8px;
+}
+
+.nihss-grid {
+  display: grid;
+  gap: 8px;
+}
+.nihss-grid label {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.nihss-grid input[type='number'] {
+  width: 3rem;
+}
+
+.nihss-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-top: 8px;
 }
 .split-grid {

--- a/index.html
+++ b/index.html
@@ -106,10 +106,62 @@
               <div>
                 <label for="p_nihss0">NIHSS (pradinis)</label>
                 <input id="p_nihss0" type="number" min="0" max="42" />
+                <details class="nihss-calc" data-target="p_nihss0">
+                  <summary><span class="pill">🧮 Skaičiuoti</span></summary>
+                  <div class="card">
+                    <div class="nihss-grid">
+                      <label>1a. Sąmonės lygis<input type="number" min="0" max="3" data-score /></label>
+                      <label>1b. Klausimai<input type="number" min="0" max="2" data-score /></label>
+                      <label>1c. Komandos<input type="number" min="0" max="2" data-score /></label>
+                      <label>2. Žvilgsnis<input type="number" min="0" max="2" data-score /></label>
+                      <label>3. Regėjimas<input type="number" min="0" max="3" data-score /></label>
+                      <label>4. Veido judesiai<input type="number" min="0" max="3" data-score /></label>
+                      <label>5a. Rankos (K)<input type="number" min="0" max="4" data-score /></label>
+                      <label>5b. Rankos (D)<input type="number" min="0" max="4" data-score /></label>
+                      <label>6a. Kojos (K)<input type="number" min="0" max="4" data-score /></label>
+                      <label>6b. Kojos (D)<input type="number" min="0" max="4" data-score /></label>
+                      <label>7. Ataksija<input type="number" min="0" max="2" data-score /></label>
+                      <label>8. Jutimai<input type="number" min="0" max="2" data-score /></label>
+                      <label>9. Kalba<input type="number" min="0" max="3" data-score /></label>
+                      <label>10. Artikuliacija<input type="number" min="0" max="2" data-score /></label>
+                      <label>11. Neglect<input type="number" min="0" max="2" data-score /></label>
+                    </div>
+                    <div class="nihss-actions">
+                      <strong>Viso: <span class="nihss-total">0</span></strong>
+                      <button type="button" class="btn apply">Taikyti</button>
+                    </div>
+                  </div>
+                </details>
               </div>
               <div>
                 <label for="p_nihss24">NIHSS (24 h)</label>
                 <input id="p_nihss24" type="number" min="0" max="42" />
+                <details class="nihss-calc" data-target="p_nihss24">
+                  <summary><span class="pill">🧮 Skaičiuoti</span></summary>
+                  <div class="card">
+                    <div class="nihss-grid">
+                      <label>1a. Sąmonės lygis<input type="number" min="0" max="3" data-score /></label>
+                      <label>1b. Klausimai<input type="number" min="0" max="2" data-score /></label>
+                      <label>1c. Komandos<input type="number" min="0" max="2" data-score /></label>
+                      <label>2. Žvilgsnis<input type="number" min="0" max="2" data-score /></label>
+                      <label>3. Regėjimas<input type="number" min="0" max="3" data-score /></label>
+                      <label>4. Veido judesiai<input type="number" min="0" max="3" data-score /></label>
+                      <label>5a. Rankos (K)<input type="number" min="0" max="4" data-score /></label>
+                      <label>5b. Rankos (D)<input type="number" min="0" max="4" data-score /></label>
+                      <label>6a. Kojos (K)<input type="number" min="0" max="4" data-score /></label>
+                      <label>6b. Kojos (D)<input type="number" min="0" max="4" data-score /></label>
+                      <label>7. Ataksija<input type="number" min="0" max="2" data-score /></label>
+                      <label>8. Jutimai<input type="number" min="0" max="2" data-score /></label>
+                      <label>9. Kalba<input type="number" min="0" max="3" data-score /></label>
+                      <label>10. Artikuliacija<input type="number" min="0" max="2" data-score /></label>
+                      <label>11. Neglect<input type="number" min="0" max="2" data-score /></label>
+                    </div>
+                    <div class="nihss-actions">
+                      <strong>Viso: <span class="nihss-total">0</span></strong>
+                      <button type="button" class="btn apply">Taikyti</button>
+                    </div>
+                  </div>
+                </details>
               </div>
             </fieldset>
           </form>

--- a/js/app.js
+++ b/js/app.js
@@ -13,6 +13,27 @@ import {
   getDrafts,
 } from './storage.js';
 
+function initNIHSS() {
+  $$('.nihss-calc').forEach((calc) => {
+    const target = document.getElementById(calc.dataset.target);
+    const inputs = calc.querySelectorAll('input[data-score]');
+    const totalEl = calc.querySelector('.nihss-total');
+    const update = () => {
+      const sum = Array.from(inputs).reduce(
+        (s, i) => s + (parseInt(i.value, 10) || 0),
+        0,
+      );
+      totalEl.textContent = sum;
+    };
+    inputs.forEach((i) => i.addEventListener('input', update));
+    calc.querySelector('.apply').addEventListener('click', () => {
+      target.value = totalEl.textContent;
+      target.dispatchEvent(new Event('input'));
+      calc.removeAttribute('open');
+    });
+  });
+}
+
 function bind() {
   // Now buttons
   $$('button[data-now]').forEach((b) =>
@@ -169,6 +190,7 @@ function bind() {
   });
 
   // Initial
+  initNIHSS();
   updateDrugDefaults();
   updateKPIs();
   updateDraftSelect();


### PR DESCRIPTION
## Summary
- keep side navigation fixed while scrolling
- add expandable NIHSS score calculators for initial and 24h inputs

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a430188d4083209d983be393319871