### PR TITLE
feat: auto update decision time and summary

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -211,6 +211,8 @@ function bind() {
   const showSection = (id) => {
     sections.forEach((s) => s.classList.toggle('hidden', s.id !== id));
     tabs.forEach((t) => t.classList.toggle('active', t.dataset.section === id));
+    if (id === 'summarySec') genSummary();
+    if (id === 'decision' && !inputs.d_time.value) setNow('d_time');
     document.body.classList.remove('nav-open');
   };
   const activateFromHash = () => {
@@ -259,6 +261,7 @@ function bind() {
       saveLS(inputs.draftSelect.value);
       updateSaveStatus();
     }
+    if (!$('#summarySec').classList.contains('hidden')) genSummary();
   });
 
   // Initial


### PR DESCRIPTION
## Summary
- populate decision time automatically when the decision tab opens
- generate summary immediately when the summary tab is shown and keep it in sync with form edits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a470ded1a88320b9a882c364546fb2