### PR TITLE
Streamline sidebar and keep live timer visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -677,6 +677,9 @@ section[data-tab='Intervencijos'] h3 {
   .header-actions .btn .btn-label {
     display: none;
   }
+  #liveTimers {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 table.tbl {
@@ -839,11 +842,6 @@ table.tbl td:first-child {
   font-family:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono',
     'Courier New', monospace;
-}
-.section-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
 }
 .footer {
   margin: 16px auto 24px;

--- a/index.html
+++ b/index.html
@@ -1102,41 +1102,7 @@
           <div class="mini mt-8">Laikmačiai atsinaujina kas 1 s</div>
         </section>
 
-        <section class="card">
-          <h2>Greiti veiksmai</h2>
-          <div class="section-actions">
-            <button data-now="t_ct" class="btn">📸 Pažymėti KT dabar</button>
-            <button data-now="t_needle" class="btn">
-              💉 Pažymėti trombolizę dabar
-            </button>
-            <button data-now="t_groin" class="btn">
-              🕳️ Pažymėti kateterizaciją dabar
-            </button>
-            <button id="clearTimes" class="btn">🧹 Išvalyti laikus</button>
-          </div>
-        </section>
-
-        <section class="card">
-          <h2>Naudojimo patarimai</h2>
-          <ol class="mini m0 ml-18">
-            <li>
-              Užpildykite bent „Atvykimo“ ir „Pradžios/LKW“ laikus – rodikliai
-              paskaičiuos automatškai.
-            </li>
-            <li>
-              Įveskite svorį ir pasirinkite vaistą – skaičiuoklė pateiks tikslią
-              dozę ir tūrius.
-            </li>
-            <li>
-              Pažymėkite atliktas intervencijas, atverkite santrauką – ji
-              generuojama automatiškai – ir spauskite „Kopijuoti“.
-            </li>
-            <li>
-              „Išsaugoti/Atkurti“ naudoja vietinę naršyklės atmintį
-              (localStorage).
-            </li>
-          </ol>
-        </section>
+        
       </aside>
     </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -234,15 +234,6 @@ function bind() {
   );
   showSection(tabs[0]?.dataset.section);
 
-  // Clear times
-  $('#clearTimes').addEventListener('click', () => {
-    TIME_FIELDS.forEach((id) => {
-      const el = document.getElementById(id);
-      el.value = '';
-    });
-    updateKPIs();
-  });
-
   // New patient
   $('#newPatientBtn').addEventListener('click', () => {
     if (confirm('Išvalyti visus laukus naujam pacientui?')) {


### PR DESCRIPTION
## Summary
- ensure live timer stays in one row on small screens
- remove quick actions and usage tips sections
- clean up unused JS and CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a462f283408320bb657ee4567b20c7