### PR TITLE
Group header actions and add save status

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,6 @@
 ﻿:root {
   color-scheme: dark;
+  --header-height: 68px;
 }
 :root.dark {
   --bg: #0c1218;
@@ -94,11 +95,14 @@ header {
   min-width: 220px;
 }
 .header-actions .btn {
-  flex: 1 1 100px;
-  min-width: 100px;
+  flex: 0 1 auto;
+  min-width: auto;
 }
 #saveStatus {
   width: 100%;
+  color: var(--muted);
+  font-size: 0.8125rem;
+  margin-top: 4px;
 }
 h1 {
   font-size: 1.25rem;
@@ -144,9 +148,9 @@ main {
 nav {
   position: sticky;
   top: 0;
-  margin-top: 68px;
+  margin-top: var(--header-height);
   align-self: start;
-  max-height: calc(100vh - 68px);
+  max-height: calc(100vh - var(--header-height));
   overflow-y: auto;
 }
 #navToggle {
@@ -422,17 +426,6 @@ select.invalid {
   background: var(--yellow);
   display: inline-block;
 }
-#saveStatus {
-  color: var(--muted);
-  font-size: 0.8125rem;
-  margin-top: 4px;
-}
-#saveStatus.offline {
-  color: var(--yellow);
-}
-#saveStatus.offline::before {
-  content: '⚠ ';
-}
 .split {
   display: flex;
   gap: 12px;
@@ -680,6 +673,9 @@ section[data-tab='Intervencijos'] h3 {
   .grid-2,
   .grid-3 {
     grid-template-columns: 1fr;
+  }
+  .header-actions .btn .btn-label {
+    display: none;
   }
 }
 .cols-2 {

--- a/index.html
+++ b/index.html
@@ -21,39 +21,57 @@
         </div>
         <div class="header-actions">
           <button id="newPatientBtn" title="Naujas pacientas" class="btn">
-            🆕 Naujas
+            🆕 <span class="btn-label">Naujas</span>
           </button>
           <button
             id="saveBtn"
             title="Išsaugoti vietoje (naršyklėje)"
             class="btn"
           >
-            💾 Išsaugoti
+            💾 <span class="btn-label">Išsaugoti</span>
           </button>
-          <select id="draftSelect" title="Išsaugoti juodraščiai" class="btn"></select>
-          <button id="loadBtn" title="Atkurti pasirinktą" class="btn">
-            📂 Atkurti
-          </button>
-          <button id="renameDraftBtn" title="Pervardyti juodraštį" class="btn">
-            ✏️ Pervardyti
-          </button>
-          <button id="deleteDraftBtn" title="Ištrinti juodraštį" class="btn">
-            🗑️ Trinti
-          </button>
-          <button id="exportBtn" title="Eksportuoti JSON" class="btn">
-            ⬇️ Eksportuoti
-          </button>
-          <input
-            id="importFile"
-            type="file"
-            accept="application/json"
-            class="hidden"
-          />
-          <button id="importBtn" title="Importuoti JSON" class="btn">
-            ⬆️ Importuoti
-          </button>
+          <details class="more-actions">
+            <summary>⋮</summary>
+            <div class="menu">
+              <select
+                id="draftSelect"
+                title="Išsaugoti juodraščiai"
+                class="btn"
+              ></select>
+              <button id="loadBtn" title="Atkurti pasirinktą" class="btn">
+                📂 <span class="btn-label">Atkurti</span>
+              </button>
+              <button
+                id="renameDraftBtn"
+                title="Pervardyti juodraštį"
+                class="btn"
+              >
+                ✏️ <span class="btn-label">Pervardyti</span>
+              </button>
+              <button
+                id="deleteDraftBtn"
+                title="Ištrinti juodraštį"
+                class="btn"
+              >
+                🗑️ <span class="btn-label">Trinti</span>
+              </button>
+              <button id="exportBtn" title="Eksportuoti JSON" class="btn">
+                ⬇️ <span class="btn-label">Eksportuoti</span>
+              </button>
+              <input
+                id="importFile"
+                type="file"
+                accept="application/json"
+                class="hidden"
+              />
+              <button id="importBtn" title="Importuoti JSON" class="btn">
+                ⬆️ <span class="btn-label">Importuoti</span>
+              </button>
+            </div>
+          </details>
         </div>
       </div>
+      <div id="saveStatus" aria-live="polite"></div>
     </header>
 
     <div class="wrap layout-main">

--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,15 @@ function initNIHSS() {
 }
 
 function bind() {
+  const header = document.querySelector('header');
+  const setHeaderHeight = () =>
+    document.documentElement.style.setProperty(
+      '--header-height',
+      header.offsetHeight + 'px',
+    );
+  setHeaderHeight();
+  window.addEventListener('resize', setHeaderHeight);
+
   // Now buttons
   $$('button[data-now]').forEach((b) =>
     b.addEventListener('click', () => setNow(b.getAttribute('data-now'))),
@@ -71,6 +80,15 @@ function bind() {
   });
 
   // Save/Load/Export/Import
+  const saveStatus = document.getElementById('saveStatus');
+  const updateSaveStatus = () => {
+    const t = new Date().toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+    });
+    saveStatus.textContent = `Saved at ${t}`;
+  };
+
   $('#saveBtn').addEventListener('click', () => {
     const existing = inputs.draftSelect.value;
     let name = null;
@@ -79,6 +97,7 @@ function bind() {
     const id = saveLS(existing || undefined, name);
     inputs.draftSelect.value = id;
     alert('Išsaugota naršyklėje.');
+    updateSaveStatus();
   });
   $('#loadBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
@@ -185,8 +204,10 @@ function bind() {
     state.autosave = e.target.value;
   });
   document.addEventListener('input', () => {
-    if (state.autosave === 'on' && inputs.draftSelect.value)
+    if (state.autosave === 'on' && inputs.draftSelect.value) {
       saveLS(inputs.draftSelect.value);
+      updateSaveStatus();
+    }
   });
 
   // Initial


### PR DESCRIPTION
## Summary
- Nest rarely used draft controls in a `<details>` menu so only New and Save show by default
- Track header size with a `--header-height` variable set from JS for dynamic nav offset
- Show timestamped save feedback and allow header buttons to collapse to icons on narrow screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4363c9ccc8320ac34d6d3750c937d