### PR TITLE
feat: improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 
 
 
-  <div id="toastContainer" class="toast-container"></div>
+  <div id="toastContainer" class="toast-container" role="region" aria-live="polite"></div>
   <header>
   <div class="wrap">
     <div class="brand">
@@ -56,29 +56,29 @@
 
   <div class="wrap layout-main">
     <button id="navToggle" class="btn">☰ <span class="btn-label">Meniu</span></button>
-    <nav>
-  <a href="#activation" data-section="activation" class="tab active"
+    <nav role="tablist">
+  <a id="tab-activation" href="#activation" data-section="activation" class="tab active" role="tab" aria-controls="activation" aria-selected="true" tabindex="0"
     ><span class="tab-icon">🚨</span>Aktyvacija</a
   >
-  <a href="#arrival" data-section="arrival" class="tab"
+  <a id="tab-arrival" href="#arrival" data-section="arrival" class="tab" role="tab" aria-controls="arrival" aria-selected="false" tabindex="-1"
     ><span class="tab-icon">🚑</span>Paciento atvykimas</a
   >
-  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+  <a id="tab-thrombolysis" href="#thrombolysis" data-section="thrombolysis" class="tab" role="tab" aria-controls="thrombolysis" aria-selected="false" tabindex="-1"
     ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
   >
-  <a href="#nihss" data-section="nihss" class="tab"
+  <a id="tab-nihss" href="#nihss" data-section="nihss" class="tab" role="tab" aria-controls="nihss" aria-selected="false" tabindex="-1"
     ><span class="tab-icon">🧮</span>NIHSS</a
   >
-  <a href="#decision" data-section="decision" class="tab"
+  <a id="tab-decision" href="#decision" data-section="decision" class="tab" role="tab" aria-controls="decision" aria-selected="false" tabindex="-1"
     ><span class="tab-icon">☑️</span>Sprendimas</a
   >
-  <a href="#summarySec" data-section="summarySec" class="tab"
+  <a id="tab-summarySec" href="#summarySec" data-section="summarySec" class="tab" role="tab" aria-controls="summarySec" aria-selected="false" tabindex="-1"
     ><span class="tab-icon">📄</span>Santrauka</a
   >
 </nav>
 
     <main class="px-0">
-              <section id="activation" class="card">
+              <section id="activation" class="card" role="tabpanel" aria-labelledby="tab-activation" tabindex="0">
           <h2>Komandos aktyvacija</h2>
           <form>
             <fieldset>
@@ -294,7 +294,7 @@
         </section>
 
               <!-- Paciento atvykimas -->
-        <section id="arrival" class="card hidden">
+        <section id="arrival" class="card hidden" role="tabpanel" aria-labelledby="tab-arrival" tabindex="-1" aria-hidden="true">
           <h2>Paciento atvykimas</h2>
           <form>
             <fieldset>
@@ -570,7 +570,7 @@
 
 
               <!-- Pasiruošimas trombolizei -->
-        <section id="thrombolysis" class="card hidden">
+        <section id="thrombolysis" class="card hidden" role="tabpanel" aria-labelledby="tab-thrombolysis" tabindex="-1" aria-hidden="true">
           <h2>Pasiruošimas trombolizei</h2>
           <form>
             <div class="grid-3">
@@ -703,7 +703,7 @@
 
 
               <!-- NIHSS -->
-        <section id="nihss" class="card hidden">
+        <section id="nihss" class="card hidden" role="tabpanel" aria-labelledby="tab-nihss" tabindex="-1" aria-hidden="true">
           <h2>NIHSS</h2>
           <form>
             <fieldset>
@@ -877,7 +877,7 @@
 
 
               <!-- Sprendimas -->
-        <section id="decision" class="card hidden">
+        <section id="decision" class="card hidden" role="tabpanel" aria-labelledby="tab-decision" tabindex="-1" aria-hidden="true">
           <h2>Sprendimas</h2>
           <form>
             <fieldset>
@@ -932,7 +932,7 @@
 
 
               <!-- Santrauka HIS sistemai -->
-        <section id="summarySec" class="card full-span hidden">
+        <section id="summarySec" class="card full-span hidden" role="tabpanel" aria-labelledby="tab-summarySec" tabindex="-1" aria-hidden="true">
           <h2>Santrauka (kopijavimui į HIS)</h2>
           <textarea
             id="summary"

--- a/js/app.js
+++ b/js/app.js
@@ -224,8 +224,18 @@ function bind() {
   const tabs = $$('nav .tab');
   const sections = $$('main > section');
   const showSection = (id) => {
-    sections.forEach((s) => s.classList.toggle('hidden', s.id !== id));
-    tabs.forEach((t) => t.classList.toggle('active', t.dataset.section === id));
+    sections.forEach((s) => {
+      const active = s.id === id;
+      s.classList.toggle('hidden', !active);
+      s.setAttribute('tabindex', active ? '0' : '-1');
+      s.setAttribute('aria-hidden', active ? 'false' : 'true');
+    });
+    tabs.forEach((t) => {
+      const selected = t.dataset.section === id;
+      t.classList.toggle('active', selected);
+      t.setAttribute('aria-selected', selected ? 'true' : 'false');
+      t.setAttribute('tabindex', selected ? '0' : '-1');
+    });
     if (id === 'summarySec') genSummary();
     if (id === 'decision' && inputs.d_time && !inputs.d_time.value)
       setNow('d_time');
@@ -238,14 +248,26 @@ function bind() {
   $('#navToggle').addEventListener('click', () => {
     document.body.classList.toggle('nav-open');
   });
-  tabs.forEach((tab) =>
+  tabs.forEach((tab, index) => {
     tab.addEventListener('click', (e) => {
       e.preventDefault();
       const id = tab.dataset.section;
       showSection(id);
       if (id) location.hash = id;
-    }),
-  );
+    });
+    tab.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        const dir = e.key === 'ArrowRight' ? 1 : -1;
+        const next = (index + dir + tabs.length) % tabs.length;
+        const nextTab = tabs[next];
+        const id = nextTab.dataset.section;
+        nextTab.focus();
+        showSection(id);
+        if (id) location.hash = id;
+      }
+    });
+  });
   window.addEventListener('hashchange', activateFromHash);
   activateFromHash();
 

--- a/js/toast.js
+++ b/js/toast.js
@@ -9,11 +9,14 @@ const toast = {
     const { type, duration = 3000 } = options;
     const el = document.createElement('div');
     el.className = 'toast' + (type ? ` ${type}` : '');
+    el.setAttribute('role', 'alert');
     el.textContent = msg;
 
     const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
     closeBtn.className = 'toast-close';
     closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.setAttribute('tabindex', '0');
     closeBtn.innerHTML = '&times;';
     el.appendChild(closeBtn);
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "type": "module",
   "devDependencies": {
     "prettier": "^3.2.5",
-    "husky": "^9.0.11"
+    "husky": "^9.0.11",
+    "axe-core": "^4.8.3",
+    "jsdom": "^24.0.0"
   },
   "scripts": {
     "format": "prettier --write js/*.js",

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import axe from 'axe-core';
+
+test('index.html has no accessibility violations', async () => {
+  const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'dangerously' });
+  dom.window.eval(axe.source);
+  const results = await dom.window.axe.run();
+  assert.strictEqual(
+    results.violations.length,
+    0,
+    JSON.stringify(results.violations, null, 2),
+  );
+});


### PR DESCRIPTION
## Summary
- add ARIA live region for toasts and annotate navigation as tablist
- expose tab panels with keyboard support and alertable toasts
- add axe-core accessibility regression test

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68a56d01f1208320b3ac7850d74807b9