### PR TITLE
Bubble change events when setting radio values

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -29,7 +29,7 @@ function getRadioValue(nodes) {
 function setRadioValue(nodes, value) {
   nodes.forEach((n) => {
     n.checked = n.value === value;
-    n.dispatchEvent(new Event('change'));
+    n.dispatchEvent(new Event('change', { bubbles: true }));
   });
 }
 

--- a/test/changeEvents.test.js
+++ b/test/changeEvents.test.js
@@ -1,0 +1,98 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const elements = {};
+function createEl() {
+  return {
+    value: '',
+    textContent: '',
+    innerHTML: '',
+    style: {},
+    classList: {
+      classes: new Set(),
+      add(...cs) {
+        cs.forEach((c) => this.classes.add(c));
+      },
+      remove(...cs) {
+        cs.forEach((c) => this.classes.delete(c));
+      },
+      contains(c) {
+        return this.classes.has(c);
+      },
+    },
+    querySelector: () => ({ textContent: '' }),
+    checked: false,
+    appendChild(child) {
+      (this.children || (this.children = [])).push(child);
+    },
+    select: () => {},
+    listeners: {},
+    addEventListener(type, fn) {
+      (this.listeners[type] || (this.listeners[type] = [])).push(fn);
+    },
+    dispatchEvent(evt) {
+      (this.listeners[evt.type] || []).forEach((fn) => fn.call(this, evt));
+      if (evt.bubbles && document.dispatchEvent) document.dispatchEvent(evt);
+    },
+  };
+}
+function getEl(key) {
+  if (!elements[key]) elements[key] = createEl();
+  return elements[key];
+}
+
+const documentStub = {
+  listeners: {},
+  querySelector: (sel) => getEl(sel),
+  querySelectorAll: () => [],
+  getElementById: (id) => getEl('#' + id),
+  addEventListener(type, fn) {
+    (this.listeners[type] || (this.listeners[type] = [])).push(fn);
+  },
+  dispatchEvent(evt) {
+    (this.listeners[evt.type] || []).forEach((fn) => fn.call(this, evt));
+  },
+  createElement: () => createEl(),
+  execCommand: () => true,
+};
+
+global.document = documentStub;
+const localStorageStub = {
+  setItem() {},
+  getItem() {
+    return null;
+  },
+  removeItem() {},
+};
+
+global.localStorage = localStorageStub;
+global.confirm = () => true;
+global.prompt = () => '';
+global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };
+global.Blob = function () {};
+global.FileReader = function () {
+  this.readAsText = () => {};
+};
+global.setInterval = () => {};
+global.window = { isSecureContext: true };
+
+test('setPayload bubbles change events', async () => {
+  const { inputs } = await import('../js/state.js');
+  const { setPayload } = await import('../js/storage.js');
+
+  const known = createEl();
+  known.value = 'known';
+  const unknown = createEl();
+  unknown.value = 'unknown';
+  inputs.lkw_type = [known, unknown];
+
+  let changeCount = 0;
+  document.addEventListener('change', () => {
+    changeCount++;
+  });
+
+  setPayload({ arrival_lkw_type: 'unknown' });
+
+  assert.strictEqual(unknown.checked, true);
+  assert.strictEqual(changeCount, 2);
+});


### PR DESCRIPTION
## Summary
- ensure setRadioValue emits bubbling change events
- add regression test verifying change handlers fire after payload load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a4b1dddc788320a309dccd4375ff5b