### PR TITLE
refactor: extract toast utility

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2,6 +2,7 @@ import { $, $$, inputs, state } from './state.js';
 import { setNow } from './time.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { genSummary, copySummary } from './summary.js';
+import { showToast } from './toast.js';
 import { updateAge } from './age.js';
 import {
   saveLS,
@@ -13,20 +14,6 @@ import {
   updateDraftSelect,
   getDrafts,
 } from './storage.js';
-
-function showToast(msg) {
-  const container = document.getElementById('toastContainer');
-  if (!container) return;
-  const el = document.createElement('div');
-  el.className = 'toast';
-  el.textContent = msg;
-  container.appendChild(el);
-  setTimeout(() => {
-    el.classList.add('hide');
-    el.addEventListener('transitionend', () => el.remove());
-  }, 3000);
-}
-window.showToast = showToast;
 
 function initNIHSS() {
   $$('.nihss-calc').forEach((calc) => {

--- a/js/summary.js
+++ b/js/summary.js
@@ -1,4 +1,5 @@
 import { inputs } from './state.js';
+import { showToast } from './toast.js';
 
 export function genSummary() {
   const get = (el) => (el && el.value ? el.value : null);

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,0 +1,25 @@
+const toast = {
+  showToast(msg) {
+    if (typeof document === 'undefined') return;
+    const container = document.getElementById('toastContainer');
+    if (!container) return;
+    const el = document.createElement('div');
+    el.className = 'toast';
+    el.textContent = msg;
+    container.appendChild(el);
+    setTimeout(() => {
+      el.classList.add('hide');
+      el.addEventListener('transitionend', () => el.remove());
+    }, 3000);
+  },
+};
+
+export function showToast(msg) {
+  return toast.showToast(msg);
+}
+
+if (typeof window !== 'undefined') {
+  window.showToast = showToast;
+}
+
+export { toast };

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -38,7 +38,8 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   };
 
   global.document = documentStub;
-  global.showToast = () => {};
+  const { toast } = await import('../js/toast.js');
+  toast.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -39,7 +39,8 @@ test('genSummary generates summary text correctly', async () => {
   };
 
   global.document = documentStub;
-  global.showToast = () => {};
+  const { toast } = await import('../js/toast.js');
+  toast.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -57,7 +57,8 @@ const localStorageStub = {
 };
 
 global.document = documentStub;
-global.showToast = () => {};
+const { toast } = await import('../js/toast.js');
+toast.showToast = () => {};
 global.confirm = () => true;
 global.prompt = () => '';
 global.localStorage = localStorageStub;

--- a/test/updateDrugDefaults.test.js
+++ b/test/updateDrugDefaults.test.js
@@ -20,7 +20,8 @@ test('updateDrugDefaults sets default concentrations correctly', async () => {
   };
 
   global.document = documentStub;
-  global.showToast = () => {};
+  const { toast } = await import('../js/toast.js');
+  toast.showToast = () => {};
   global.confirm = () => true;
   global.localStorage = { setItem: () => {}, getItem: () => null };
   global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };


### PR DESCRIPTION
## Summary
- move toast logic into new `js/toast.js` module and expose `showToast`
- import toast module in app and summary scripts instead of relying on global
- update tests to stub toast utility through module path

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a4a58e7f208320958cab89739741d5