### PR TITLE
Fix tab navigation scroll offset for sticky header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,6 +136,10 @@ main {
   padding: 0 16px;
 }
 
+main > section {
+  scroll-margin-top: calc(var(--header-height) + 16px);
+}
+
 .layout-main {
   display: grid;
   grid-template-columns: 220px 1fr 220px;


### PR DESCRIPTION
## Summary
- Ensure sections account for sticky header when navigating tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a56d7c63ac83208566b1c3e3c971e0