### PR TITLE
Translate English UI text to Lithuanian

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
                 </div>
               </div>
               <div>
-                <label for="t_door">Atvykimas į SG (Door)</label>
+                <label for="t_door">Atvykimas į SG</label>
                 <div class="row">
                   <input id="t_door" type="datetime-local" />
                   <button class="btn ghost" data-now="t_door">Dabar</button>
@@ -219,14 +219,14 @@
                 </div>
               </div>
               <div>
-                <label for="t_needle">Trombolizės pradžia (Needle)</label>
+                <label for="t_needle">Trombolizės pradžia</label>
                 <div class="row">
                   <input id="t_needle" type="datetime-local" />
                   <button class="btn ghost" data-now="t_needle">Dabar</button>
                 </div>
               </div>
               <div>
-                <label for="t_groin">Kateterizacijos pradžia (Groin)</label>
+                <label for="t_groin">Kateterizacijos pradžia</label>
                 <div class="row">
                   <input id="t_groin" type="datetime-local" />
                   <button class="btn ghost" data-now="t_groin">Dabar</button>
@@ -246,21 +246,21 @@
             <div class="kpi" id="kpi_d2ct">
               <div class="dot"></div>
               <div>
-                <div class="muted">Door → KT</div>
+                <div class="muted">Atvykimas → KT</div>
                 <div class="val" data-val>D2CT: —</div>
               </div>
             </div>
             <div class="kpi" id="kpi_d2n">
               <div class="dot"></div>
               <div>
-                <div class="muted">Door → Needle</div>
+                <div class="muted">Atvykimas → Trombolizė</div>
                 <div class="val" data-val>D2N: —</div>
               </div>
             </div>
             <div class="kpi" id="kpi_d2g">
               <div class="dot"></div>
               <div>
-                <div class="muted">Door → Groin</div>
+                <div class="muted">Atvykimas → Kateterizacija</div>
                 <div class="val" data-val>D2G: —</div>
               </div>
             </div>
@@ -457,17 +457,17 @@
         <section class="card">
           <h2>Gyvas laikmatis</h2>
           <div id="liveTimers" class="grid-3">
-            <div class="kpi" title="Nuo Door">
+            <div class="kpi" title="Nuo atvykimo">
               <div class="dot" id="t_since_door_dot"></div>
               <div>
-                <div class="muted">Praėjo nuo Door</div>
+                <div class="muted">Praėjo nuo atvykimo</div>
                 <div class="val" id="t_since_door">—</div>
               </div>
             </div>
-            <div class="kpi" title="Nuo Onset">
+            <div class="kpi" title="Nuo pradžios">
               <div class="dot" id="t_since_onset_dot"></div>
               <div>
-                <div class="muted">Praėjo nuo Onset</div>
+                <div class="muted">Praėjo nuo pradžios</div>
                 <div class="val" id="t_since_onset">—</div>
               </div>
             </div>
@@ -477,7 +477,7 @@
             >
               <div class="dot" id="t_to_needle_dot"></div>
               <div>
-                <div class="muted">Iki Needle tikslo</div>
+                <div class="muted">Iki trombolizės tikslo</div>
                 <div class="val" id="t_to_needle">—</div>
               </div>
             </div>
@@ -490,10 +490,10 @@
           <div class="section-actions">
             <button data-now="t_ct" class="btn">📸 Pažymėti KT dabar</button>
             <button data-now="t_needle" class="btn">
-              💉 Pažymėti Needle dabar
+              💉 Pažymėti trombolizę dabar
             </button>
             <button data-now="t_groin" class="btn">
-              🕳️ Pažymėti Groin dabar
+              🕳️ Pažymėti kateterizaciją dabar
             </button>
             <button id="clearTimes" class="btn">🧹 Išvalyti laikus</button>
           </div>
@@ -503,7 +503,7 @@
           <h2>Naudojimo patarimai</h2>
           <ol class="mini m0 ml-18">
             <li>
-              Užpildykite bent „Door“ ir „Onset/LKW“ laikus – rodikliai
+              Užpildykite bent „Atvykimo“ ir „Pradžios/LKW“ laikus – rodikliai
               paskaičiuos automatškai.
             </li>
             <li>

--- a/js/app.js
+++ b/js/app.js
@@ -86,7 +86,7 @@ function bind() {
       hour: '2-digit',
       minute: '2-digit',
     });
-    saveStatus.textContent = `Saved at ${t}`;
+    saveStatus.textContent = `Išsaugota ${t}`;
   };
 
   $('#saveBtn').addEventListener('click', () => {

--- a/js/summary.js
+++ b/js/summary.js
@@ -44,10 +44,10 @@ export function genSummary() {
 
   const parts = [];
   parts.push(
-    `PACIENTAS: Ligos istorijos Nr. ${id}, gim. data: ${dob}, lytis: ${sex}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}, po 24 h: ${nih24}.`,
+    `PACIENTAS: Ligos istorijos Nr. ${id}, gim. data: ${dob}, lytis: ${sex}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}, po 24 val: ${nih24}.`,
   );
   parts.push(
-    `LAIKAI: LKW: ${tLKW || '—'}, Onset: ${tOnset || '—'}, Door: ${tDoor || '—'}, KT: ${tCT || '—'}, Needle: ${tN || '—'}, Groin: ${tG || '—'}, Reperfuzija: ${tR || '—'}.`,
+    `LAIKAI: LKW: ${tLKW || '—'}, Pradžia: ${tOnset || '—'}, Atvykimas: ${tDoor || '—'}, KT: ${tCT || '—'}, Trombolizė: ${tN || '—'}, Kateterizacija: ${tG || '—'}, Reperfuzija: ${tR || '—'}.`,
   );
   parts.push(
     `RODIKLIAI: D2CT ${fmtMins(d2ct)}, D2N ${fmtMins(d2n)}, D2G ${fmtMins(d2g)}${o2n != null ? `, O2N ${fmtMins(o2n)}` : ''}. Tikslai: D2CT ≤ ${state.goals.d2ct} min, D2N ≤ ${state.goals.d2n} min, D2G ≤ ${state.goals.d2g} min.`,

--- a/js/time.js
+++ b/js/time.js
@@ -27,7 +27,7 @@ export function fmtMins(m) {
   m = Math.abs(m);
   const h = Math.floor(m / 60);
   const r = m % 60;
-  return h ? `${sign}${h} h ${r} min` : `${sign}${r} min`;
+  return h ? `${sign}${h} val ${r} min` : `${sign}${r} min`;
 }
 
 export function toLocalInputValue(d) {

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -79,19 +79,19 @@ test('genSummary generates summary text correctly', async () => {
   inputs.i_tici.value = '2b';
 
   inputs.i_decision.value = 'Gydymas tęsti';
-  inputs.notes.value = 'No issues';
+  inputs.notes.value = 'Be pastabų';
 
   genSummary();
 
   const summary = inputs.summary.value;
   assert(
     summary.includes(
-      'PACIENTAS: Ligos istorijos Nr. 123, gim. data: 1980-01-01, lytis: Vyras, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 h: 5.'
+      'PACIENTAS: Ligos istorijos Nr. 123, gim. data: 1980-01-01, lytis: Vyras, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 val: 5.'
     )
   );
   assert(
     summary.includes(
-      'RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 h 30 min, O2N 1 h 20 min.'
+      'RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 val 30 min, O2N 1 val 20 min.'
     )
   );
   assert(

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -68,13 +68,16 @@ global.FileReader = function () {
 };
 global.setInterval = () => {};
 global.window = { isSecureContext: true };
-global.navigator = {
-  clipboard: {
-    writeText: async (txt) => {
-      global.__copied = txt;
+Object.defineProperty(global, 'navigator', {
+  value: {
+    clipboard: {
+      writeText: async (txt) => {
+        global.__copied = txt;
+      },
     },
   },
-};
+  configurable: true,
+});
 
 const { inputs } = await import('../js/state.js');
 const { saveLS, loadLS, deleteLS, setPayload } = await import('../js/storage.js');


### PR DESCRIPTION
## Summary
- lokalizavome sąsajos tekstą į lietuvių kalbą, įskaitant laiko laukus, KPI etiketes ir veiksmų mygtukus
- atnaujinome santraukos generavimą, laiko formatavimą ir pranešimą apie išsaugojimą
- pataisėme testus, kad jie atitiktų naują tekstą ir tinkamai nustatytų `navigator`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a438c56a20832090164b92b42f2e51