### PR TITLE
Fix navigation tab handling and responsive timer grid

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -671,6 +671,12 @@ section[data-tab='Intervencijos'] h3 {
   grid-template-columns: repeat(3, 1fr);
 }
 
+#liveTimers {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
 @media (max-width: 600px) {
   .grid-2,
   .grid-3 {
@@ -680,7 +686,7 @@ section[data-tab='Intervencijos'] h3 {
     display: none;
   }
   #liveTimers {
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -77,22 +77,22 @@
     <div class="wrap layout-main">
       <button id="navToggle" class="btn">☰ Meniu</button>
       <nav>
-        <a href="#" data-section="activation" class="tab active"
+        <a href="#activation" data-section="activation" class="tab active"
           ><span class="tab-icon">🚨</span>Aktyvacija</a
         >
-        <a href="#" data-section="arrival" class="tab"
+        <a href="#arrival" data-section="arrival" class="tab"
           ><span class="tab-icon">🚑</span>Paciento atvykimas</a
         >
-        <a href="#" data-section="thrombolysis" class="tab"
+        <a href="#thrombolysis" data-section="thrombolysis" class="tab"
           ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
         >
-        <a href="#" data-section="nihss" class="tab"
+        <a href="#nihss" data-section="nihss" class="tab"
           ><span class="tab-icon">🧮</span>NIHSS</a
         >
-        <a href="#" data-section="decision" class="tab"
+        <a href="#decision" data-section="decision" class="tab"
           ><span class="tab-icon">☑️</span>Sprendimas</a
         >
-        <a href="#" data-section="summarySec" class="tab"
+        <a href="#summarySec" data-section="summarySec" class="tab"
           ><span class="tab-icon">📄</span>Santrauka</a
         >
       </nav>

--- a/js/app.js
+++ b/js/app.js
@@ -213,16 +213,23 @@ function bind() {
     tabs.forEach((t) => t.classList.toggle('active', t.dataset.section === id));
     document.body.classList.remove('nav-open');
   };
+  const activateFromHash = () => {
+    const id = location.hash.slice(1) || tabs[0]?.dataset.section;
+    if (id) showSection(id);
+  };
   $('#navToggle').addEventListener('click', () => {
     document.body.classList.toggle('nav-open');
   });
   tabs.forEach((tab) =>
     tab.addEventListener('click', (e) => {
       e.preventDefault();
-      showSection(tab.dataset.section);
+      const id = tab.dataset.section;
+      showSection(id);
+      if (id) location.hash = id;
     }),
   );
-  showSection(tabs[0]?.dataset.section);
+  window.addEventListener('hashchange', activateFromHash);
+  activateFromHash();
 
   // New patient
   $('#newPatientBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Ensure navigation tabs use real section links and respond to URL hash changes
- Add responsive grid styling for live timers to fit small screens

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46c6252d88320922c75d984e51d93