### PR TITLE
Add warning for unsaved form changes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -35,6 +35,7 @@ function initNIHSS() {
 }
 
 function bind() {
+  let dirty = false;
   const header = document.querySelector('header');
   const setHeaderHeight = () =>
     document.documentElement.style.setProperty(
@@ -147,6 +148,7 @@ function bind() {
     inputs.draftSelect.value = id;
     alert('Išsaugota naršyklėje.');
     updateSaveStatus();
+    dirty = false;
   });
   $('#loadBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
@@ -158,6 +160,7 @@ function bind() {
     if (p) {
       setPayload(p);
       alert('Atkurta iš naršyklės.');
+      dirty = false;
     } else alert('Nėra išsaugoto įrašo.');
   });
   $('#renameDraftBtn').addEventListener('click', () => {
@@ -262,11 +265,23 @@ function bind() {
     state.autosave = e.target.value;
   });
   document.addEventListener('input', () => {
+    dirty = true;
     if (state.autosave === 'on' && inputs.draftSelect.value) {
       saveLS(inputs.draftSelect.value);
       updateSaveStatus();
+      dirty = false;
     }
     if (!$('#summarySec').classList.contains('hidden')) genSummary();
+  });
+  document.addEventListener('change', () => {
+    dirty = true;
+  });
+
+  window.addEventListener('beforeunload', (e) => {
+    if (dirty) {
+      e.preventDefault();
+      e.returnValue = '';
+    }
   });
 
   // Initial


### PR DESCRIPTION
## Summary
- Track unsaved edits with a `dirty` flag and warn before leaving the page
- Reset the dirty flag after saving or loading a draft

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a488f87b108320bbf88661dd3983b2