### PR TITLE
Rename patient info section to NIHSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
         <a href="#" data-section="thrombolysis" class="tab"
           ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
         >
-        <a href="#" data-section="patient" class="tab"
-          ><span class="tab-icon">🧍</span>Paciento informacija</a
+        <a href="#" data-section="nihss" class="tab"
+          ><span class="tab-icon">🧮</span>NIHSS</a
         >
         <a href="#" data-section="times" class="tab"
           ><span class="tab-icon">⏱️</span>Laikai ir tikslai</a
@@ -139,12 +139,20 @@
                     <td>Veido paralyžius</td>
                     <td>
                       <label class="pill"
-                        ><input type="radio" name="a_face" value="yes" />Taip</label
+                        ><input
+                          type="radio"
+                          name="a_face"
+                          value="yes"
+                        />Taip</label
                       >
                     </td>
                     <td>
                       <label class="pill"
-                        ><input type="radio" name="a_face" value="no" />Ne</label
+                        ><input
+                          type="radio"
+                          name="a_face"
+                          value="no"
+                        />Ne</label
                       >
                     </td>
                   </tr>
@@ -152,7 +160,11 @@
                     <td>Rankos silpnumas</td>
                     <td>
                       <label class="pill"
-                        ><input type="radio" name="a_arm" value="yes" />Taip</label
+                        ><input
+                          type="radio"
+                          name="a_arm"
+                          value="yes"
+                        />Taip</label
                       >
                     </td>
                     <td>
@@ -165,12 +177,20 @@
                     <td>Kalbos sutrikimas</td>
                     <td>
                       <label class="pill"
-                        ><input type="radio" name="a_speech" value="yes" />Taip</label
+                        ><input
+                          type="radio"
+                          name="a_speech"
+                          value="yes"
+                        />Taip</label
                       >
                     </td>
                     <td>
                       <label class="pill"
-                        ><input type="radio" name="a_speech" value="no" />Ne</label
+                        ><input
+                          type="radio"
+                          name="a_speech"
+                          value="no"
+                        />Ne</label
                       >
                     </td>
                   </tr>
@@ -230,10 +250,16 @@
                   ><input id="a_apixaban" type="checkbox" />Apiksabanas</label
                 >
                 <label class="pill"
-                  ><input id="a_rivaroxaban" type="checkbox" />Rivaroksabanas</label
+                  ><input
+                    id="a_rivaroxaban"
+                    type="checkbox"
+                  />Rivaroksabanas</label
                 >
                 <label class="pill"
-                  ><input id="a_dabigatran" type="checkbox" />Dabigatranas</label
+                  ><input
+                    id="a_dabigatran"
+                    type="checkbox"
+                  />Dabigatranas</label
                 >
                 <label class="pill"
                   ><input id="a_edoxaban" type="checkbox" />Edoksabanas</label
@@ -252,11 +278,12 @@
                   (aktyvuoti insulto komandą)</label
                 >
                 <label class="pill"
-                  ><input type="radio" name="a_lkw" value="4.5-24" /> &gt;4,5 val
-                  bet &lt;24 val (informuoti SPS gyd.)</label
+                  ><input type="radio" name="a_lkw" value="4.5-24" /> &gt;4,5
+                  val bet &lt;24 val (informuoti SPS gyd.)</label
                 >
                 <label class="pill"
-                  ><input type="radio" name="a_lkw" value="unknown" /> Nežinoma</label
+                  ><input type="radio" name="a_lkw" value="unknown" />
+                  Nežinoma</label
                 >
               </div>
             </fieldset>
@@ -338,7 +365,8 @@
                       name="arrival_contra"
                       value="Netiesioginio veikimo antikoaguliantai (INR ≥1,7)"
                     />
-                    Pacientas vartoja netiesioginio veikimo antikoaguliantus (INR ≥1,7)
+                    Pacientas vartoja netiesioginio veikimo antikoaguliantus
+                    (INR ≥1,7)
                   </label>
                 </li>
                 <li>
@@ -348,7 +376,8 @@
                       name="arrival_contra"
                       value="Arterijos punkcija nekompresuojamoje vietoje per 7 d."
                     />
-                    Arterijos punkcija nekompresuojamoje vietoje per pastarąsias 7 d.
+                    Arterijos punkcija nekompresuojamoje vietoje per pastarąsias
+                    7 d.
                   </label>
                 </li>
                 <li>
@@ -468,7 +497,8 @@
                       name="arrival_contra"
                       value="Virškinamojo ar šlapimo takų kraujavimas per 21 d."
                     />
-                    Virškinamojo ar šlapimo takų kraujavimas per pastarąsias 21 d.
+                    Virškinamojo ar šlapimo takų kraujavimas per pastarąsias 21
+                    d.
                   </label>
                 </li>
                 <li>
@@ -518,7 +548,8 @@
                       name="arrival_contra"
                       value="Tiesioginiai trombino ar Xa inhibitoriai su patologiniais tyrimais"
                     />
-                    Tiesioginiai trombino ar Xa inhibitoriai su patologiniais tyrimais
+                    Tiesioginiai trombino ar Xa inhibitoriai su patologiniais
+                    tyrimais
                   </label>
                 </li>
                 <li>
@@ -553,7 +584,14 @@
             <div class="grid-3">
               <div>
                 <label for="p_weight">Svoris (kg)</label>
-                <input id="p_weight" type="number" min="1" max="300" step="0.1" placeholder="kg" />
+                <input
+                  id="p_weight"
+                  type="number"
+                  min="1"
+                  max="300"
+                  step="0.1"
+                  placeholder="kg"
+                />
               </div>
               <div>
                 <label for="p_bp">AKS (mmHg)</label>
@@ -565,13 +603,50 @@
               </div>
             </div>
             <div class="mt-10">
-              <button type="button" id="bpCorrBtn" class="btn">AKS korekcija</button>
+              <button type="button" id="bpCorrBtn" class="btn">
+                AKS korekcija
+              </button>
               <div id="bpMedList" class="hidden mt-10">
-                <button type="button" class="btn bp-med" data-med="Labetololis" data-dose="10 mg">Labetololis</button>
-                <button type="button" class="btn bp-med" data-med="Enalaprilis" data-dose="1.25 mg">Enalaprilis</button>
-                <button type="button" class="btn bp-med" data-med="Metoprololis" data-dose="5 mg">Metoprololis</button>
-                <button type="button" class="btn bp-med" data-med="Natrio nitroprusidas" data-dose="0.3 µg/kg/min">Natrio nitroprusidas</button>
-                <button type="button" class="btn bp-med" data-med="Kita" data-dose="">Kita</button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Labetololis"
+                  data-dose="10 mg"
+                >
+                  Labetololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Enalaprilis"
+                  data-dose="1.25 mg"
+                >
+                  Enalaprilis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Metoprololis"
+                  data-dose="5 mg"
+                >
+                  Metoprololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Natrio nitroprusidas"
+                  data-dose="0.3 µg/kg/min"
+                >
+                  Natrio nitroprusidas
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Kita"
+                  data-dose=""
+                >
+                  Kita
+                </button>
               </div>
               <div id="bpEntries" class="mt-10"></div>
             </div>
@@ -580,13 +655,23 @@
               <div>
                 <label>Vaistas</label>
                 <select id="drug_type">
-                  <option value="tnk">Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius</option>
-                  <option value="tpa">Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90% per 60 min</option>
+                  <option value="tnk">
+                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                  </option>
+                  <option value="tpa">
+                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                    per 60 min
+                  </option>
                 </select>
               </div>
               <div>
                 <label>Koncentracija (mg/ml)</label>
-                <input id="drug_conc" type="number" step="0.01" placeholder="pvz. 5" />
+                <input
+                  id="drug_conc"
+                  type="number"
+                  step="0.01"
+                  placeholder="pvz. 5"
+                />
               </div>
             </div>
             <div class="grid-2 mt-10">
@@ -611,32 +696,24 @@
             </div>
             <div class="section-actions mt-10">
               <button id="calcBtn" class="btn primary">🧮 Skaičiuoti</button>
-              <span class="mini">Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši skaičiuoklė – pagalbinė.</span>
+              <span class="mini"
+                >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši
+                skaičiuoklė – pagalbinė.</span
+              >
             </div>
             <div class="section-actions mt-10">
-              <button type="button" id="startThrombolysis" class="btn">Pradėta trombolizė</button>
+              <button type="button" id="startThrombolysis" class="btn">
+                Pradėta trombolizė
+              </button>
             </div>
           </form>
         </section>
 
-        <!-- Paciento informacija -->
-        <section id="patient" class="card hidden">
-          <h2>Paciento informacija</h2>
+        <!-- NIHSS -->
+        <section id="nihss" class="card hidden">
+          <h2>NIHSS</h2>
           <form>
-            <fieldset class="grid-2">
-              <div>
-                <label for="p_id">Ligos istorijos Nr.</label>
-                <input id="p_id" type="text" placeholder="(nebūtina)" />
-              </div>
-              <div>
-                <label for="p_sex">Lytis</label>
-                <select id="p_sex">
-                  <option value="">—</option>
-                  <option value="Vyras">Vyras</option>
-                  <option value="Moteris">Moteris</option>
-                  <option value="Kita / nenurodyta">Kita / nenurodyta</option>
-                </select>
-              </div>
+            <fieldset>
               <div>
                 <label for="p_nihss0">NIHSS (pradinis)</label>
                 <input id="p_nihss0" type="number" min="0" max="42" />
@@ -644,51 +721,111 @@
                   <summary><span class="pill">🧮 Skaičiuoti</span></summary>
                   <div class="card">
                     <div class="nihss-grid">
-                      <label>1a. Sąmonės lygis<input type="number" min="0" max="3" data-score /></label>
-                      <label>1b. Klausimai<input type="number" min="0" max="2" data-score /></label>
-                      <label>1c. Komandos<input type="number" min="0" max="2" data-score /></label>
-                      <label>2. Žvilgsnis<input type="number" min="0" max="2" data-score /></label>
-                      <label>3. Regėjimas<input type="number" min="0" max="3" data-score /></label>
-                      <label>4. Veido judesiai<input type="number" min="0" max="3" data-score /></label>
-                      <label>5a. Rankos (K)<input type="number" min="0" max="4" data-score /></label>
-                      <label>5b. Rankos (D)<input type="number" min="0" max="4" data-score /></label>
-                      <label>6a. Kojos (K)<input type="number" min="0" max="4" data-score /></label>
-                      <label>6b. Kojos (D)<input type="number" min="0" max="4" data-score /></label>
-                      <label>7. Ataksija<input type="number" min="0" max="2" data-score /></label>
-                      <label>8. Jutimai<input type="number" min="0" max="2" data-score /></label>
-                      <label>9. Kalba<input type="number" min="0" max="3" data-score /></label>
-                      <label>10. Artikuliacija<input type="number" min="0" max="2" data-score /></label>
-                      <label>11. Neglect<input type="number" min="0" max="2" data-score /></label>
-                    </div>
-                    <div class="nihss-actions">
-                      <strong>Viso: <span class="nihss-total">0</span></strong>
-                      <button type="button" class="btn apply">Taikyti</button>
-                    </div>
-                  </div>
-                </details>
-              </div>
-              <div>
-                <label for="p_nihss24">NIHSS (24 h)</label>
-                <input id="p_nihss24" type="number" min="0" max="42" />
-                <details class="nihss-calc" data-target="p_nihss24">
-                  <summary><span class="pill">🧮 Skaičiuoti</span></summary>
-                  <div class="card">
-                    <div class="nihss-grid">
-                      <label>1a. Sąmonės lygis<input type="number" min="0" max="3" data-score /></label>
-                      <label>1b. Klausimai<input type="number" min="0" max="2" data-score /></label>
-                      <label>1c. Komandos<input type="number" min="0" max="2" data-score /></label>
-                      <label>2. Žvilgsnis<input type="number" min="0" max="2" data-score /></label>
-                      <label>3. Regėjimas<input type="number" min="0" max="3" data-score /></label>
-                      <label>4. Veido judesiai<input type="number" min="0" max="3" data-score /></label>
-                      <label>5a. Rankos (K)<input type="number" min="0" max="4" data-score /></label>
-                      <label>5b. Rankos (D)<input type="number" min="0" max="4" data-score /></label>
-                      <label>6a. Kojos (K)<input type="number" min="0" max="4" data-score /></label>
-                      <label>6b. Kojos (D)<input type="number" min="0" max="4" data-score /></label>
-                      <label>7. Ataksija<input type="number" min="0" max="2" data-score /></label>
-                      <label>8. Jutimai<input type="number" min="0" max="2" data-score /></label>
-                      <label>9. Kalba<input type="number" min="0" max="3" data-score /></label>
-                      <label>10. Artikuliacija<input type="number" min="0" max="2" data-score /></label>
-                      <label>11. Neglect<input type="number" min="0" max="2" data-score /></label>
+                      <label
+                        >1a. Sąmonės lygis<input
+                          type="number"
+                          min="0"
+                          max="3"
+                          data-score
+                      /></label>
+                      <label
+                        >1b. Klausimai<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >1c. Komandos<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >2. Žvilgsnis<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >3. Regėjimas<input
+                          type="number"
+                          min="0"
+                          max="3"
+                          data-score
+                      /></label>
+                      <label
+                        >4. Veido judesiai<input
+                          type="number"
+                          min="0"
+                          max="3"
+                          data-score
+                      /></label>
+                      <label
+                        >5a. Rankos (K)<input
+                          type="number"
+                          min="0"
+                          max="4"
+                          data-score
+                      /></label>
+                      <label
+                        >5b. Rankos (D)<input
+                          type="number"
+                          min="0"
+                          max="4"
+                          data-score
+                      /></label>
+                      <label
+                        >6a. Kojos (K)<input
+                          type="number"
+                          min="0"
+                          max="4"
+                          data-score
+                      /></label>
+                      <label
+                        >6b. Kojos (D)<input
+                          type="number"
+                          min="0"
+                          max="4"
+                          data-score
+                      /></label>
+                      <label
+                        >7. Ataksija<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >8. Jutimai<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >9. Kalba<input
+                          type="number"
+                          min="0"
+                          max="3"
+                          data-score
+                      /></label>
+                      <label
+                        >10. Artikuliacija<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
+                      <label
+                        >11. Neglect<input
+                          type="number"
+                          min="0"
+                          max="2"
+                          data-score
+                      /></label>
                     </div>
                     <div class="nihss-actions">
                       <strong>Viso: <span class="nihss-total">0</span></strong>

--- a/js/app.js
+++ b/js/app.js
@@ -146,7 +146,10 @@ function bind() {
     const existing = inputs.draftSelect.value;
     let name = null;
     if (!existing)
-      name = prompt('Juodraščio pavadinimas?', inputs.id.value || 'Juodraštis');
+      name = prompt(
+        'Juodraščio pavadinimas?',
+        inputs.nih0.value || 'Juodraštis',
+      );
     const id = saveLS(existing || undefined, name);
     inputs.draftSelect.value = id;
     alert('Išsaugota naršyklėje.');

--- a/js/state.js
+++ b/js/state.js
@@ -8,13 +8,10 @@ export const state = {
 };
 
 export const inputs = {
-  id: $('#p_id'),
-  sex: $('#p_sex'),
   weight: $('#p_weight'),
   bp: $('#p_bp'),
   inr: $('#p_inr'),
   nih0: $('#p_nihss0'),
-  nih24: $('#p_nihss24'),
   lkw: $('#t_lkw'),
   onset: $('#t_onset'),
   door: $('#t_door'),

--- a/js/storage.js
+++ b/js/storage.js
@@ -36,13 +36,10 @@ function setRadioValue(nodes, value) {
 
 export function getPayload() {
   return {
-    p_id: inputs.id.value,
-    p_sex: inputs.sex.value,
     p_weight: inputs.weight.value,
     p_bp: inputs.bp.value,
     p_inr: inputs.inr.value,
     p_nihss0: inputs.nih0.value,
-    p_nihss24: inputs.nih24.value,
     t_lkw: inputs.lkw.value,
     t_onset: inputs.onset.value,
     t_door: inputs.door.value,
@@ -99,13 +96,10 @@ export function getPayload() {
 
 export function setPayload(p) {
   if (!p) return;
-  inputs.id.value = p.p_id || '';
-  inputs.sex.value = p.p_sex || '';
   inputs.weight.value = p.p_weight || '';
   inputs.bp.value = p.p_bp || '';
   inputs.inr.value = p.p_inr || '';
   inputs.nih0.value = p.p_nihss0 || '';
-  inputs.nih24.value = p.p_nihss24 || '';
   inputs.lkw.value = p.t_lkw || '';
   inputs.onset.value = p.t_onset || '';
   inputs.door.value = p.t_door || '';
@@ -170,7 +164,10 @@ export function saveLS(id, name) {
   const drafts = getDrafts();
   const draftId = id || Date.now().toString();
   const draftName =
-    name || drafts[draftId]?.name || inputs.id.value || `Juodraštis ${draftId}`;
+    name ||
+    drafts[draftId]?.name ||
+    inputs.nih0.value ||
+    `Juodraštis ${draftId}`;
   drafts[draftId] = { name: draftName, data: getPayload() };
   setDrafts(drafts);
   updateDraftSelect(draftId);

--- a/js/summary.js
+++ b/js/summary.js
@@ -4,12 +4,9 @@ import { toDate, minsBetween, fmtMins } from './time.js';
 export function genSummary() {
   const get = (el) => (el && el.value ? el.value : null);
   const dob = get(inputs.a_dob) || '—';
-  const sex = get(inputs.sex) || '—';
-  const id = get(inputs.id) || '—';
   const w = get(inputs.weight) || '—';
   const bp = get(inputs.bp) || '—';
   const nih0 = get(inputs.nih0) || '—';
-  const nih24 = get(inputs.nih24) || '—';
 
   const tLKW = get(inputs.lkw),
     tOnset = get(inputs.onset),
@@ -44,7 +41,7 @@ export function genSummary() {
 
   const parts = [];
   parts.push(
-    `PACIENTAS: Ligos istorijos Nr. ${id}, gim. data: ${dob}, lytis: ${sex}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}, po 24 val: ${nih24}.`,
+    `PACIENTAS: gim. data: ${dob}, svoris: ${w} kg, AKS atvykus: ${bp}. NIHSS pradinis: ${nih0}.`,
   );
   parts.push(
     `LAIKAI: LKW: ${tLKW || '—'}, Pradžia: ${tOnset || '—'}, Atvykimas: ${tDoor || '—'}, KT: ${tCT || '—'}, Trombolizė: ${tN || '—'}, Kateterizacija: ${tG || '—'}, Reperfuzija: ${tR || '—'}.`,

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -53,13 +53,10 @@ test('genSummary generates summary text correctly', async () => {
   const { genSummary } = await import('../js/summary.js');
 
   // populate typical inputs
-  inputs.id.value = '123';
   inputs.a_dob.value = '1980-01-01';
-  inputs.sex.value = 'Vyras';
   inputs.weight.value = '80';
   inputs.bp.value = '120/80';
   inputs.nih0.value = '10';
-  inputs.nih24.value = '5';
 
   inputs.lkw.value = '2024-01-01T07:00';
   inputs.onset.value = '2024-01-01T07:30';
@@ -86,23 +83,22 @@ test('genSummary generates summary text correctly', async () => {
   const summary = inputs.summary.value;
   assert(
     summary.includes(
-      'PACIENTAS: Ligos istorijos Nr. 123, gim. data: 1980-01-01, lytis: Vyras, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10, po 24 val: 5.'
-    )
+      'PACIENTAS: gim. data: 1980-01-01, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10.',
+    ),
   );
   assert(
     summary.includes(
-      'RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 val 30 min, O2N 1 val 20 min.'
-    )
+      'RODIKLIAI: D2CT 20 min, D2N 50 min, D2G 1 val 30 min, O2N 1 val 20 min.',
+    ),
   );
   assert(
     summary.includes(
-      'TYRIMAI/INTERVENCIJOS: KT galvos, IV trombolizė, TICI: 2b.'
-    )
+      'TYRIMAI/INTERVENCIJOS: KT galvos, IV trombolizė, TICI: 2b.',
+    ),
   );
   assert(
     summary.includes(
-      'VAISTAI: Tenekteplazė. Koncentracija: 5 mg/ml. Bendra dozė: 20 mg (4 ml).'
-    )
+      'VAISTAI: Tenekteplazė. Koncentracija: 5 mg/ml. Bendra dozė: 20 mg (4 ml).',
+    ),
   );
 });
-

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -80,7 +80,9 @@ Object.defineProperty(global, 'navigator', {
 });
 
 const { inputs } = await import('../js/state.js');
-const { saveLS, loadLS, deleteLS, setPayload } = await import('../js/storage.js');
+const { saveLS, loadLS, deleteLS, setPayload } = await import(
+  '../js/storage.js'
+);
 const { copySummary } = await import('../js/summary.js');
 
 function resetInputs() {
@@ -94,47 +96,47 @@ test('localStorage handles multiple records', { concurrency: false }, () => {
   localStorageStub.store = {};
   resetInputs();
 
-  inputs.id.value = 'p1';
+  inputs.nih0.value = '1';
   saveLS('d1');
-  inputs.id.value = 'p2';
+  inputs.nih0.value = '2';
   saveLS('d2');
   const rec1 = loadLS('d1');
   const rec2 = loadLS('d2');
-  assert.strictEqual(rec1.p_id, 'p1');
-  assert.strictEqual(rec2.p_id, 'p2');
+  assert.strictEqual(rec1.p_nihss0, '1');
+  assert.strictEqual(rec2.p_nihss0, '2');
 
   deleteLS('d1');
   assert.strictEqual(loadLS('d1'), null);
-  assert.strictEqual(loadLS('d2').p_id, 'p2');
+  assert.strictEqual(loadLS('d2').p_nihss0, '2');
 });
 
-test('saveLS/loadLS with copySummary copies generated text', { concurrency: false }, async () => {
-  localStorageStub.store = {};
-  resetInputs();
+test(
+  'saveLS/loadLS with copySummary copies generated text',
+  { concurrency: false },
+  async () => {
+    localStorageStub.store = {};
+    resetInputs();
 
-  inputs.id.value = 'abc';
-  inputs.a_dob.value = '2000-01-01';
-  inputs.sex.value = 'Vyras';
-  inputs.weight.value = '70';
-  inputs.bp.value = '120/80';
-  inputs.nih0.value = '5';
-  inputs.lkw.value = '2024-01-01T08:00';
-  inputs.door.value = '2024-01-01T08:30';
-  inputs.ct.value = '2024-01-01T08:45';
-  inputs.drugType.value = 'tnk';
-  inputs.drugConc.value = '5';
-  inputs.doseTotal.value = '10';
-  inputs.doseVol.value = '2';
+    inputs.a_dob.value = '2000-01-01';
+    inputs.weight.value = '70';
+    inputs.bp.value = '120/80';
+    inputs.nih0.value = '5';
+    inputs.lkw.value = '2024-01-01T08:00';
+    inputs.door.value = '2024-01-01T08:30';
+    inputs.ct.value = '2024-01-01T08:45';
+    inputs.drugType.value = 'tnk';
+    inputs.drugConc.value = '5';
+    inputs.doseTotal.value = '10';
+    inputs.doseVol.value = '2';
 
-  saveLS('draft1');
-  inputs.id.value = '';
-  inputs.a_dob.value = '';
-  setPayload(loadLS('draft1'));
+    saveLS('draft1');
+    inputs.a_dob.value = '';
+    setPayload(loadLS('draft1'));
 
-  await copySummary();
+    await copySummary();
 
-  assert.ok(global.__copied.includes('PACIENTAS'));
-  assert.ok(global.__copied.includes('abc'));
-  assert.strictEqual(getEl('#summary').value, global.__copied);
-});
-
+    assert.ok(global.__copied.includes('PACIENTAS'));
+    assert.ok(global.__copied.includes('NIHSS pradinis: 5'));
+    assert.strictEqual(getEl('#summary').value, global.__copied);
+  },
+);


### PR DESCRIPTION
## Summary
- rename "Paciento informacija" tab to "NIHSS" and leave only initial NIHSS calculator
- drop patient ID, sex, and 24h NIHSS fields from state, storage, and summary
- update tests for new NIHSS-only workflow

## Testing
- `npm run format`
- `npx prettier --write test/*.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a459d0f62083208f2b1e7a90586e43