### PR TITLE
Improve date/time input UX with placeholders and styled buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -247,6 +247,38 @@ textarea {
   min-height: 80px;
   resize: vertical;
 }
+
+.input-group {
+  position: relative;
+}
+
+.input-group button {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+input[type='date']::-webkit-calendar-picker-indicator,
+input[type='datetime-local']::-webkit-calendar-picker-indicator {
+  filter: invert(1);
+  cursor: pointer;
+}
+
+input[type='date']::-webkit-calendar-picker-indicator:hover,
+input[type='datetime-local']::-webkit-calendar-picker-indicator:hover {
+  filter: invert(1) brightness(1.2);
+}
+
+.time-input {
+  width: 100%;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #0f1620;
+  color: var(--ink);
+  font-size: 0.875rem;
+}
 .btn {
   border: 1px solid var(--line);
   background: #152231;

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
                 </div>
                 <div>
                   <label for="a_dob">Gimimo data</label>
-                  <input id="a_dob" type="date" />
+                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" step="60" />
                   <div id="a_age_display" class="subtle"></div>
                   <input id="a_age" type="hidden" />
                 </div>
@@ -320,8 +320,15 @@
             <fieldset>
               <legend>Atvykimo laikas</legend>
               <div class="row">
-                <input id="t_door" type="datetime-local" />
-                <button class="btn ghost" data-now="t_door">Dabar</button>
+                <div class="input-group">
+                  <input
+                    id="t_door"
+                    type="datetime-local"
+                    placeholder="YYYY-MM-DD HH:MM"
+                    step="60"
+                  />
+                  <button class="btn ghost" data-now="t_door">Dabar</button>
+                </div>
               </div>
             </fieldset>
 
@@ -342,8 +349,15 @@
                 >
               </div>
               <div id="lkwTimeRow" class="row mt-4">
-                <input id="t_lkw" type="datetime-local" />
-                <button class="btn ghost" data-now="t_lkw">Dabar</button>
+                <div class="input-group">
+                  <input
+                    id="t_lkw"
+                    type="datetime-local"
+                    placeholder="YYYY-MM-DD HH:MM"
+                    step="60"
+                  />
+                  <button class="btn ghost" data-now="t_lkw">Dabar</button>
+                </div>
               </div>
             </fieldset>
 
@@ -886,8 +900,15 @@
             <fieldset>
               <legend>Sprendimo laikas</legend>
               <div class="row">
-                <input id="d_time" type="datetime-local" />
-                <button class="btn ghost" data-now="d_time">Dabar</button>
+                <div class="input-group">
+                  <input
+                    id="d_time"
+                    type="datetime-local"
+                    placeholder="YYYY-MM-DD HH:MM"
+                    step="60"
+                  />
+                  <button class="btn ghost" data-now="d_time">Dabar</button>
+                </div>
               </div>
             </fieldset>
             <fieldset class="mt-10">

--- a/js/app.js
+++ b/js/app.js
@@ -81,9 +81,13 @@ function bind() {
         const now = new Date().toISOString().slice(11, 16);
         const entry = document.createElement('div');
         entry.className = 'bp-entry mt-10';
-        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><input type="time" value="${now}" /><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+        const id = `bp_time_${Date.now()}`;
+        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-now="${id}">Dabar</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
+        entry
+          .querySelector(`[data-now="${id}"]`)
+          .addEventListener('click', () => setNow(id));
       });
     });
   }


### PR DESCRIPTION
## Summary
- Add placeholders and minute-step support to date and datetime inputs while wrapping their "Dabar" buttons in `.input-group` containers
- Style input groups, calendar picker indicators and new `.time-input` class for consistent appearance
- Generate dynamic time inputs with `time-input` class and associated "Dabar" functionality

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4870fcbdc832090985f012d72882d