### PR TITLE
feat: improve toast notifications

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -671,6 +671,7 @@ section[data-tab='Intervencijos'] h3 {
   transition:
     opacity 0.3s,
     transform 0.3s;
+  position: relative;
 }
 .toast.success {
   background: var(--green);
@@ -683,6 +684,17 @@ section[data-tab='Intervencijos'] h3 {
 .toast.hide {
   opacity: 0;
   transform: translateY(10px);
+}
+
+.toast-close {
+  position: absolute;
+  top: 4px;
+  right: 8px;
+  background: none;
+  border: none;
+  color: inherit;
+  font-size: 16px;
+  cursor: pointer;
 }
 .arrival-timer {
   font-family: monospace;

--- a/js/app.js
+++ b/js/app.js
@@ -153,7 +153,7 @@ function bind() {
       );
     const id = saveLS(existing || undefined, name);
     inputs.draftSelect.value = id;
-    showToast('Išsaugota naršyklėje.');
+    showToast('Išsaugota naršyklėje.', { type: 'success' });
     updateSaveStatus();
     dirty = false;
   });
@@ -166,9 +166,9 @@ function bind() {
     const p = loadLS(id);
     if (p) {
       setPayload(p);
-      showToast('Atkurta iš naršyklės.');
+      showToast('Atkurta iš naršyklės.', { type: 'success' });
       dirty = false;
-    } else showToast('Nėra išsaugoto įrašo.');
+    } else showToast('Nėra išsaugoto įrašo.', { type: 'error' });
   });
   $('#renameDraftBtn').addEventListener('click', () => {
     const id = inputs.draftSelect.value;
@@ -210,9 +210,9 @@ function bind() {
       try {
         const p = JSON.parse(reader.result);
         setPayload(p);
-        showToast('Importuota.');
+        showToast('Importuota.', { type: 'success' });
       } catch (err) {
-        showToast('Klaida skaitant JSON.');
+        showToast('Klaida skaitant JSON.', { type: 'error' });
       }
       e.target.value = '';
     };

--- a/js/summary.js
+++ b/js/summary.js
@@ -46,11 +46,11 @@ export function copySummary() {
   genSummary();
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {
-      showToast('Nepavyko nukopijuoti: ' + err);
+      showToast('Nepavyko nukopijuoti: ' + err, { type: 'error' });
     });
   } else {
     inputs.summary.select();
     const ok = document.execCommand('copy');
-    if (!ok) showToast('Nepavyko nukopijuoti');
+    if (!ok) showToast('Nepavyko nukopijuoti', { type: 'error' });
   }
 }

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,21 +1,55 @@
 const toast = {
-  showToast(msg) {
+  queue: [],
+  showing: false,
+  _showNext() {
+    if (this.showing) return;
+    const item = this.queue.shift();
+    if (!item) return;
+    const { msg, options, container } = item;
+    const { type, duration = 3000 } = options;
+    const el = document.createElement('div');
+    el.className = 'toast' + (type ? ` ${type}` : '');
+    el.textContent = msg;
+
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'toast-close';
+    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.innerHTML = '&times;';
+    el.appendChild(closeBtn);
+
+    const hide = () => {
+      el.classList.add('hide');
+      el.addEventListener(
+        'transitionend',
+        () => {
+          el.remove();
+          this.showing = false;
+          this._showNext();
+        },
+        { once: true },
+      );
+    };
+
+    const timer = setTimeout(hide, duration);
+    closeBtn.addEventListener('click', () => {
+      clearTimeout(timer);
+      hide();
+    });
+
+    container.appendChild(el);
+    this.showing = true;
+  },
+  showToast(msg, options = {}) {
     if (typeof document === 'undefined') return;
     const container = document.getElementById('toastContainer');
     if (!container) return;
-    const el = document.createElement('div');
-    el.className = 'toast';
-    el.textContent = msg;
-    container.appendChild(el);
-    setTimeout(() => {
-      el.classList.add('hide');
-      el.addEventListener('transitionend', () => el.remove());
-    }, 3000);
+    this.queue.push({ msg, options, container });
+    this._showNext();
   },
 };
 
-export function showToast(msg) {
-  return toast.showToast(msg);
+export function showToast(msg, options) {
+  return toast.showToast(msg, options);
 }
 
 if (typeof window !== 'undefined') {


### PR DESCRIPTION
## Summary
- allow toast API to accept options for type and duration with queueing and manual close
- style close button and make toast container positioning relative
- use toast types for success and error messages across app and summary

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a55c847aec832098a164146b2426da