### PR TITLE
Fix duplicate weight input and BP correction button

### DIFF
--- a/index.html
+++ b/index.html
@@ -589,11 +589,7 @@
                 <input id="drug_conc" type="number" step="0.01" placeholder="pvz. 5" />
               </div>
             </div>
-            <div class="grid-3 mt-10">
-              <div>
-                <label>Svoris (kg)</label>
-                <input id="calc_weight" type="number" min="1" max="300" step="0.1" placeholder="kg" />
-              </div>
+            <div class="grid-2 mt-10">
               <div>
                 <label>Bendra dozė (mg)</label>
                 <input id="dose_total" type="number" step="0.1" readonly />

--- a/js/app.js
+++ b/js/app.js
@@ -76,23 +76,27 @@ function bind() {
   inputs.a_dob.addEventListener('input', updateAge);
 
   // BP correction
-  const bpMedList = $('#bpMedList');
-  const bpEntries = $('#bpEntries');
-  $('#bpCorrBtn')?.addEventListener('click', () => {
-    bpMedList.classList.toggle('hidden');
-  });
-  $$('#bpMedList .bp-med').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const med = btn.dataset.med;
-      const dose = btn.dataset.dose || '';
-      const now = new Date().toISOString().slice(11, 16);
-      const entry = document.createElement('div');
-      entry.className = 'bp-entry mt-10';
-      entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><input type="time" value="${now}" /><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
-      bpEntries.appendChild(entry);
-      bpMedList.classList.add('hidden');
+  const bpCorrBtn = document.getElementById('bpCorrBtn');
+  const bpMedList = document.getElementById('bpMedList');
+  const bpEntries = document.getElementById('bpEntries');
+  if (bpCorrBtn && bpMedList && bpEntries) {
+    bpCorrBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      bpMedList.classList.toggle('hidden');
     });
-  });
+    bpMedList.querySelectorAll('.bp-med').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const med = btn.dataset.med;
+        const dose = btn.dataset.dose || '';
+        const now = new Date().toISOString().slice(11, 16);
+        const entry = document.createElement('div');
+        entry.className = 'bp-entry mt-10';
+        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><input type="time" value="${now}" /><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+        bpEntries.appendChild(entry);
+        bpMedList.classList.add('hidden');
+      });
+    });
+  }
 
   // Pill checked state
   document.querySelectorAll('.pill input').forEach((input) => {

--- a/js/drugs.js
+++ b/js/drugs.js
@@ -15,14 +15,12 @@ export function updateDrugDefaults() {
 
 export function calcDrugs() {
   const type = inputs.drugType.value;
-  const w = Number(
-    (inputs.calcWeight.value || inputs.weight.value || '').replace(/,/g, '.'),
-  );
+  const w = Number((inputs.weight.value || '').replace(/,/g, '.'));
   const conc = Number((inputs.drugConc.value || '').replace(/,/g, '.'));
   const wValid = Number.isFinite(w) && w > 0;
   const cValid = Number.isFinite(conc) && conc > 0;
 
-  [inputs.calcWeight, inputs.weight, inputs.drugConc].forEach((el) => {
+  [inputs.weight, inputs.drugConc].forEach((el) => {
     el.classList.remove('invalid');
     if (el.setCustomValidity) el.setCustomValidity('');
   });
@@ -33,13 +31,10 @@ export function calcDrugs() {
     inputs.tpaBolus.value = '';
     inputs.tpaInf.value = '';
     if (!wValid) {
-      const target = inputs.calcWeight.value
-        ? inputs.calcWeight
-        : inputs.weight;
-      target.classList.add('invalid');
-      if (target.setCustomValidity)
-        target.setCustomValidity('Įveskite teisingą svorį.');
-      if (target.reportValidity) target.reportValidity();
+      inputs.weight.classList.add('invalid');
+      if (inputs.weight.setCustomValidity)
+        inputs.weight.setCustomValidity('Įveskite teisingą svorį.');
+      if (inputs.weight.reportValidity) inputs.weight.reportValidity();
     }
     if (!cValid) {
       inputs.drugConc.classList.add('invalid');

--- a/js/state.js
+++ b/js/state.js
@@ -27,7 +27,6 @@ export const inputs = {
   arrival_contra: $$('input[name="arrival_contra"]'),
   drugType: $('#drug_type'),
   drugConc: $('#drug_conc'),
-  calcWeight: $('#calc_weight'),
   doseTotal: $('#dose_total'),
   doseVol: $('#dose_volume'),
   tpaBolus: $('#tpa_bolus'),

--- a/js/storage.js
+++ b/js/storage.js
@@ -52,7 +52,6 @@ export function getPayload() {
     t_reperf: inputs.reperf.value,
     drug_type: inputs.drugType.value,
     drug_conc: inputs.drugConc.value,
-    calc_weight: inputs.calcWeight.value,
     dose_total: inputs.doseTotal.value,
     dose_volume: inputs.doseVol.value,
     tpa_bolus: inputs.tpaBolus.value,
@@ -116,7 +115,6 @@ export function setPayload(p) {
   inputs.reperf.value = p.t_reperf || '';
   inputs.drugType.value = p.drug_type || 'tnk';
   inputs.drugConc.value = p.drug_conc || '';
-  inputs.calcWeight.value = p.calc_weight || '';
   inputs.doseTotal.value = p.dose_total || '';
   inputs.doseVol.value = p.dose_volume || '';
   inputs.tpaBolus.value = p.tpa_bolus || '';

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -52,18 +52,17 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   const { calcDrugs } = await import('../js/drugs.js');
 
   // invalid weight
-  inputs.calcWeight.value = '0';
-  inputs.weight.value = '';
+  inputs.weight.value = '0';
   inputs.drugConc.value = '5';
   inputs.drugType.value = 'tnk';
 
   calcDrugs();
-  assert(inputs.calcWeight.classList.contains('invalid'));
+  assert(inputs.weight.classList.contains('invalid'));
   assert.strictEqual(inputs.doseTotal.value, '');
 
   // invalid concentration
-  inputs.calcWeight.value = '70';
-  inputs.calcWeight.classList.remove('invalid');
+  inputs.weight.value = '70';
+  inputs.weight.classList.remove('invalid');
   inputs.drugConc.value = '0';
   inputs.drugConc.classList.remove('invalid');
   inputs.doseTotal.value = '';
@@ -74,7 +73,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
 
   // TNK calculation
   inputs.drugConc.classList.remove('invalid');
-  inputs.calcWeight.value = '70';
+  inputs.weight.value = '70';
   inputs.drugConc.value = '5';
   inputs.drugType.value = 'tnk';
 
@@ -85,7 +84,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.strictEqual(inputs.tpaInf.value, '');
 
   // TNK maximum cap
-  inputs.calcWeight.value = '200';
+  inputs.weight.value = '200';
   inputs.drugConc.value = '5';
 
   calcDrugs();
@@ -94,7 +93,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
 
   // tPA calculation
   inputs.drugType.value = 'tpa';
-  inputs.calcWeight.value = '70';
+  inputs.weight.value = '70';
   inputs.drugConc.value = '1';
 
   calcDrugs();
@@ -107,7 +106,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   );
 
   // tPA maximum cap
-  inputs.calcWeight.value = '120';
+  inputs.weight.value = '120';
   inputs.drugConc.value = '1';
 
   calcDrugs();
@@ -120,7 +119,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   );
 
   // reset outputs when inputs become invalid after valid calc
-  inputs.calcWeight.value = '70';
+  inputs.weight.value = '70';
   inputs.drugConc.value = '1';
 
   calcDrugs();
@@ -128,7 +127,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.notStrictEqual(inputs.doseTotal.value, '');
 
   // invalidate weight
-  inputs.calcWeight.value = '0';
+  inputs.weight.value = '0';
 
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '');
@@ -137,7 +136,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.strictEqual(inputs.tpaInf.value, '');
 
   // restore valid inputs
-  inputs.calcWeight.value = '70';
+  inputs.weight.value = '70';
   inputs.drugConc.value = '1';
 
   calcDrugs();


### PR DESCRIPTION
## Summary
- Remove second weight field from thrombolysis preparation and rely on patient weight for drug dose calculations
- Ensure BP correction button reveals medication options and logs selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a456d66d888320a57e213bf9942af2