### PR TITLE
feat: replace alerts with toast notifications

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
+    <div id="toastContainer" class="toast-container"></div>
     <header>
       <div class="wrap">
         <div class="brand">

--- a/js/app.js
+++ b/js/app.js
@@ -14,6 +14,20 @@ import {
   getDrafts,
 } from './storage.js';
 
+function showToast(msg) {
+  const container = document.getElementById('toastContainer');
+  if (!container) return;
+  const el = document.createElement('div');
+  el.className = 'toast';
+  el.textContent = msg;
+  container.appendChild(el);
+  setTimeout(() => {
+    el.classList.add('hide');
+    el.addEventListener('transitionend', () => el.remove());
+  }, 3000);
+}
+window.showToast = showToast;
+
 function initNIHSS() {
   $$('.nihss-calc').forEach((calc) => {
     const target = document.getElementById(calc.dataset.target);
@@ -146,27 +160,27 @@ function bind() {
       );
     const id = saveLS(existing || undefined, name);
     inputs.draftSelect.value = id;
-    alert('Išsaugota naršyklėje.');
+    showToast('Išsaugota naršyklėje.');
     updateSaveStatus();
     dirty = false;
   });
   $('#loadBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
     if (!id) {
-      alert('Pasirinkite juodraštį.');
+      showToast('Pasirinkite juodraštį.');
       return;
     }
     const p = loadLS(id);
     if (p) {
       setPayload(p);
-      alert('Atkurta iš naršyklės.');
+      showToast('Atkurta iš naršyklės.');
       dirty = false;
-    } else alert('Nėra išsaugoto įrašo.');
+    } else showToast('Nėra išsaugoto įrašo.');
   });
   $('#renameDraftBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
     if (!id) {
-      alert('Pasirinkite juodraštį.');
+      showToast('Pasirinkite juodraštį.');
       return;
     }
     const drafts = getDrafts();
@@ -176,7 +190,7 @@ function bind() {
   $('#deleteDraftBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
     if (!id) {
-      alert('Pasirinkite juodraštį.');
+      showToast('Pasirinkite juodraštį.');
       return;
     }
     if (confirm('Ištrinti juodraštį?')) {
@@ -203,9 +217,9 @@ function bind() {
       try {
         const p = JSON.parse(reader.result);
         setPayload(p);
-        alert('Importuota.');
+        showToast('Importuota.');
       } catch (err) {
-        alert('Klaida skaitant JSON.');
+        showToast('Klaida skaitant JSON.');
       }
       e.target.value = '';
     };

--- a/js/summary.js
+++ b/js/summary.js
@@ -45,11 +45,11 @@ export function copySummary() {
   genSummary();
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {
-      alert('Nepavyko nukopijuoti: ' + err);
+      showToast('Nepavyko nukopijuoti: ' + err);
     });
   } else {
     inputs.summary.select();
     const ok = document.execCommand('copy');
-    if (!ok) alert('Nepavyko nukopijuoti');
+    if (!ok) showToast('Nepavyko nukopijuoti');
   }
 }

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -38,7 +38,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   };
 
   global.document = documentStub;
-  global.alert = () => {};
+  global.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -39,7 +39,7 @@ test('genSummary generates summary text correctly', async () => {
   };
 
   global.document = documentStub;
-  global.alert = () => {};
+  global.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -57,7 +57,7 @@ const localStorageStub = {
 };
 
 global.document = documentStub;
-global.alert = () => {};
+global.showToast = () => {};
 global.confirm = () => true;
 global.prompt = () => '';
 global.localStorage = localStorageStub;

--- a/test/updateDrugDefaults.test.js
+++ b/test/updateDrugDefaults.test.js
@@ -20,7 +20,7 @@ test('updateDrugDefaults sets default concentrations correctly', async () => {
   };
 
   global.document = documentStub;
-  global.alert = () => {};
+  global.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };


### PR DESCRIPTION
## Summary
- add toast container to page layout
- implement global `showToast` helper and replace `alert` usage
- adjust tests to stub toast notifications

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48bc09b68832083a3d8b1eccad83f