### PR TITLE
refactor: template build for main HTML

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import path from 'path';
+
+function actionButton(id, title, icon, label, classes = '') {
+  const cls = classes ? `btn ${classes}` : 'btn';
+  return `<button id="${id}"${title ? ` title="${title}"` : ''} class="${cls}">${icon} <span class="btn-label">${label}</span></button>`;
+}
+
+function timeInput(id, wrapperId = '', wrapperClass = 'row') {
+  return `<div class="${wrapperClass}"${wrapperId ? ` id="${wrapperId}"` : ''}>
+  <div class="input-group">
+    <input
+      id="${id}"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button class="btn ghost" data-now="${id}">Dabar</button>
+  </div>
+</div>`;
+}
+
+const macros = { actionButton, timeInput };
+
+function render(template) {
+  // includes
+  template = template.replace(/\{% include \"(.+?)\" %\}/g, (_, file) => {
+    const partial = fs.readFileSync(path.join('templates', file), 'utf8');
+    return render(partial);
+  });
+  // macros
+  template = template.replace(/\{\{\s*macros\.actionButton\((.*?)\)\s*\}\}/g, (_, args) => {
+    const parsed = eval(`[${args}]`);
+    return macros.actionButton(...parsed);
+  });
+  template = template.replace(/\{\{\s*macros\.timeInput\((.*?)\)\s*\}\}/g, (_, args) => {
+    const parsed = eval(`[${args}]`);
+    return macros.timeInput(...parsed);
+  });
+  return template;
+}
+
+let index = fs.readFileSync('templates/index.njk', 'utf8');
+index = index
+  .replace(/\{% extends \"layout.njk\" %\}/, '')
+  .replace(/\{% import \"macros.njk\" as macros %\}/, '')
+  .replace(/\{% block content %\}/, '')
+  .replace(/\{% endblock %\}/, '');
+
+const content = render(index);
+const layout = fs.readFileSync('templates/layout.njk', 'utf8');
+const html = layout.replace('{% block content %}{% endblock %}', content);
+fs.writeFileSync('index.html', html);

--- a/index.html
+++ b/index.html
@@ -7,100 +7,78 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
-    <div id="toastContainer" class="toast-container"></div>
-    <header>
-      <div class="wrap">
-        <div class="brand">
-          <div class="logo" aria-hidden="true"></div>
-          <div>
-            <h1>Insulto komandos forma · Greito įvedimo aplikacija</h1>
-            <div class="subtle">
-              Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
-              santrauka HIS sistemai
-            </div>
-          </div>
-        </div>
-        <div class="header-actions">
-          <button id="newPatientBtn" title="Naujas pacientas" class="btn">
-            🆕 <span class="btn-label">Naujas</span>
-          </button>
-          <button
-            id="saveBtn"
-            title="Išsaugoti vietoje (naršyklėje)"
-            class="btn"
-          >
-            💾 <span class="btn-label">Išsaugoti</span>
-          </button>
-          <details class="more-actions">
-            <summary>⋮</summary>
-            <div class="menu">
-              <input id="draftFilter" placeholder="Filtruoti..." />
-              <select
-                id="draftSelect"
-                title="Išsaugoti juodraščiai"
-                class="btn"
-              ></select>
-              <button id="loadBtn" title="Atkurti pasirinktą" class="btn">
-                📂 <span class="btn-label">Atkurti</span>
-              </button>
-              <button
-                id="renameDraftBtn"
-                title="Pervardyti juodraštį"
-                class="btn"
-              >
-                ✏️ <span class="btn-label">Pervardyti</span>
-              </button>
-              <button
-                id="deleteDraftBtn"
-                title="Ištrinti juodraštį"
-                class="btn"
-              >
-                🗑️ <span class="btn-label">Trinti</span>
-              </button>
-              <button id="exportBtn" title="Eksportuoti JSON" class="btn">
-                ⬇️ <span class="btn-label">Eksportuoti</span>
-              </button>
-              <input
-                id="importFile"
-                type="file"
-                accept="application/json"
-                class="hidden"
-              />
-              <button id="importBtn" title="Importuoti JSON" class="btn">
-                ⬆️ <span class="btn-label">Importuoti</span>
-              </button>
-            </div>
-          </details>
+    
+
+
+
+  <div id="toastContainer" class="toast-container"></div>
+  <header>
+  <div class="wrap">
+    <div class="brand">
+      <div class="logo" aria-hidden="true"></div>
+      <div>
+        <h1>Insulto komandos forma · Greito įvedimo aplikacija</h1>
+        <div class="subtle">
+          Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
+          santrauka HIS sistemai
         </div>
       </div>
-      <div id="saveStatus" aria-live="polite"></div>
-    </header>
+    </div>
+    <div class="header-actions">
+      <button id="newPatientBtn" title="Naujas pacientas" class="btn">🆕 <span class="btn-label">Naujas</span></button>
+      <button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn">💾 <span class="btn-label">Išsaugoti</span></button>
+      <details class="more-actions">
+        <summary>⋮</summary>
+        <div class="menu">
+          <input id="draftFilter" placeholder="Filtruoti..." />
+          <select
+            id="draftSelect"
+            title="Išsaugoti juodraščiai"
+            class="btn"
+          ></select>
+          <button id="loadBtn" title="Atkurti pasirinktą" class="btn">📂 <span class="btn-label">Atkurti</span></button>
+          <button id="renameDraftBtn" title="Pervardyti juodraštį" class="btn">✏️ <span class="btn-label">Pervardyti</span></button>
+          <button id="deleteDraftBtn" title="Ištrinti juodraštį" class="btn">🗑️ <span class="btn-label">Trinti</span></button>
+          <button id="exportBtn" title="Eksportuoti JSON" class="btn">⬇️ <span class="btn-label">Eksportuoti</span></button>
+          <input
+            id="importFile"
+            type="file"
+            accept="application/json"
+            class="hidden"
+          />
+          <button id="importBtn" title="Importuoti JSON" class="btn">⬆️ <span class="btn-label">Importuoti</span></button>
+        </div>
+      </details>
+    </div>
+  </div>
+  <div id="saveStatus" aria-live="polite"></div>
+</header>
 
-    <div class="wrap layout-main">
-      <button id="navToggle" class="btn">☰ Meniu</button>
-      <nav>
-        <a href="#activation" data-section="activation" class="tab active"
-          ><span class="tab-icon">🚨</span>Aktyvacija</a
-        >
-        <a href="#arrival" data-section="arrival" class="tab"
-          ><span class="tab-icon">🚑</span>Paciento atvykimas</a
-        >
-        <a href="#thrombolysis" data-section="thrombolysis" class="tab"
-          ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
-        >
-        <a href="#nihss" data-section="nihss" class="tab"
-          ><span class="tab-icon">🧮</span>NIHSS</a
-        >
-        <a href="#decision" data-section="decision" class="tab"
-          ><span class="tab-icon">☑️</span>Sprendimas</a
-        >
-        <a href="#summarySec" data-section="summarySec" class="tab"
-          ><span class="tab-icon">📄</span>Santrauka</a
-        >
-      </nav>
-      <main class="px-0">
-        <!-- Aktyvacija -->
-        <section id="activation" class="card">
+  <div class="wrap layout-main">
+    <button id="navToggle" class="btn">☰ <span class="btn-label">Meniu</span></button>
+    <nav>
+  <a href="#activation" data-section="activation" class="tab active"
+    ><span class="tab-icon">🚨</span>Aktyvacija</a
+  >
+  <a href="#arrival" data-section="arrival" class="tab"
+    ><span class="tab-icon">🚑</span>Paciento atvykimas</a
+  >
+  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
+  >
+  <a href="#nihss" data-section="nihss" class="tab"
+    ><span class="tab-icon">🧮</span>NIHSS</a
+  >
+  <a href="#decision" data-section="decision" class="tab"
+    ><span class="tab-icon">☑️</span>Sprendimas</a
+  >
+  <a href="#summarySec" data-section="summarySec" class="tab"
+    ><span class="tab-icon">📄</span>Santrauka</a
+  >
+</nav>
+
+    <main class="px-0">
+              <section id="activation" class="card">
           <h2>Komandos aktyvacija</h2>
           <form>
             <fieldset>
@@ -315,23 +293,23 @@
           </form>
         </section>
 
-        <!-- Paciento atvykimas -->
+              <!-- Paciento atvykimas -->
         <section id="arrival" class="card hidden">
           <h2>Paciento atvykimas</h2>
           <form>
             <fieldset>
               <legend>Atvykimo laikas</legend>
               <div class="row">
-                <div class="input-group">
-                  <input
-                    id="t_door"
-                    type="datetime-local"
-                    placeholder="YYYY-MM-DD HH:MM"
-                    step="60"
-                  />
-                  <button class="btn ghost" data-now="t_door">Dabar</button>
-                </div>
-              </div>
+  <div class="input-group">
+    <input
+      id="t_door"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button class="btn ghost" data-now="t_door">Dabar</button>
+  </div>
+</div>
             </fieldset>
 
             <fieldset>
@@ -350,17 +328,17 @@
                   vidurio laikas</label
                 >
               </div>
-              <div id="lkwTimeRow" class="row mt-4">
-                <div class="input-group">
-                  <input
-                    id="t_lkw"
-                    type="datetime-local"
-                    placeholder="YYYY-MM-DD HH:MM"
-                    step="60"
-                  />
-                  <button class="btn ghost" data-now="t_lkw">Dabar</button>
-                </div>
-              </div>
+              <div class="row mt-4" id="lkwTimeRow">
+  <div class="input-group">
+    <input
+      id="t_lkw"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button class="btn ghost" data-now="t_lkw">Dabar</button>
+  </div>
+</div>
             </fieldset>
 
             <fieldset>
@@ -590,7 +568,8 @@
           </form>
         </section>
 
-        <!-- Pasiruošimas trombolizei -->
+
+              <!-- Pasiruošimas trombolizei -->
         <section id="thrombolysis" class="card hidden">
           <h2>Pasiruošimas trombolizei</h2>
           <form>
@@ -722,7 +701,8 @@
           </form>
         </section>
 
-        <!-- NIHSS -->
+
+              <!-- NIHSS -->
         <section id="nihss" class="card hidden">
           <h2>NIHSS</h2>
           <form>
@@ -895,23 +875,24 @@
           </form>
         </section>
 
-        <!-- Sprendimas -->
+
+              <!-- Sprendimas -->
         <section id="decision" class="card hidden">
           <h2>Sprendimas</h2>
           <form>
             <fieldset>
               <legend>Sprendimo laikas</legend>
               <div class="row">
-                <div class="input-group">
-                  <input
-                    id="d_time"
-                    type="datetime-local"
-                    placeholder="YYYY-MM-DD HH:MM"
-                    step="60"
-                  />
-                  <button class="btn ghost" data-now="d_time">Dabar</button>
-                </div>
-              </div>
+  <div class="input-group">
+    <input
+      id="d_time"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button class="btn ghost" data-now="d_time">Dabar</button>
+  </div>
+</div>
             </fieldset>
             <fieldset class="mt-10">
               <legend>Sprendimas</legend>
@@ -949,7 +930,8 @@
           </form>
         </section>
 
-        <!-- Santrauka HIS sistemai -->
+
+              <!-- Santrauka HIS sistemai -->
         <section id="summarySec" class="card full-span hidden">
           <h2>Santrauka (kopijavimui į HIS)</h2>
           <textarea
@@ -958,11 +940,11 @@
             placeholder="Santrauka generuojama automatiškai"
           ></textarea>
           <div class="sticky-actions">
-            <button id="copySummaryBtn" class="btn">📋 Kopijuoti</button>
+            <button id="copySummaryBtn" title="Kopijuoti santrauką" class="btn">📋 <span class="btn-label">Kopijuoti</span></button>
           </div>
         </section>
 
-        <details class="settings">
+              <details class="settings">
           <summary><span class="pill">⚙️ Nustatymai</span></summary>
             <div class="card">
               <div class="grid-3">
@@ -985,13 +967,14 @@
             </div>
           </details>
 
-        <div class="footer">
+              <div class="footer">
           ⚠️ Atskaita: ši priemonė yra pagalbinė. Galutiniai klinikiniai
           sprendimai remiasi gydytojo vertinimu ir galiojančiomis gairėmis.
         </div>
-      </main>
 
-    </div>
+    </main>
+  </div>
+
 
     <script type="module" src="js/app.js"></script>
   </body>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "format": "prettier --write js/*.js",
     "test": "node --test",
+    "build": "node build.js",
     "prepare": "husky install"
   }
 }

--- a/templates/index.njk
+++ b/templates/index.njk
@@ -1,0 +1,21 @@
+{% extends "layout.njk" %}
+{% import "macros.njk" as macros %}
+
+{% block content %}
+  <div id="toastContainer" class="toast-container"></div>
+  {% include "partials/header.njk" %}
+  <div class="wrap layout-main">
+    {{ macros.actionButton('navToggle', '', '☰', 'Meniu') }}
+    {% include "partials/nav.njk" %}
+    <main class="px-0">
+      {% include "sections/activation.njk" %}
+      {% include "sections/arrival.njk" %}
+      {% include "sections/thrombolysis.njk" %}
+      {% include "sections/nihss.njk" %}
+      {% include "sections/decision.njk" %}
+      {% include "sections/summary.njk" %}
+      {% include "partials/settings.njk" %}
+      {% include "partials/footer.njk" %}
+    </main>
+  </div>
+{% endblock %}

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="lt" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Insulto komandos forma – Greito įvedimo aplikacija</title>
+    <link rel="stylesheet" href="css/style.css" />
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+    <script type="module" src="js/app.js"></script>
+  </body>
+</html>

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -1,0 +1,17 @@
+{% macro actionButton(id, title, icon, label, classes='') %}
+<button id="{{ id }}"{% if title %} title="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}">{{ icon }} <span class="btn-label">{{ label }}</span></button>
+{% endmacro %}
+
+{% macro timeInput(id, wrapperId='', wrapperClass='row') %}
+<div class="{{ wrapperClass }}"{% if wrapperId %} id="{{ wrapperId }}"{% endif %}>
+  <div class="input-group">
+    <input
+      id="{{ id }}"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button class="btn ghost" data-now="{{ id }}">Dabar</button>
+  </div>
+</div>
+{% endmacro %}

--- a/templates/partials/footer.njk
+++ b/templates/partials/footer.njk
@@ -1,0 +1,4 @@
+        <div class="footer">
+          ⚠️ Atskaita: ši priemonė yra pagalbinė. Galutiniai klinikiniai
+          sprendimai remiasi gydytojo vertinimu ir galiojančiomis gairėmis.
+        </div>

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -1,0 +1,41 @@
+<header>
+  <div class="wrap">
+    <div class="brand">
+      <div class="logo" aria-hidden="true"></div>
+      <div>
+        <h1>Insulto komandos forma · Greito įvedimo aplikacija</h1>
+        <div class="subtle">
+          Skubi duomenų registracija, laikų sekimas, vaistų skaičiuoklės ir
+          santrauka HIS sistemai
+        </div>
+      </div>
+    </div>
+    <div class="header-actions">
+      {{ macros.actionButton('newPatientBtn', 'Naujas pacientas', '🆕', 'Naujas') }}
+      {{ macros.actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', '💾', 'Išsaugoti') }}
+      <details class="more-actions">
+        <summary>⋮</summary>
+        <div class="menu">
+          <input id="draftFilter" placeholder="Filtruoti..." />
+          <select
+            id="draftSelect"
+            title="Išsaugoti juodraščiai"
+            class="btn"
+          ></select>
+          {{ macros.actionButton('loadBtn', 'Atkurti pasirinktą', '📂', 'Atkurti') }}
+          {{ macros.actionButton('renameDraftBtn', 'Pervardyti juodraštį', '✏️', 'Pervardyti') }}
+          {{ macros.actionButton('deleteDraftBtn', 'Ištrinti juodraštį', '🗑️', 'Trinti') }}
+          {{ macros.actionButton('exportBtn', 'Eksportuoti JSON', '⬇️', 'Eksportuoti') }}
+          <input
+            id="importFile"
+            type="file"
+            accept="application/json"
+            class="hidden"
+          />
+          {{ macros.actionButton('importBtn', 'Importuoti JSON', '⬆️', 'Importuoti') }}
+        </div>
+      </details>
+    </div>
+  </div>
+  <div id="saveStatus" aria-live="polite"></div>
+</header>

--- a/templates/partials/nav.njk
+++ b/templates/partials/nav.njk
@@ -1,0 +1,20 @@
+<nav>
+  <a href="#activation" data-section="activation" class="tab active"
+    ><span class="tab-icon">🚨</span>Aktyvacija</a
+  >
+  <a href="#arrival" data-section="arrival" class="tab"
+    ><span class="tab-icon">🚑</span>Paciento atvykimas</a
+  >
+  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
+  >
+  <a href="#nihss" data-section="nihss" class="tab"
+    ><span class="tab-icon">🧮</span>NIHSS</a
+  >
+  <a href="#decision" data-section="decision" class="tab"
+    ><span class="tab-icon">☑️</span>Sprendimas</a
+  >
+  <a href="#summarySec" data-section="summarySec" class="tab"
+    ><span class="tab-icon">📄</span>Santrauka</a
+  >
+</nav>

--- a/templates/partials/settings.njk
+++ b/templates/partials/settings.njk
@@ -1,0 +1,22 @@
+        <details class="settings">
+          <summary><span class="pill">⚙️ Nustatymai</span></summary>
+            <div class="card">
+              <div class="grid-3">
+                <div>
+                  <label>TNK numatyta koncentracija (mg/ml)</label>
+                  <input id="def_tnk" type="number" step="0.1" value="5" />
+                </div>
+                <div>
+                  <label>tPA numatyta koncentracija (mg/ml)</label>
+                  <input id="def_tpa" type="number" step="0.1" value="1" />
+                </div>
+                <div>
+                  <label>Automatinis išsaugojimas</label>
+                  <select id="autosave">
+                    <option value="on">Įjungtas</option>
+                    <option value="off">Išjungtas</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </details>

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -1,0 +1,214 @@
+        <section id="activation" class="card">
+          <h2>Komandos aktyvacija</h2>
+          <form>
+            <fieldset>
+              <legend>Paciento duomenys</legend>
+              <div class="grid-2">
+                <div>
+                  <label for="a_personal">Asmens kodas</label>
+                  <input id="a_personal" type="text" />
+                </div>
+                <div>
+                  <label for="a_name">Vardas, Pavardė</label>
+                  <input id="a_name" type="text" />
+                </div>
+                <div>
+                  <label for="a_dob">Gimimo data</label>
+                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" />
+                  <div id="a_age_display" class="subtle"></div>
+                  <input id="a_age" type="hidden" />
+                </div>
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend>Simptomai</legend>
+              <table class="tbl">
+                <thead>
+                  <tr>
+                    <th>Sutrikimas</th>
+                    <th>Taip</th>
+                    <th>Ne</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Veido paralyžius</td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_face"
+                          value="yes"
+                        />Taip</label
+                      >
+                    </td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_face"
+                          value="no"
+                        />Ne</label
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Rankos silpnumas</td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_arm"
+                          value="yes"
+                        />Taip</label
+                      >
+                    </td>
+                    <td>
+                      <label class="pill"
+                        ><input type="radio" name="a_arm" value="no" />Ne</label
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Kalbos sutrikimas</td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_speech"
+                          value="yes"
+                        />Taip</label
+                      >
+                    </td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_speech"
+                          value="no"
+                        />Ne</label
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Pusiausvyros sutrikimas</td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_balance"
+                          value="yes"
+                        />Taip</label
+                      >
+                    </td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_balance"
+                          value="no"
+                        />Ne</label
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>Sąmonės/kvėpavimo sutrikimas</td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_conscious"
+                          value="yes"
+                        />Taip</label
+                      >
+                    </td>
+                    <td>
+                      <label class="pill"
+                        ><input
+                          type="radio"
+                          name="a_conscious"
+                          value="no"
+                        />Ne</label
+                      >
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </fieldset>
+
+            <fieldset>
+              <legend>Vartojami vaistai</legend>
+              <div class="grid-2">
+                <label class="pill"
+                  ><input id="a_warfarin" type="checkbox" />Varfarinas</label
+                >
+                <label class="pill"
+                  ><input id="a_apixaban" type="checkbox" />Apiksabanas</label
+                >
+                <label class="pill"
+                  ><input
+                    id="a_rivaroxaban"
+                    type="checkbox"
+                  />Rivaroksabanas</label
+                >
+                <label class="pill"
+                  ><input
+                    id="a_dabigatran"
+                    type="checkbox"
+                  />Dabigatranas</label
+                >
+                <label class="pill"
+                  ><input id="a_edoxaban" type="checkbox" />Edoksabanas</label
+                >
+                <label class="pill"
+                  ><input id="a_unknown" type="checkbox" />Nežinoma</label
+                >
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend>Paskutinį kartą matytas sveikas</legend>
+              <div class="grid-3">
+                <label class="pill"
+                  ><input type="radio" name="a_lkw" value="<4.5" /> &lt;4,5 val
+                  (aktyvuoti insulto komandą)</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="a_lkw" value="4.5-24" /> &gt;4,5
+                  val bet &lt;24 val (informuoti SPS gyd.)</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="a_lkw" value="unknown" />
+                  Nežinoma</label
+                >
+              </div>
+            </fieldset>
+
+            <fieldset>
+              <legend>Parametrai</legend>
+              <div class="grid-2">
+                <div>
+                  <label for="a_glucose">Gliukozė</label>
+                  <input id="a_glucose" type="text" />
+                </div>
+                <div>
+                  <label for="a_aks">AKS</label>
+                  <input id="a_aks" type="text" />
+                </div>
+                <div>
+                  <label for="a_hr">ŠSD</label>
+                  <input id="a_hr" type="text" />
+                </div>
+                <div>
+                  <label for="a_spo2">SpO₂</label>
+                  <input id="a_spo2" type="text" />
+                </div>
+                <div>
+                  <label for="a_temp">Temperatūra</label>
+                  <input id="a_temp" type="text" />
+                </div>
+              </div>
+            </fieldset>
+          </form>
+        </section>

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -1,0 +1,255 @@
+        <!-- Paciento atvykimas -->
+        <section id="arrival" class="card hidden">
+          <h2>Paciento atvykimas</h2>
+          <form>
+            <fieldset>
+              <legend>Atvykimo laikas</legend>
+              {{ macros.timeInput('t_door') }}
+            </fieldset>
+
+            <fieldset>
+              <legend>Paskutinį kartą matytas sveikas</legend>
+              <div class="grid-3">
+                <label class="pill"
+                  ><input type="radio" name="lkw_type" value="known" checked />
+                  Paskutinį kartą matytas sveikas</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="lkw_type" value="unknown" />
+                  Nežinoma</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="lkw_type" value="sleep" /> Miego
+                  vidurio laikas</label
+                >
+              </div>
+              {{ macros.timeInput('t_lkw', 'lkwTimeRow', 'row mt-4') }}
+            </fieldset>
+
+            <fieldset>
+              <legend>Simptomai</legend>
+              <textarea id="arrival_symptoms" rows="3"></textarea>
+            </fieldset>
+
+            <fieldset>
+              <legend>Kontraindikacijos trombolizei</legend>
+              <ul class="contra-list">
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Netiesioginio veikimo antikoaguliantai (INR ≥1,7)"
+                    />
+                    Pacientas vartoja netiesioginio veikimo antikoaguliantus
+                    (INR ≥1,7)
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Arterijos punkcija nekompresuojamoje vietoje per 7 d."
+                    />
+                    Arterijos punkcija nekompresuojamoje vietoje per pastarąsias
+                    7 d.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Didelė operacija ar sunkus sužalojimas per 14 d."
+                    />
+                    Didelė operacija ar sunkus sužalojimas per pastarąsias 14 d.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Sunki galvos trauma ar insultas per 3 mėn."
+                    />
+                    Sunki galvos trauma ar insultas per paskutinius 3 mėn.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Ankstesnis intrakranijinis kraujavimas"
+                    />
+                    Ankstesnis intrakranijinis kraujavimas
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Intrakranijinis navikas, AVM ar aneurizma"
+                    />
+                    Intrakranijinis navikas, AVM ar aneurizma
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Ītariama subarachnoidinė hemoragija"
+                    />
+                    Ītariama subarachnoidinė hemoragija
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Lumbalinė punkcija per 7 d."
+                    />
+                    Lumbalinė punkcija per pastarąsias 7 d.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Trombocitų kiekis <100×10⁹/l"
+                    />
+                    Trombocitų kiekis &lt;100×10⁹/l
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="AKS ≥185/110 nepaisant gydymo"
+                    />
+                    AKS ≥185/110 mmHg nepaisant gydymo
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Gliukozė <2,8 arba >22 mmol/l"
+                    />
+                    Gliukozė &lt;2,8 arba &gt;22 mmol/l
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Traukuliai insulto pradžioje"
+                    />
+                    Traukuliai insulto pradžioje
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Aktyvus vidinis kraujavimas"
+                    />
+                    Aktyvus vidinis kraujavimas
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Virškinamojo ar šlapimo takų kraujavimas per 21 d."
+                    />
+                    Virškinamojo ar šlapimo takų kraujavimas per pastarąsias 21
+                    d.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Nėštumas"
+                    />
+                    Nėštumas
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Infekcinis endokarditas"
+                    />
+                    Infekcinis endokarditas
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Miokardo infarktas per 3 mėn."
+                    />
+                    Miokardo infarktas per paskutinius 3 mėn.
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Heparino vartojimas per 48 h su pailgėjusiu aPTT"
+                    />
+                    Heparino vartojimas per pastarąsias 48 h su pailgėjusiu aPTT
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Tiesioginiai trombino ar Xa inhibitoriai su patologiniais tyrimais"
+                    />
+                    Tiesioginiai trombino ar Xa inhibitoriai su patologiniais
+                    tyrimais
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="KT rodo >1/3 ACM teritorijos pažaidą"
+                    />
+                    KT rodo &gt;1/3 ACM teritorijos pažaidą
+                  </label>
+                </li>
+                <li>
+                  <label>
+                    <input
+                      type="checkbox"
+                      name="arrival_contra"
+                      value="Nekontroliuojama hipertenzija, reikalinga intensyvi terapija"
+                    />
+                    Nekontroliuojama hipertenzija, reikalinga intensyvi terapija
+                  </label>
+                </li>
+              </ul>
+            </fieldset>
+          </form>
+        </section>
+

--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -1,0 +1,44 @@
+        <!-- Sprendimas -->
+        <section id="decision" class="card hidden">
+          <h2>Sprendimas</h2>
+          <form>
+            <fieldset>
+              <legend>Sprendimo laikas</legend>
+              {{ macros.timeInput('d_time') }}
+            </fieldset>
+            <fieldset class="mt-10">
+              <legend>Sprendimas</legend>
+              <div>
+                <label class="pill"
+                  ><input
+                    type="radio"
+                    name="d_decision"
+                    value="Taikoma IVT, indikacijų MTE nenustatyta"
+                  />Taikoma IVT, indikacijų MTE nenustatyta</label
+                >
+                <label class="pill"
+                  ><input
+                    type="radio"
+                    name="d_decision"
+                    value="Taikoma IVT, rengiamasi MTE atlikimui"
+                  />Taikoma IVT, rengiamasi MTE atlikimui</label
+                >
+                <label class="pill"
+                  ><input
+                    type="radio"
+                    name="d_decision"
+                    value="Rengiamasi MTE atlikimui"
+                  />Rengiamasi MTE atlikimui</label
+                >
+                <label class="pill"
+                  ><input
+                    type="radio"
+                    name="d_decision"
+                    value="Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika"
+                  />Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika</label
+                >
+              </div>
+            </fieldset>
+          </form>
+        </section>
+

--- a/templates/sections/nihss.njk
+++ b/templates/sections/nihss.njk
@@ -1,0 +1,173 @@
+        <!-- NIHSS -->
+        <section id="nihss" class="card hidden">
+          <h2>NIHSS</h2>
+          <form>
+            <fieldset>
+              <div>
+                <label for="p_nihss0">NIHSS (pradinis)</label>
+                <input id="p_nihss0" type="number" min="0" max="42" />
+                <div class="card nihss-calc" data-target="p_nihss0">
+                    <div class="nihss-grid">
+                      <label
+                        >1a. Sąmonės lygis
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Budrus</option>
+                          <option value="1">
+                            1 – Nevisiškai budrus, reaguoja į menką stimulaciją
+                          </option>
+                          <option value="2">
+                            2 – Reaguoja tik į stiprią/pakartotinę stimulaciją
+                          </option>
+                          <option value="3">3 – Nereaguoja</option>
+                        </select>
+                      </label>
+                      <label
+                        >1b. Klausimai
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Atsako abu</option>
+                          <option value="1">1 – Atsako vieną</option>
+                          <option value="2">2 – Neatsako</option>
+                        </select>
+                      </label>
+                      <label
+                        >1c. Komandos
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Atlieka abi</option>
+                          <option value="1">1 – Atlieka vieną</option>
+                          <option value="2">2 – Neatlieka</option>
+                        </select>
+                      </label>
+                      <label
+                        >2. Žvilgsnis
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Normalus</option>
+                          <option value="1">1 – Dalinis paralyžius</option>
+                          <option value="2">2 – Priverstinis nukrypimas</option>
+                        </select>
+                      </label>
+                      <label
+                        >3. Regėjimas
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nėra deficito</option>
+                          <option value="1">1 – Dalinė hemianopsija</option>
+                          <option value="2">2 – Pilna hemianopsija</option>
+                          <option value="3">3 – Dvišalė hemianopsija / aklumas</option>
+                        </select>
+                      </label>
+                      <label
+                        >4. Veido judesiai
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Simetriški</option>
+                          <option value="1">1 – Lengvas paralyžius</option>
+                          <option value="2">2 – Dalinis paralyžius</option>
+                          <option value="3">3 – Visiškas paralyžius</option>
+                        </select>
+                      </label>
+                      <label
+                        >5a. Rankos (K)
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nedreifuoja</option>
+                          <option value="1">1 – Dreifuoja</option>
+                          <option value="2">2 – Nedidelis judėjimas prieš gravitaciją</option>
+                          <option value="3">3 – Neįveikia gravitacijos</option>
+                          <option value="4">4 – Judesių nėra</option>
+                        </select>
+                      </label>
+                      <label
+                        >5b. Rankos (D)
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nedreifuoja</option>
+                          <option value="1">1 – Dreifuoja</option>
+                          <option value="2">2 – Nedidelis judėjimas prieš gravitaciją</option>
+                          <option value="3">3 – Neįveikia gravitacijos</option>
+                          <option value="4">4 – Judesių nėra</option>
+                        </select>
+                      </label>
+                      <label
+                        >6a. Kojos (K)
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nedreifuoja</option>
+                          <option value="1">1 – Dreifuoja</option>
+                          <option value="2">2 – Nedidelis judėjimas prieš gravitaciją</option>
+                          <option value="3">3 – Neįveikia gravitacijos</option>
+                          <option value="4">4 – Judesių nėra</option>
+                        </select>
+                      </label>
+                      <label
+                        >6b. Kojos (D)
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nedreifuoja</option>
+                          <option value="1">1 – Dreifuoja</option>
+                          <option value="2">2 – Nedidelis judėjimas prieš gravitaciją</option>
+                          <option value="3">3 – Neįveikia gravitacijos</option>
+                          <option value="4">4 – Judesių nėra</option>
+                        </select>
+                      </label>
+                      <label
+                        >7. Ataksija
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nėra</option>
+                          <option value="1">1 – Vienoje galūnėje</option>
+                          <option value="2">2 – Dviejose galūnėse</option>
+                        </select>
+                      </label>
+                      <label
+                        >8. Jutimai
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Normalūs</option>
+                          <option value="1">1 – Lengvas ar vidutinis sutrikimas</option>
+                          <option value="2">2 – Sunkus ar visiškas sutrikimas</option>
+                        </select>
+                      </label>
+                      <label
+                        >9. Kalba
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nėra afazijos</option>
+                          <option value="1">1 – Lengva ar vidutinė afazija</option>
+                          <option value="2">2 – Sunki afazija</option>
+                          <option value="3">3 – Globali afazija / nekalba</option>
+                        </select>
+                      </label>
+                      <label
+                        >10. Artikuliacija
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Normali</option>
+                          <option value="1">1 – Lengva ar vidutinė dizartrija</option>
+                          <option value="2">2 – Sunki dizartrija</option>
+                        </select>
+                      </label>
+                      <label
+                        >11. Neglect
+                        <select data-score>
+                          <option value=""></option>
+                          <option value="0">0 – Nėra</option>
+                          <option value="1">1 – Vienos modalės neglektas</option>
+                          <option value="2">2 – Sunkus/daugiamodalis neglektas</option>
+                        </select>
+                      </label>
+                    </div>
+                    <div class="nihss-actions">
+                      <strong>Viso: <span class="nihss-total">0</span></strong>
+                      <button type="button" class="btn apply">Taikyti</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </fieldset>
+          </form>
+        </section>
+

--- a/templates/sections/summary.njk
+++ b/templates/sections/summary.njk
@@ -1,0 +1,12 @@
+        <!-- Santrauka HIS sistemai -->
+        <section id="summarySec" class="card full-span hidden">
+          <h2>Santrauka (kopijavimui į HIS)</h2>
+          <textarea
+            id="summary"
+            class="summary mono"
+            placeholder="Santrauka generuojama automatiškai"
+          ></textarea>
+          <div class="sticky-actions">
+            {{ macros.actionButton('copySummaryBtn', 'Kopijuoti santrauką', '📋', 'Kopijuoti') }}
+          </div>
+        </section>

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -1,0 +1,132 @@
+        <!-- Pasiruošimas trombolizei -->
+        <section id="thrombolysis" class="card hidden">
+          <h2>Pasiruošimas trombolizei</h2>
+          <form>
+            <div class="grid-3">
+              <div>
+                <label for="p_weight">Svoris (kg)</label>
+                <input
+                  id="p_weight"
+                  type="number"
+                  min="1"
+                  max="300"
+                  step="0.1"
+                  placeholder="kg"
+                />
+              </div>
+              <div>
+                <label for="p_bp">AKS (mmHg)</label>
+                <input id="p_bp" type="text" placeholder="pvz. 178/92" />
+              </div>
+              <div>
+                <label for="p_inr">INR</label>
+                <input id="p_inr" type="number" step="0.1" />
+              </div>
+            </div>
+            <div class="mt-10">
+              <button type="button" id="bpCorrBtn" class="btn">
+                AKS korekcija
+              </button>
+              <div id="bpMedList" class="hidden mt-10">
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Labetololis"
+                  data-dose="10 mg"
+                >
+                  Labetololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Enalaprilis"
+                  data-dose="1.25 mg"
+                >
+                  Enalaprilis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Metoprololis"
+                  data-dose="5 mg"
+                >
+                  Metoprololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Natrio nitroprusidas"
+                  data-dose="0.3 µg/kg/min"
+                >
+                  Natrio nitroprusidas
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Kita"
+                  data-dose=""
+                >
+                  Kita
+                </button>
+              </div>
+              <div id="bpEntries" class="mt-10"></div>
+            </div>
+            <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
+            <div class="grid-2">
+              <div>
+                <label>Vaistas</label>
+                <select id="drug_type">
+                  <option value="tnk">
+                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                  </option>
+                  <option value="tpa">
+                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                    per 60 min
+                  </option>
+                </select>
+              </div>
+              <div>
+                <label>Koncentracija (mg/ml)</label>
+                <input
+                  id="drug_conc"
+                  type="number"
+                  step="0.01"
+                  placeholder="pvz. 5"
+                />
+              </div>
+            </div>
+            <div class="grid-2 mt-10">
+              <div>
+                <label>Bendra dozė (mg)</label>
+                <input id="dose_total" type="number" step="0.1" readonly />
+              </div>
+              <div>
+                <label>Tūris (ml)</label>
+                <input id="dose_volume" type="number" step="0.1" readonly />
+              </div>
+            </div>
+            <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
+              <div>
+                <label>Bolius 10% (mg / ml)</label>
+                <input id="tpa_bolus" type="text" readonly />
+              </div>
+              <div>
+                <label>Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                <input id="tpa_infusion" type="text" readonly />
+              </div>
+            </div>
+            <div class="section-actions mt-10">
+              <button id="calcBtn" class="btn primary">🧮 Skaičiuoti</button>
+              <span class="mini"
+                >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši
+                skaičiuoklė – pagalbinė.</span
+              >
+            </div>
+            <div class="section-actions mt-10">
+              <button type="button" id="startThrombolysis" class="btn">
+                Pradėta trombolizė
+              </button>
+            </div>
+          </form>
+        </section>
+


### PR DESCRIPTION
## Summary
- Split monolithic HTML into modular Nunjucks-style templates for header, navigation and form sections
- Introduced reusable macros for action buttons and timestamp inputs
- Added build script to compose templates into final `index.html`

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56aff975c8320ba994cb8af7c7aa9