### PR TITLE
Add draft list filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
           <details class="more-actions">
             <summary>⋮</summary>
             <div class="menu">
+              <input id="draftFilter" placeholder="Filtruoti..." />
               <select
                 id="draftSelect"
                 title="Išsaugoti juodraščiai"

--- a/js/app.js
+++ b/js/app.js
@@ -150,6 +150,12 @@ function bind() {
     saveStatus.textContent = `Išsaugota ${t}`;
   };
 
+  const draftFilter = document.getElementById('draftFilter');
+  if (draftFilter)
+    draftFilter.addEventListener('input', () =>
+      updateDraftSelect(inputs.draftSelect.value),
+    );
+
   $('#saveBtn').addEventListener('click', () => {
     const existing = inputs.draftSelect.value;
     let name = null;

--- a/js/storage.js
+++ b/js/storage.js
@@ -173,16 +173,20 @@ export function updateDraftSelect(selectedId) {
   const sel = inputs.draftSelect;
   if (!sel) return;
   sel.innerHTML = '';
+  const filterVal =
+    document.getElementById('draftFilter')?.value.toLowerCase() || '';
   const drafts = getDrafts();
   const opt0 = document.createElement('option');
   opt0.value = '';
   opt0.textContent = '—';
   sel.appendChild(opt0);
-  Object.entries(drafts).forEach(([id, d]) => {
-    const opt = document.createElement('option');
-    opt.value = id;
-    opt.textContent = d.name;
-    sel.appendChild(opt);
-  });
+  Object.entries(drafts)
+    .filter(([, d]) => d.name.toLowerCase().includes(filterVal))
+    .forEach(([id, d]) => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = d.name;
+      sel.appendChild(opt);
+    });
   if (selectedId) sel.value = selectedId;
 }


### PR DESCRIPTION
## Summary
- Add filter input for draft selection and hook it up in the UI
- Filter draft entries in `updateDraftSelect` based on text input
- Refresh draft list as user types in the filter field

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a48d1fd8ec8320bacd51dad4079854