### PR TITLE
refactor DOM accessors for dynamic elements

### DIFF
--- a/js/age.js
+++ b/js/age.js
@@ -1,4 +1,4 @@
-import { inputs } from './state.js';
+import * as dom from './state.js';
 
 export function calcAge(dob) {
   if (!dob) return '';
@@ -12,8 +12,10 @@ export function calcAge(dob) {
 }
 
 export function updateAge() {
-  const age = calcAge(inputs.a_dob.value);
-  inputs.a_age.value = age;
+  const dobEl = dom.getADobInput();
+  const ageEl = dom.getAAgeInput();
+  const age = calcAge(dobEl?.value);
+  if (ageEl) ageEl.value = age;
   const disp = document.getElementById('a_age_display');
   if (disp) disp.textContent = age ? `${age} m.` : '';
 }

--- a/js/app.js
+++ b/js/app.js
@@ -1,4 +1,4 @@
-import { $, $$, inputs, state } from './state.js';
+import { $, $$, state, getInputs } from './state.js';
 import { setNow } from './time.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { genSummary, copySummary } from './summary.js';
@@ -36,6 +36,7 @@ function initNIHSS() {
 }
 
 function bind() {
+  const inputs = getInputs();
   let dirty = false;
   const header = document.querySelector('header');
   const setHeaderHeight = () =>

--- a/js/drugs.js
+++ b/js/drugs.js
@@ -1,45 +1,68 @@
-import { inputs } from './state.js';
+import * as dom from './state.js';
 import { computeDose } from './computeDose.js';
 
 export function updateDrugDefaults() {
-  const type = inputs.drugType.value;
+  const typeEl = dom.getDrugTypeInput();
+  const concEl = dom.getDrugConcInput();
+  const defTnkEl = dom.getDefTnkInput();
+  const defTpaEl = dom.getDefTpaInput();
+  if (!typeEl || !concEl || !defTnkEl || !defTpaEl) return;
+  const type = typeEl.value;
   const conc =
     type === 'tnk'
-      ? Number(inputs.def_tnk.value || 5)
-      : Number(inputs.def_tpa.value || 1);
-  inputs.drugConc.value = String(conc);
-  document.getElementById('tpaBreakdown').style.display =
-    type === 'tpa' ? 'grid' : 'none';
+      ? Number(defTnkEl.value || 5)
+      : Number(defTpaEl.value || 1);
+  concEl.value = String(conc);
+  const tpaBreakdown = document.getElementById('tpaBreakdown');
+  if (tpaBreakdown) tpaBreakdown.style.display = type === 'tpa' ? 'grid' : 'none';
 }
 
 export function calcDrugs() {
-  const type = inputs.drugType.value;
-  const w = Number((inputs.weight.value || '').replace(/,/g, '.'));
-  const conc = Number((inputs.drugConc.value || '').replace(/,/g, '.'));
+  const typeEl = dom.getDrugTypeInput();
+  const weightEl = dom.getWeightInput();
+  const concEl = dom.getDrugConcInput();
+  const doseTotalEl = dom.getDoseTotalInput();
+  const doseVolEl = dom.getDoseVolInput();
+  const tpaBolusEl = dom.getTpaBolusInput();
+  const tpaInfEl = dom.getTpaInfInput();
+  if (
+    !typeEl ||
+    !weightEl ||
+    !concEl ||
+    !doseTotalEl ||
+    !doseVolEl ||
+    !tpaBolusEl ||
+    !tpaInfEl
+  )
+    return;
+
+  const type = typeEl.value;
+  const w = Number((weightEl.value || '').replace(/,/g, '.'));
+  const conc = Number((concEl.value || '').replace(/,/g, '.'));
   const wValid = Number.isFinite(w) && w > 0;
   const cValid = Number.isFinite(conc) && conc > 0;
 
-  [inputs.weight, inputs.drugConc].forEach((el) => {
+  [weightEl, concEl].forEach((el) => {
     el.classList.remove('invalid');
     if (el.setCustomValidity) el.setCustomValidity('');
   });
 
   if (!wValid || !cValid) {
-    inputs.doseTotal.value = '';
-    inputs.doseVol.value = '';
-    inputs.tpaBolus.value = '';
-    inputs.tpaInf.value = '';
+    doseTotalEl.value = '';
+    doseVolEl.value = '';
+    tpaBolusEl.value = '';
+    tpaInfEl.value = '';
     if (!wValid) {
-      inputs.weight.classList.add('invalid');
-      if (inputs.weight.setCustomValidity)
-        inputs.weight.setCustomValidity('Įveskite teisingą svorį.');
-      if (inputs.weight.reportValidity) inputs.weight.reportValidity();
+      weightEl.classList.add('invalid');
+      if (weightEl.setCustomValidity)
+        weightEl.setCustomValidity('Įveskite teisingą svorį.');
+      if (weightEl.reportValidity) weightEl.reportValidity();
     }
     if (!cValid) {
-      inputs.drugConc.classList.add('invalid');
-      if (inputs.drugConc.setCustomValidity)
-        inputs.drugConc.setCustomValidity('Įveskite teisingą koncentraciją.');
-      if (inputs.drugConc.reportValidity) inputs.drugConc.reportValidity();
+      concEl.classList.add('invalid');
+      if (concEl.setCustomValidity)
+        concEl.setCustomValidity('Įveskite teisingą koncentraciją.');
+      if (concEl.reportValidity) concEl.reportValidity();
     }
     return;
   }
@@ -47,15 +70,15 @@ export function calcDrugs() {
   const result = computeDose(w, conc, type);
   if (!result) return;
 
-  inputs.doseTotal.value = result.doseTotal;
-  inputs.doseVol.value = result.doseVol;
+  doseTotalEl.value = result.doseTotal;
+  doseVolEl.value = result.doseVol;
 
   if (result.bolus) {
     const { bolus, infusion } = result;
-    inputs.tpaBolus.value = `${bolus.mg} mg (${bolus.ml} ml)`;
-    inputs.tpaInf.value = `${infusion.mg} mg (${infusion.ml} ml) · ~${infusion.rateMlH} ml/val`;
+    tpaBolusEl.value = `${bolus.mg} mg (${bolus.ml} ml)`;
+    tpaInfEl.value = `${infusion.mg} mg (${infusion.ml} ml) · ~${infusion.rateMlH} ml/val`;
   } else {
-    inputs.tpaBolus.value = '';
-    inputs.tpaInf.value = '';
+    tpaBolusEl.value = '';
+    tpaInfEl.value = '';
   }
 }

--- a/js/state.js
+++ b/js/state.js
@@ -6,50 +6,98 @@ export const state = {
   autosave: 'on',
 };
 
-export const inputs = {
-  weight: $('#p_weight'),
-  bp: $('#p_bp'),
-  inr: $('#p_inr'),
-  nih0: $('#p_nihss0'),
-  lkw: $('#t_lkw'),
-  door: $('#t_door'),
-  d_time: $('#d_time'),
-  d_decision: $$('input[name="d_decision"]'),
-  lkw_type: $$('input[name="lkw_type"]'),
-  arrival_symptoms: $('#arrival_symptoms'),
-  arrival_contra: $$('input[name="arrival_contra"]'),
-  drugType: $('#drug_type'),
-  drugConc: $('#drug_conc'),
-  doseTotal: $('#dose_total'),
-  doseVol: $('#dose_volume'),
-  tpaBolus: $('#tpa_bolus'),
-  tpaInf: $('#tpa_infusion'),
-  def_tnk: $('#def_tnk'),
-  def_tpa: $('#def_tpa'),
-  autosave: $('#autosave'),
-  summary: $('#summary'),
-  draftSelect: $('#draftSelect'),
-  a_personal: $('#a_personal'),
-  a_name: $('#a_name'),
-  a_dob: $('#a_dob'),
-  a_age: $('#a_age'),
-  a_sym_face: $$('input[name="a_face"]'),
-  a_sym_arm: $$('input[name="a_arm"]'),
-  a_sym_speech: $$('input[name="a_speech"]'),
-  a_sym_balance: $$('input[name="a_balance"]'),
-  a_sym_conscious: $$('input[name="a_conscious"]'),
-  a_warfarin: $('#a_warfarin'),
-  a_apixaban: $('#a_apixaban'),
-  a_rivaroxaban: $('#a_rivaroxaban'),
-  a_dabigatran: $('#a_dabigatran'),
-  a_edoxaban: $('#a_edoxaban'),
-  a_unknown: $('#a_unknown'),
-  a_lkw: $$('input[name="a_lkw"]'),
-  a_glucose: $('#a_glucose'),
-  a_aks: $('#a_aks'),
-  a_hr: $('#a_hr'),
-  a_spo2: $('#a_spo2'),
-  a_temp: $('#a_temp'),
-};
+// Individual DOM accessors
+export const getWeightInput = () => $('#p_weight');
+export const getBpInput = () => $('#p_bp');
+export const getInrInput = () => $('#p_inr');
+export const getNih0Input = () => $('#p_nihss0');
+export const getLkwInput = () => $('#t_lkw');
+export const getDoorInput = () => $('#t_door');
+export const getDTimeInput = () => $('#d_time');
+export const getDDecisionInputs = () => $$('input[name="d_decision"]');
+export const getLkwTypeInputs = () => $$('input[name="lkw_type"]');
+export const getArrivalSymptomsInput = () => $('#arrival_symptoms');
+export const getArrivalContraInputs = () => $$('input[name="arrival_contra"]');
+export const getDrugTypeInput = () => $('#drug_type');
+export const getDrugConcInput = () => $('#drug_conc');
+export const getDoseTotalInput = () => $('#dose_total');
+export const getDoseVolInput = () => $('#dose_volume');
+export const getTpaBolusInput = () => $('#tpa_bolus');
+export const getTpaInfInput = () => $('#tpa_infusion');
+export const getDefTnkInput = () => $('#def_tnk');
+export const getDefTpaInput = () => $('#def_tpa');
+export const getAutosaveInput = () => $('#autosave');
+export const getSummaryInput = () => $('#summary');
+export const getDraftSelect = () => $('#draftSelect');
+export const getAPersonalInput = () => $('#a_personal');
+export const getANameInput = () => $('#a_name');
+export const getADobInput = () => $('#a_dob');
+export const getAAgeInput = () => $('#a_age');
+export const getASymFaceInputs = () => $$('input[name="a_face"]');
+export const getASymArmInputs = () => $$('input[name="a_arm"]');
+export const getASymSpeechInputs = () => $$('input[name="a_speech"]');
+export const getASymBalanceInputs = () => $$('input[name="a_balance"]');
+export const getASymConsciousInputs = () => $$('input[name="a_conscious"]');
+export const getAWarfarinInput = () => $('#a_warfarin');
+export const getAApixabanInput = () => $('#a_apixaban');
+export const getARivaroxabanInput = () => $('#a_rivaroxaban');
+export const getADabigatranInput = () => $('#a_dabigatran');
+export const getAEdoxabanInput = () => $('#a_edoxaban');
+export const getAUnknownInput = () => $('#a_unknown');
+export const getALkwInputs = () => $$('input[name="a_lkw"]');
+export const getAGlucoseInput = () => $('#a_glucose');
+export const getAAksInput = () => $('#a_aks');
+export const getAHrInput = () => $('#a_hr');
+export const getASpo2Input = () => $('#a_spo2');
+export const getATempInput = () => $('#a_temp');
 
-state.autosave = inputs.autosave.value || 'on';
+// Convenience aggregator for tests
+export function getInputs() {
+  return {
+    weight: getWeightInput(),
+    bp: getBpInput(),
+    inr: getInrInput(),
+    nih0: getNih0Input(),
+    lkw: getLkwInput(),
+    door: getDoorInput(),
+    d_time: getDTimeInput(),
+    d_decision: getDDecisionInputs(),
+    lkw_type: getLkwTypeInputs(),
+    arrival_symptoms: getArrivalSymptomsInput(),
+    arrival_contra: getArrivalContraInputs(),
+    drugType: getDrugTypeInput(),
+    drugConc: getDrugConcInput(),
+    doseTotal: getDoseTotalInput(),
+    doseVol: getDoseVolInput(),
+    tpaBolus: getTpaBolusInput(),
+    tpaInf: getTpaInfInput(),
+    def_tnk: getDefTnkInput(),
+    def_tpa: getDefTpaInput(),
+    autosave: getAutosaveInput(),
+    summary: getSummaryInput(),
+    draftSelect: getDraftSelect(),
+    a_personal: getAPersonalInput(),
+    a_name: getANameInput(),
+    a_dob: getADobInput(),
+    a_age: getAAgeInput(),
+    a_sym_face: getASymFaceInputs(),
+    a_sym_arm: getASymArmInputs(),
+    a_sym_speech: getASymSpeechInputs(),
+    a_sym_balance: getASymBalanceInputs(),
+    a_sym_conscious: getASymConsciousInputs(),
+    a_warfarin: getAWarfarinInput(),
+    a_apixaban: getAApixabanInput(),
+    a_rivaroxaban: getARivaroxabanInput(),
+    a_dabigatran: getADabigatranInput(),
+    a_edoxaban: getAEdoxabanInput(),
+    a_unknown: getAUnknownInput(),
+    a_lkw: getALkwInputs(),
+    a_glucose: getAGlucoseInput(),
+    a_aks: getAAksInput(),
+    a_hr: getAHrInput(),
+    a_spo2: getASpo2Input(),
+    a_temp: getATempInput(),
+  };
+}
+
+state.autosave = getAutosaveInput()?.value || 'on';

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,6 +1,8 @@
-import { inputs, state } from './state.js';
+import * as dom from './state.js';
 import { updateDrugDefaults } from './drugs.js';
 import { updateAge } from './age.js';
+
+const { state } = dom;
 
 const LS_KEY = 'insultoKomandaDrafts_v1';
 
@@ -34,111 +36,120 @@ function setRadioValue(nodes, value) {
 }
 
 export function getPayload() {
+  const inputs = dom.getInputs();
   return {
-    p_weight: inputs.weight.value,
-    p_bp: inputs.bp.value,
-    p_inr: inputs.inr.value,
-    p_nihss0: inputs.nih0.value,
-    t_lkw: inputs.lkw.value,
-    t_door: inputs.door.value,
-    d_time: inputs.d_time.value,
-    d_decision: getRadioValue(inputs.d_decision),
-    drug_type: inputs.drugType.value,
-    drug_conc: inputs.drugConc.value,
-    dose_total: inputs.doseTotal.value,
-    dose_volume: inputs.doseVol.value,
-    tpa_bolus: inputs.tpaBolus.value,
-    tpa_infusion: inputs.tpaInf.value,
-    arrival_lkw_type: getRadioValue(inputs.lkw_type),
-    arrival_symptoms: inputs.arrival_symptoms.value,
-    arrival_contra: inputs.arrival_contra
+    p_weight: inputs.weight?.value || '',
+    p_bp: inputs.bp?.value || '',
+    p_inr: inputs.inr?.value || '',
+    p_nihss0: inputs.nih0?.value || '',
+    t_lkw: inputs.lkw?.value || '',
+    t_door: inputs.door?.value || '',
+    d_time: inputs.d_time?.value || '',
+    d_decision: getRadioValue(inputs.d_decision || []),
+    drug_type: inputs.drugType?.value || '',
+    drug_conc: inputs.drugConc?.value || '',
+    dose_total: inputs.doseTotal?.value || '',
+    dose_volume: inputs.doseVol?.value || '',
+    tpa_bolus: inputs.tpaBolus?.value || '',
+    tpa_infusion: inputs.tpaInf?.value || '',
+    arrival_lkw_type: getRadioValue(inputs.lkw_type || []),
+    arrival_symptoms: inputs.arrival_symptoms?.value || '',
+    arrival_contra: (inputs.arrival_contra || [])
       .filter((n) => n.checked)
       .map((n) => n.value)
       .join('; '),
-    def_tnk: inputs.def_tnk.value,
-    def_tpa: inputs.def_tpa.value,
+    def_tnk: inputs.def_tnk?.value || '',
+    def_tpa: inputs.def_tpa?.value || '',
     autosave: state.autosave,
-    a_personal: inputs.a_personal.value,
-    a_name: inputs.a_name.value,
-    a_dob: inputs.a_dob.value,
-    a_age: inputs.a_age.value,
-    a_sym_face: getRadioValue(inputs.a_sym_face),
-    a_sym_arm: getRadioValue(inputs.a_sym_arm),
-    a_sym_speech: getRadioValue(inputs.a_sym_speech),
-    a_sym_balance: getRadioValue(inputs.a_sym_balance),
-    a_sym_conscious: getRadioValue(inputs.a_sym_conscious),
-    a_drug_warfarin: inputs.a_warfarin.checked,
-    a_drug_apixaban: inputs.a_apixaban.checked,
-    a_drug_rivaroxaban: inputs.a_rivaroxaban.checked,
-    a_drug_dabigatran: inputs.a_dabigatran.checked,
-    a_drug_edoxaban: inputs.a_edoxaban.checked,
-    a_drug_unknown: inputs.a_unknown.checked,
-    a_lkw: getRadioValue(inputs.a_lkw),
-    a_glucose: inputs.a_glucose.value,
-    a_aks: inputs.a_aks.value,
-    a_hr: inputs.a_hr.value,
-    a_spo2: inputs.a_spo2.value,
-    a_temp: inputs.a_temp.value,
+    a_personal: inputs.a_personal?.value || '',
+    a_name: inputs.a_name?.value || '',
+    a_dob: inputs.a_dob?.value || '',
+    a_age: inputs.a_age?.value || '',
+    a_sym_face: getRadioValue(inputs.a_sym_face || []),
+    a_sym_arm: getRadioValue(inputs.a_sym_arm || []),
+    a_sym_speech: getRadioValue(inputs.a_sym_speech || []),
+    a_sym_balance: getRadioValue(inputs.a_sym_balance || []),
+    a_sym_conscious: getRadioValue(inputs.a_sym_conscious || []),
+    a_drug_warfarin: inputs.a_warfarin?.checked || false,
+    a_drug_apixaban: inputs.a_apixaban?.checked || false,
+    a_drug_rivaroxaban: inputs.a_rivaroxaban?.checked || false,
+    a_drug_dabigatran: inputs.a_dabigatran?.checked || false,
+    a_drug_edoxaban: inputs.a_edoxaban?.checked || false,
+    a_drug_unknown: inputs.a_unknown?.checked || false,
+    a_lkw: getRadioValue(inputs.a_lkw || []),
+    a_glucose: inputs.a_glucose?.value || '',
+    a_aks: inputs.a_aks?.value || '',
+    a_hr: inputs.a_hr?.value || '',
+    a_spo2: inputs.a_spo2?.value || '',
+    a_temp: inputs.a_temp?.value || '',
   };
 }
 
 export function setPayload(p) {
   if (!p) return;
-  inputs.weight.value = p.p_weight || '';
-  inputs.bp.value = p.p_bp || '';
-  inputs.inr.value = p.p_inr || '';
-  inputs.nih0.value = p.p_nihss0 || '';
-  inputs.lkw.value = p.t_lkw || '';
-  inputs.door.value = p.t_door || '';
-  inputs.d_time.value = p.d_time || '';
-  setRadioValue(inputs.d_decision, p.d_decision || '');
-  inputs.drugType.value = p.drug_type || 'tnk';
-  inputs.drugConc.value = p.drug_conc || '';
-  inputs.doseTotal.value = p.dose_total || '';
-  inputs.doseVol.value = p.dose_volume || '';
-  inputs.tpaBolus.value = p.tpa_bolus || '';
-  inputs.tpaInf.value = p.tpa_infusion || '';
-  setRadioValue(inputs.lkw_type, p.arrival_lkw_type || 'known');
-  inputs.arrival_symptoms.value = p.arrival_symptoms || '';
+  const inputs = dom.getInputs();
+  if (inputs.weight) inputs.weight.value = p.p_weight || '';
+  if (inputs.bp) inputs.bp.value = p.p_bp || '';
+  if (inputs.inr) inputs.inr.value = p.p_inr || '';
+  if (inputs.nih0) inputs.nih0.value = p.p_nihss0 || '';
+  if (inputs.lkw) inputs.lkw.value = p.t_lkw || '';
+  if (inputs.door) inputs.door.value = p.t_door || '';
+  if (inputs.d_time) inputs.d_time.value = p.d_time || '';
+  if (inputs.d_decision) setRadioValue(inputs.d_decision, p.d_decision || '');
+  if (inputs.drugType) inputs.drugType.value = p.drug_type || 'tnk';
+  if (inputs.drugConc) inputs.drugConc.value = p.drug_conc || '';
+  if (inputs.doseTotal) inputs.doseTotal.value = p.dose_total || '';
+  if (inputs.doseVol) inputs.doseVol.value = p.dose_volume || '';
+  if (inputs.tpaBolus) inputs.tpaBolus.value = p.tpa_bolus || '';
+  if (inputs.tpaInf) inputs.tpaInf.value = p.tpa_infusion || '';
+  if (inputs.lkw_type)
+    setRadioValue(inputs.lkw_type, p.arrival_lkw_type || 'known');
+  if (inputs.arrival_symptoms)
+    inputs.arrival_symptoms.value = p.arrival_symptoms || '';
   const contraVals = (p.arrival_contra || '').split(/;\s*/).filter(Boolean);
-  inputs.arrival_contra.forEach((cb) => {
+  (inputs.arrival_contra || []).forEach((cb) => {
     cb.checked = contraVals.includes(cb.value);
   });
-  inputs.a_personal.value = p.a_personal || '';
-  inputs.a_name.value = p.a_name || '';
-  inputs.a_dob.value = p.a_dob || '';
+  if (inputs.a_personal) inputs.a_personal.value = p.a_personal || '';
+  if (inputs.a_name) inputs.a_name.value = p.a_name || '';
+  if (inputs.a_dob) inputs.a_dob.value = p.a_dob || '';
   updateAge();
-  setRadioValue(inputs.a_sym_face, p.a_sym_face || '');
-  setRadioValue(inputs.a_sym_arm, p.a_sym_arm || '');
-  setRadioValue(inputs.a_sym_speech, p.a_sym_speech || '');
-  setRadioValue(inputs.a_sym_balance, p.a_sym_balance || '');
-  setRadioValue(inputs.a_sym_conscious, p.a_sym_conscious || '');
-  inputs.a_warfarin.checked = !!p.a_drug_warfarin;
-  inputs.a_apixaban.checked = !!p.a_drug_apixaban;
-  inputs.a_rivaroxaban.checked = !!p.a_drug_rivaroxaban;
-  inputs.a_dabigatran.checked = !!p.a_drug_dabigatran;
-  inputs.a_edoxaban.checked = !!p.a_drug_edoxaban;
-  inputs.a_unknown.checked = !!p.a_drug_unknown;
-  setRadioValue(inputs.a_lkw, p.a_lkw || '');
-  inputs.a_glucose.value = p.a_glucose || '';
-  inputs.a_aks.value = p.a_aks || '';
-  inputs.a_hr.value = p.a_hr || '';
-  inputs.a_spo2.value = p.a_spo2 || '';
-  inputs.a_temp.value = p.a_temp || '';
-  inputs.def_tnk.value = p.def_tnk || 5;
-  inputs.def_tpa.value = p.def_tpa || 1;
-  inputs.autosave.value = p.autosave || 'on';
-  state.autosave = inputs.autosave.value || 'on';
+  if (inputs.a_sym_face) setRadioValue(inputs.a_sym_face, p.a_sym_face || '');
+  if (inputs.a_sym_arm) setRadioValue(inputs.a_sym_arm, p.a_sym_arm || '');
+  if (inputs.a_sym_speech) setRadioValue(inputs.a_sym_speech, p.a_sym_speech || '');
+  if (inputs.a_sym_balance)
+    setRadioValue(inputs.a_sym_balance, p.a_sym_balance || '');
+  if (inputs.a_sym_conscious)
+    setRadioValue(inputs.a_sym_conscious, p.a_sym_conscious || '');
+  if (inputs.a_warfarin) inputs.a_warfarin.checked = !!p.a_drug_warfarin;
+  if (inputs.a_apixaban) inputs.a_apixaban.checked = !!p.a_drug_apixaban;
+  if (inputs.a_rivaroxaban)
+    inputs.a_rivaroxaban.checked = !!p.a_drug_rivaroxaban;
+  if (inputs.a_dabigatran)
+    inputs.a_dabigatran.checked = !!p.a_drug_dabigatran;
+  if (inputs.a_edoxaban) inputs.a_edoxaban.checked = !!p.a_drug_edoxaban;
+  if (inputs.a_unknown) inputs.a_unknown.checked = !!p.a_drug_unknown;
+  if (inputs.a_lkw) setRadioValue(inputs.a_lkw, p.a_lkw || '');
+  if (inputs.a_glucose) inputs.a_glucose.value = p.a_glucose || '';
+  if (inputs.a_aks) inputs.a_aks.value = p.a_aks || '';
+  if (inputs.a_hr) inputs.a_hr.value = p.a_hr || '';
+  if (inputs.a_spo2) inputs.a_spo2.value = p.a_spo2 || '';
+  if (inputs.a_temp) inputs.a_temp.value = p.a_temp || '';
+  if (inputs.def_tnk) inputs.def_tnk.value = p.def_tnk || 5;
+  if (inputs.def_tpa) inputs.def_tpa.value = p.def_tpa || 1;
+  if (inputs.autosave) inputs.autosave.value = p.autosave || 'on';
+  state.autosave = inputs.autosave?.value || 'on';
   updateDrugDefaults();
 }
 
 export function saveLS(id, name) {
+  const inputs = dom.getInputs();
   const drafts = getDrafts();
   const draftId = id || Date.now().toString();
   const draftName =
     name ||
     drafts[draftId]?.name ||
-    inputs.nih0.value ||
+    inputs.nih0?.value ||
     `Juodraštis ${draftId}`;
   drafts[draftId] = { name: draftName, data: getPayload() };
   setDrafts(drafts);
@@ -170,6 +181,7 @@ export function renameLS(id, newName) {
 }
 
 export function updateDraftSelect(selectedId) {
+  const inputs = dom.getInputs();
   const sel = inputs.draftSelect;
   if (!sel) return;
   sel.innerHTML = '';

--- a/js/summary.js
+++ b/js/summary.js
@@ -1,7 +1,8 @@
-import { inputs } from './state.js';
+import * as dom from './state.js';
 import { showToast } from './toast.js';
 
 export function collectSummaryData() {
+  const inputs = dom.getInputs();
   const get = (el) => (el && el.value ? el.value : null);
   const patient = {
     dob: get(inputs.a_dob),
@@ -15,14 +16,14 @@ export function collectSummaryData() {
     decision: get(inputs.d_time),
   };
   const drugs = {
-    type: inputs.drugType.value,
+    type: inputs.drugType?.value || '',
     conc: get(inputs.drugConc),
     totalDose: get(inputs.doseTotal),
     totalVol: get(inputs.doseVol),
     bolus: get(inputs.tpaBolus),
     infusion: get(inputs.tpaInf),
   };
-  const decision = inputs.d_decision.find((n) => n.checked)?.value || null;
+  const decision = (inputs.d_decision || []).find((n) => n.checked)?.value || null;
   return { patient, times, drugs, decision };
 }
 
@@ -55,12 +56,14 @@ export function summaryTemplate({ patient, times, drugs, decision }) {
 }
 
 export function genSummary() {
+  const inputs = dom.getInputs();
   const data = collectSummaryData();
-  inputs.summary.value = summaryTemplate(data);
+  if (inputs.summary) inputs.summary.value = summaryTemplate(data);
   return data;
 }
 
 export function copySummary() {
+  const inputs = dom.getInputs();
   genSummary();
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {

--- a/test/accessorsMock.test.js
+++ b/test/accessorsMock.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function createEl() {
+  return {
+    value: '',
+    classList: { add() {}, remove() {} },
+    setCustomValidity() {},
+    reportValidity() {},
+    style: {},
+  };
+}
+
+// Using document mapping to simulate dynamic DOM
+const elements = {};
+const documentStub = {
+  querySelector(sel) {
+    return elements[sel] || null;
+  },
+  querySelectorAll(sel) {
+    return elements[sel] ? [].concat(elements[sel]) : [];
+  },
+  getElementById(id) {
+    return elements['#' + id] || null;
+  },
+  addEventListener() {},
+  createElement: () => createEl(),
+};
+
+global.document = documentStub;
+
+// Needed globals for modules
+global.confirm = () => true;
+global.localStorage = { setItem: () => {}, getItem: () => null };
+global.URL = { createObjectURL: () => '', revokeObjectURL: () => {} };
+global.Blob = function () {};
+global.FileReader = function () { this.readAsText = () => {}; };
+global.setInterval = () => {};
+
+import('../js/toast.js').then(({ toast }) => (toast.showToast = () => {}));
+
+// calcDrugs test
+import('../js/drugs.js').then(({ calcDrugs }) => {
+  test('calcDrugs handles missing and injected elements', () => {
+    // no elements present
+    assert.doesNotThrow(() => calcDrugs());
+
+    // inject elements
+    elements['#drug_type'] = { value: 'tnk' };
+    elements['#drug_conc'] = createEl();
+    elements['#drug_conc'].value = '5';
+    elements['#p_weight'] = createEl();
+    elements['#p_weight'].value = '70';
+    elements['#dose_total'] = createEl();
+    elements['#dose_volume'] = createEl();
+    elements['#tpa_bolus'] = createEl();
+    elements['#tpa_infusion'] = createEl();
+    elements['#def_tnk'] = { value: '5' };
+    elements['#def_tpa'] = { value: '1' };
+
+    calcDrugs();
+    assert.strictEqual(elements['#dose_total'].value, 17.5);
+  });
+});
+
+// storage test
+import('../js/storage.js').then(({ setPayload, getPayload }) => {
+  test('storage functions work with dynamic inputs', () => {
+    // ensure no relevant elements present
+    delete elements['#p_weight'];
+    assert.doesNotThrow(() => setPayload({ p_weight: '70' }));
+    const p0 = getPayload();
+    assert.strictEqual(p0.p_weight, '');
+
+    // inject weight element
+    elements['#p_weight'] = createEl();
+    setPayload({ p_weight: '80' });
+    const p1 = getPayload();
+    assert.strictEqual(elements['#p_weight'].value, '80');
+    assert.strictEqual(p1.p_weight, '80');
+  });
+});

--- a/test/age.test.js
+++ b/test/age.test.js
@@ -35,7 +35,8 @@ test('calcAge and updateAge compute and display age correctly', async () => {
     addEventListener: () => {},
   };
 
-  const { inputs } = await import('../js/state.js');
+  const { getInputs } = await import('../js/state.js');
+  const inputs = getInputs();
   const { calcAge, updateAge } = await import('../js/age.js');
 
   // valid date of birth

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -49,7 +49,8 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   };
   global.setInterval = () => {};
 
-  const { inputs } = await import('../js/state.js');
+  const { getInputs } = await import('../js/state.js');
+  const inputs = getInputs();
   const { calcDrugs } = await import('../js/drugs.js');
 
   // invalid weight

--- a/test/changeEvents.test.js
+++ b/test/changeEvents.test.js
@@ -77,14 +77,14 @@ global.setInterval = () => {};
 global.window = { isSecureContext: true };
 
 test('setPayload bubbles change events', async () => {
-  const { inputs } = await import('../js/state.js');
   const { setPayload } = await import('../js/storage.js');
 
   const known = createEl();
   known.value = 'known';
   const unknown = createEl();
   unknown.value = 'unknown';
-  inputs.lkw_type = [known, unknown];
+  document.querySelectorAll = (sel) =>
+    sel === 'input[name="lkw_type"]' ? [known, unknown] : [];
 
   let changeCount = 0;
   document.addEventListener('change', () => {

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -53,7 +53,8 @@ test('copySummary builds data object and copies formatted text', async () => {
   global.FileReader = function () { this.readAsText = () => {}; };
   global.setInterval = () => {};
 
-  const { inputs } = await import('../js/state.js');
+  const { getInputs } = await import('../js/state.js');
+  const inputs = getInputs();
   const { collectSummaryData, summaryTemplate, copySummary } = await import('../js/summary.js');
 
   inputs.a_dob.value = '1980-01-01';
@@ -63,9 +64,12 @@ test('copySummary builds data object and copies formatted text', async () => {
   inputs.lkw.value = '2024-01-01T07:00';
   inputs.door.value = '2024-01-01T08:00';
   inputs.d_time.value = '2024-01-01T08:40';
-  inputs.d_decision = [
-    { checked: true, value: 'Taikoma IVT, indikacijų MTE nenustatyta' },
-  ];
+  const decisionOpt = {
+    checked: true,
+    value: 'Taikoma IVT, indikacijų MTE nenustatyta',
+  };
+  document.querySelectorAll = (sel) =>
+    sel === 'input[name="d_decision"]' ? [decisionOpt] : [];
   inputs.drugType.value = 'tnk';
   inputs.drugConc.value = '5';
   inputs.doseTotal.value = '20';

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -50,7 +50,8 @@ test('genSummary generates summary text correctly', async () => {
   };
   global.setInterval = () => {};
 
-  const { inputs } = await import('../js/state.js');
+  const { getInputs } = await import('../js/state.js');
+  const inputs = getInputs();
   const { genSummary } = await import('../js/summary.js');
 
   // populate typical inputs
@@ -62,9 +63,12 @@ test('genSummary generates summary text correctly', async () => {
   inputs.lkw.value = '2024-01-01T07:00';
   inputs.door.value = '2024-01-01T08:00';
   inputs.d_time.value = '2024-01-01T08:40';
-  inputs.d_decision = [
-    { checked: true, value: 'Taikoma IVT, indikacijų MTE nenustatyta' },
-  ];
+  const decisionOpt = {
+    checked: true,
+    value: 'Taikoma IVT, indikacijų MTE nenustatyta',
+  };
+  document.querySelectorAll = (sel) =>
+    sel === 'input[name="d_decision"]' ? [decisionOpt] : [];
 
   inputs.drugType.value = 'tnk';
   inputs.drugConc.value = '5';

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -80,13 +80,16 @@ Object.defineProperty(global, 'navigator', {
   configurable: true,
 });
 
-const { inputs } = await import('../js/state.js');
+let inputs = null;
+const { getInputs } = await import('../js/state.js');
 const { saveLS, loadLS, deleteLS, setPayload } = await import(
   '../js/storage.js'
 );
+inputs = getInputs();
 const { copySummary } = await import('../js/summary.js');
 
 function resetInputs() {
+  inputs = getInputs();
   Object.values(inputs).forEach((el) => {
     if ('value' in el) el.value = '';
     if ('checked' in el) el.checked = false;

--- a/test/updateDrugDefaults.test.js
+++ b/test/updateDrugDefaults.test.js
@@ -31,7 +31,8 @@ test('updateDrugDefaults sets default concentrations correctly', async () => {
   };
   global.setInterval = () => {};
 
-  const { inputs } = await import('../js/state.js');
+  const { getInputs } = await import('../js/state.js');
+  const inputs = getInputs();
   const { updateDrugDefaults } = await import('../js/drugs.js');
 
   inputs.def_tnk.value = '';


### PR DESCRIPTION
## Summary
- replace static `inputs` object with per-element getters and helper `getInputs`
- update modules to call accessors and handle missing DOM nodes
- add tests that mock dynamic accessors and cover new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56840e3dc8320ba87ff9f1a8ff817