### PR TITLE
refactor: extract computeDose and add tests

### DIFF
--- a/js/computeDose.js
+++ b/js/computeDose.js
@@ -1,0 +1,39 @@
+const INFUSION_MINUTES = 60;
+
+function round1(n) {
+  return Math.round(n * 10) / 10;
+}
+
+export function computeDose(weight, concentration, type) {
+  const w = Number(weight);
+  const c = Number(concentration);
+  if (!Number.isFinite(w) || w <= 0) return null;
+  if (!Number.isFinite(c) || c <= 0) return null;
+
+  if (type === 'tnk') {
+    const doseTotal = Math.min(25, round1(0.25 * w));
+    return {
+      doseTotal,
+      doseVol: round1(doseTotal / c),
+      bolus: null,
+      infusion: null,
+    };
+  }
+
+  if (type === 'tpa') {
+    const doseTotal = Math.min(90, round1(0.9 * w));
+    const bolusMg = round1(doseTotal * 0.1);
+    const infusionMg = round1(doseTotal - bolusMg);
+    const bolusMl = round1(bolusMg / c);
+    const infusionMl = round1(infusionMg / c);
+    const rateMlH = round1((infusionMl / INFUSION_MINUTES) * 60);
+    return {
+      doseTotal,
+      doseVol: round1(doseTotal / c),
+      bolus: { mg: bolusMg, ml: bolusMl },
+      infusion: { mg: infusionMg, ml: infusionMl, rateMlH },
+    };
+  }
+
+  return null;
+}

--- a/js/drugs.js
+++ b/js/drugs.js
@@ -1,6 +1,5 @@
 import { inputs } from './state.js';
-
-const INFUSION_MINUTES = 60;
+import { computeDose } from './computeDose.js';
 
 export function updateDrugDefaults() {
   const type = inputs.drugType.value;
@@ -45,27 +44,18 @@ export function calcDrugs() {
     return;
   }
 
-  let totalMg = 0;
-  if (type === 'tnk') {
-    totalMg = Math.min(25, round1(0.25 * w));
-    inputs.doseTotal.value = totalMg;
-    inputs.doseVol.value = round1(totalMg / conc);
+  const result = computeDose(w, conc, type);
+  if (!result) return;
+
+  inputs.doseTotal.value = result.doseTotal;
+  inputs.doseVol.value = result.doseVol;
+
+  if (result.bolus) {
+    const { bolus, infusion } = result;
+    inputs.tpaBolus.value = `${bolus.mg} mg (${bolus.ml} ml)`;
+    inputs.tpaInf.value = `${infusion.mg} mg (${infusion.ml} ml) · ~${infusion.rateMlH} ml/val`;
+  } else {
     inputs.tpaBolus.value = '';
     inputs.tpaInf.value = '';
-  } else {
-    totalMg = Math.min(90, round1(0.9 * w));
-    const bolusMg = round1(totalMg * 0.1);
-    const infMg = round1(totalMg - bolusMg);
-    const bolusMl = round1(bolusMg / conc);
-    const infMl = round1(infMg / conc);
-    const rateMlH = round1((infMl / INFUSION_MINUTES) * 60);
-    inputs.doseTotal.value = totalMg;
-    inputs.doseVol.value = round1(totalMg / conc);
-    inputs.tpaBolus.value = `${bolusMg} mg (${bolusMl} ml)`;
-    inputs.tpaInf.value = `${infMg} mg (${infMl} ml) · ~${rateMlH} ml/val`;
   }
-}
-
-function round1(n) {
-  return Math.round(n * 10) / 10;
 }

--- a/test/computeDose.test.js
+++ b/test/computeDose.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeDose } from '../js/computeDose.js';
+
+test('computeDose returns null on invalid inputs', () => {
+  assert.strictEqual(computeDose(0, 1, 'tnk'), null);
+  assert.strictEqual(computeDose(70, 0, 'tnk'), null);
+  assert.strictEqual(computeDose(70, 1, 'foo'), null);
+});
+
+test('computeDose calculates TNK dose and caps at 25 mg', () => {
+  const normal = computeDose(70, 5, 'tnk');
+  assert.deepStrictEqual(normal, {
+    doseTotal: 17.5,
+    doseVol: 3.5,
+    bolus: null,
+    infusion: null,
+  });
+  const capped = computeDose(200, 5, 'tnk');
+  assert.strictEqual(capped.doseTotal, 25);
+  assert.strictEqual(capped.doseVol, 5);
+});
+
+test('computeDose calculates tPA dose and caps at 90 mg', () => {
+  const normal = computeDose(70, 1, 'tpa');
+  assert.deepStrictEqual(normal, {
+    doseTotal: 63,
+    doseVol: 63,
+    bolus: { mg: 6.3, ml: 6.3 },
+    infusion: { mg: 56.7, ml: 56.7, rateMlH: 56.7 },
+  });
+  const capped = computeDose(120, 1, 'tpa');
+  assert.strictEqual(capped.doseTotal, 90);
+  assert.deepStrictEqual(capped.bolus, { mg: 9, ml: 9 });
+  assert.deepStrictEqual(capped.infusion, { mg: 81, ml: 81, rateMlH: 81 });
+});


### PR DESCRIPTION
## Summary
- create pure `computeDose` to calculate doses with caps
- wire `calcDrugs` to use `computeDose`
- add unit tests for `computeDose`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a565bf75e08320837e060296bd58b6