### PR TITLE
Add thrombolysis preparation screen with calculators

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,14 +83,14 @@
         <a href="#" data-section="arrival" class="tab"
           ><span class="tab-icon">🚑</span>Paciento atvykimas</a
         >
+        <a href="#" data-section="thrombolysis" class="tab"
+          ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
+        >
         <a href="#" data-section="patient" class="tab"
           ><span class="tab-icon">🧍</span>Paciento informacija</a
         >
         <a href="#" data-section="times" class="tab"
           ><span class="tab-icon">⏱️</span>Laikai ir tikslai</a
-        >
-        <a href="#" data-section="drugs" class="tab"
-          ><span class="tab-icon">💊</span>Vaistų skaičiuoklės</a
         >
         <a href="#" data-section="interventions" class="tab"
           ><span class="tab-icon">🛠️</span>Tyrimai ir intervencijos</a
@@ -546,6 +546,83 @@
           </form>
         </section>
 
+        <!-- Pasiruošimas trombolizei -->
+        <section id="thrombolysis" class="card hidden">
+          <h2>Pasiruošimas trombolizei</h2>
+          <form>
+            <div class="grid-3">
+              <div>
+                <label for="p_weight">Svoris (kg)</label>
+                <input id="p_weight" type="number" min="1" max="300" step="0.1" placeholder="kg" />
+              </div>
+              <div>
+                <label for="p_bp">AKS (mmHg)</label>
+                <input id="p_bp" type="text" placeholder="pvz. 178/92" />
+              </div>
+              <div>
+                <label for="p_inr">INR</label>
+                <input id="p_inr" type="number" step="0.1" />
+              </div>
+            </div>
+            <div class="mt-10">
+              <button type="button" id="bpCorrBtn" class="btn">AKS korekcija</button>
+              <div id="bpMedList" class="hidden mt-10">
+                <button type="button" class="btn bp-med" data-med="Labetololis" data-dose="10 mg">Labetololis</button>
+                <button type="button" class="btn bp-med" data-med="Enalaprilis" data-dose="1.25 mg">Enalaprilis</button>
+                <button type="button" class="btn bp-med" data-med="Metoprololis" data-dose="5 mg">Metoprololis</button>
+                <button type="button" class="btn bp-med" data-med="Natrio nitroprusidas" data-dose="0.3 µg/kg/min">Natrio nitroprusidas</button>
+                <button type="button" class="btn bp-med" data-med="Kita" data-dose="">Kita</button>
+              </div>
+              <div id="bpEntries" class="mt-10"></div>
+            </div>
+            <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
+            <div class="grid-2">
+              <div>
+                <label>Vaistas</label>
+                <select id="drug_type">
+                  <option value="tnk">Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius</option>
+                  <option value="tpa">Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90% per 60 min</option>
+                </select>
+              </div>
+              <div>
+                <label>Koncentracija (mg/ml)</label>
+                <input id="drug_conc" type="number" step="0.01" placeholder="pvz. 5" />
+              </div>
+            </div>
+            <div class="grid-3 mt-10">
+              <div>
+                <label>Svoris (kg)</label>
+                <input id="calc_weight" type="number" min="1" max="300" step="0.1" placeholder="kg" />
+              </div>
+              <div>
+                <label>Bendra dozė (mg)</label>
+                <input id="dose_total" type="number" step="0.1" readonly />
+              </div>
+              <div>
+                <label>Tūris (ml)</label>
+                <input id="dose_volume" type="number" step="0.1" readonly />
+              </div>
+            </div>
+            <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
+              <div>
+                <label>Bolius 10% (mg / ml)</label>
+                <input id="tpa_bolus" type="text" readonly />
+              </div>
+              <div>
+                <label>Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                <input id="tpa_infusion" type="text" readonly />
+              </div>
+            </div>
+            <div class="section-actions mt-10">
+              <button id="calcBtn" class="btn primary">🧮 Skaičiuoti</button>
+              <span class="mini">Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši skaičiuoklė – pagalbinė.</span>
+            </div>
+            <div class="section-actions mt-10">
+              <button type="button" id="startThrombolysis" class="btn">Pradėta trombolizė</button>
+            </div>
+          </form>
+        </section>
+
         <!-- Paciento informacija -->
         <section id="patient" class="card hidden">
           <h2>Paciento informacija</h2>
@@ -563,21 +640,6 @@
                   <option value="Moteris">Moteris</option>
                   <option value="Kita / nenurodyta">Kita / nenurodyta</option>
                 </select>
-              </div>
-              <div>
-                <label for="p_weight">Svoris (kg)</label>
-                <input
-                  id="p_weight"
-                  type="number"
-                  min="1"
-                  max="300"
-                  step="0.1"
-                  placeholder="kg"
-                />
-              </div>
-              <div>
-                <label for="p_bp">AKS atvykus (mmHg)</label>
-                <input id="p_bp" type="text" placeholder="pvz. 178/92" />
               </div>
               <div>
                 <label for="p_nihss0">NIHSS (pradinis)</label>
@@ -714,72 +776,6 @@
             <span id="g_ct_goal">20</span> min · D2N ≤
             <span id="g_n_goal">60</span> min · D2G ≤
             <span id="g_g_goal">90</span> min
-          </div>
-        </section>
-
-        <!-- Vaistų skaičiuoklės -->
-        <section id="drugs" class="card hidden">
-          <h2>Vaistų skaičiuoklės</h2>
-          <div class="grid-2">
-            <div>
-              <label>Vaistas</label>
-              <select id="drug_type">
-                <option value="tnk">
-                  Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
-                </option>
-                <option value="tpa">
-                  Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90% per
-                  60 min
-                </option>
-              </select>
-            </div>
-            <div>
-              <label>Koncentracija (mg/ml)</label>
-              <input
-                id="drug_conc"
-                type="number"
-                step="0.01"
-                placeholder="pvz. 5"
-              />
-            </div>
-          </div>
-          <div class="grid-3 mt-10">
-            <div>
-              <label>Svoris (kg)</label>
-              <input
-                id="calc_weight"
-                type="number"
-                min="1"
-                max="300"
-                step="0.1"
-                placeholder="kg"
-              />
-            </div>
-            <div>
-              <label>Bendra dozė (mg)</label>
-              <input id="dose_total" type="number" step="0.1" readonly />
-            </div>
-            <div>
-              <label>Tūris (ml)</label>
-              <input id="dose_volume" type="number" step="0.1" readonly />
-            </div>
-          </div>
-          <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
-            <div>
-              <label>Bolius 10% (mg / ml)</label>
-              <input id="tpa_bolus" type="text" readonly />
-            </div>
-            <div>
-              <label>Infuzija 90% per 60 min (mg / ml / ml/val)</label>
-              <input id="tpa_infusion" type="text" readonly />
-            </div>
-          </div>
-          <div class="section-actions mt-10">
-            <button id="calcBtn" class="btn primary">🧮 Skaičiuoti</button>
-            <span class="mini"
-              >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši
-              skaičiuoklė – pagalbinė.</span
-            >
           </div>
         </section>
 

--- a/js/app.js
+++ b/js/app.js
@@ -75,6 +75,25 @@ function bind() {
   // Age calculation
   inputs.a_dob.addEventListener('input', updateAge);
 
+  // BP correction
+  const bpMedList = $('#bpMedList');
+  const bpEntries = $('#bpEntries');
+  $('#bpCorrBtn')?.addEventListener('click', () => {
+    bpMedList.classList.toggle('hidden');
+  });
+  $$('#bpMedList .bp-med').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const med = btn.dataset.med;
+      const dose = btn.dataset.dose || '';
+      const now = new Date().toISOString().slice(11, 16);
+      const entry = document.createElement('div');
+      entry.className = 'bp-entry mt-10';
+      entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><input type="time" value="${now}" /><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+      bpEntries.appendChild(entry);
+      bpMedList.classList.add('hidden');
+    });
+  });
+
   // Pill checked state
   document.querySelectorAll('.pill input').forEach((input) => {
     const pill = input.closest('.pill');

--- a/js/state.js
+++ b/js/state.js
@@ -12,6 +12,7 @@ export const inputs = {
   sex: $('#p_sex'),
   weight: $('#p_weight'),
   bp: $('#p_bp'),
+  inr: $('#p_inr'),
   nih0: $('#p_nihss0'),
   nih24: $('#p_nihss24'),
   lkw: $('#t_lkw'),

--- a/js/storage.js
+++ b/js/storage.js
@@ -40,6 +40,7 @@ export function getPayload() {
     p_sex: inputs.sex.value,
     p_weight: inputs.weight.value,
     p_bp: inputs.bp.value,
+    p_inr: inputs.inr.value,
     p_nihss0: inputs.nih0.value,
     p_nihss24: inputs.nih24.value,
     t_lkw: inputs.lkw.value,
@@ -103,6 +104,7 @@ export function setPayload(p) {
   inputs.sex.value = p.p_sex || '';
   inputs.weight.value = p.p_weight || '';
   inputs.bp.value = p.p_bp || '';
+  inputs.inr.value = p.p_inr || '';
   inputs.nih0.value = p.p_nihss0 || '';
   inputs.nih24.value = p.p_nihss24 || '';
   inputs.lkw.value = p.t_lkw || '';


### PR DESCRIPTION
## Summary
- Introduce "Pasiruošimas trombolizei" tab with weight, AKS, INR inputs and thrombolytic calculator
- Add AKS correction list that records chosen medication time, dose and notes
- Persist INR field through state and storage modules

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a452c534448320a3d7ba5c984095ad