### PR TITLE
Remove invalid step attribute from DOB field and add age calculation tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                 </div>
                 <div>
                   <label for="a_dob">Gimimo data</label>
-                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" step="60" />
+                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" />
                   <div id="a_age_display" class="subtle"></div>
                   <input id="a_age" type="hidden" />
                 </div>

--- a/test/age.test.js
+++ b/test/age.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+test('calcAge and updateAge compute and display age correctly', async () => {
+  const RealDate = global.Date;
+  const mockNow = new RealDate('2024-01-01T00:00:00Z');
+  global.Date = class extends RealDate {
+    constructor(value) {
+      return value ? new RealDate(value) : mockNow;
+    }
+    static now() {
+      return mockNow.getTime();
+    }
+  };
+
+  const elements = {};
+  function createEl() {
+    return {
+      value: '',
+      textContent: '',
+      classList: { add: () => {}, remove: () => {}, contains: () => false },
+      addEventListener: () => {},
+      style: {},
+    };
+  }
+  function getEl(sel) {
+    if (!elements[sel]) elements[sel] = createEl();
+    return elements[sel];
+  }
+
+  global.document = {
+    querySelector: (sel) => getEl(sel),
+    querySelectorAll: () => [],
+    getElementById: (id) => getEl('#' + id),
+    addEventListener: () => {},
+  };
+
+  const { inputs } = await import('../js/state.js');
+  const { calcAge, updateAge } = await import('../js/age.js');
+
+  // valid date of birth
+  inputs.a_dob.value = '2000-01-01';
+  assert.strictEqual(calcAge('2000-01-01'), '24');
+  updateAge();
+  assert.strictEqual(inputs.a_age.value, '24');
+  assert.strictEqual(elements['#a_age_display'].textContent, '24 m.');
+
+  // empty date of birth
+  inputs.a_dob.value = '';
+  updateAge();
+  assert.strictEqual(inputs.a_age.value, '');
+  assert.strictEqual(elements['#a_age_display'].textContent, '');
+
+  global.Date = RealDate;
+});


### PR DESCRIPTION
## Summary
- Remove `step="60"` from DOB date input so the field uses valid attributes only
- Add unit tests exercising `calcAge` and `updateAge` to ensure age display and field updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4a82cef2c8320b42c63e4ed121f98