### PR TITLE
Pervadinta programa į Insulto komandos forma

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -831,7 +831,7 @@ table.tbl td:first-child {
     display: flex;
   }
 }
-/* Stroke app specific utilities */
+/* Insulto komandos formos specifinės funkcijos */
 .muted {
   color: var(--muted);
 }

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Stroke Team – Greito įvedimo aplikacija</title>
+    <title>Insulto komandos forma – Greito įvedimo aplikacija</title>
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
@@ -12,7 +12,7 @@
         <div class="brand">
           <div class="logo" aria-hidden="true"></div>
           <div>
-            <h1>Stroke Team · Greito įvedimo aplikacija</h1>
+            <h1>Insulto komandos forma · Greito įvedimo aplikacija</h1>
             <div class="subtle">
               Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
               santrauka HIS sistemai

--- a/js/app.js
+++ b/js/app.js
@@ -168,7 +168,7 @@ function bind() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `stroke_patient_${Date.now()}.json`;
+    a.download = `insulto_pacientas_${Date.now()}.json`;
     a.click();
     URL.revokeObjectURL(url);
   });

--- a/js/storage.js
+++ b/js/storage.js
@@ -3,7 +3,7 @@ import { updateKPIs } from './time.js';
 import { updateDrugDefaults } from './drugs.js';
 import { updateAge } from './age.js';
 
-const LS_KEY = 'strokeTeamDrafts_v1';
+const LS_KEY = 'insultoKomandaDrafts_v1';
 
 export function getDrafts() {
   const raw = localStorage.getItem(LS_KEY);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "stroke-team-app",
+  "name": "insulto-komandos-forma",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "stroke-team-app",
+      "name": "insulto-komandos-forma",
       "version": "1.0.0",
       "devDependencies": {
         "prettier": "^3.2.5"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stroke-team-app",
+  "name": "insulto-komandos-forma",
   "version": "1.0.0",
   "type": "module",
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Renamed application UI text to **Insulto komandos forma** and adjusted storage keys and export filenames
- Updated package metadata to reflect the new application name

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a454cd16148320a2c54ea5769bf38b