### PR TITLE
feat: replace native prompts with modal

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -656,6 +656,36 @@ section[data-tab='Intervencijos'] h3 {
   gap: 8px;
   margin-top: 16px;
 }
+.modal h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+.modal input {
+  width: 100%;
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--bg);
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.modal .actions button {
+  background: #152231;
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+.modal .actions button.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: #2d74b8;
+}
+.modal .actions button:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .toast-container {
   position: fixed;
   bottom: 20px;

--- a/js/app.js
+++ b/js/app.js
@@ -3,6 +3,7 @@ import { setNow } from './time.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { genSummary, copySummary } from './summary.js';
 import { showToast } from './toast.js';
+import { confirmModal, promptModal } from './modal.js';
 import { updateAge } from './age.js';
 import {
   saveLS,
@@ -144,11 +145,11 @@ function bind() {
       updateDraftSelect(inputs.draftSelect.value),
     );
 
-  $('#saveBtn').addEventListener('click', () => {
+  $('#saveBtn').addEventListener('click', async () => {
     const existing = inputs.draftSelect.value;
     let name = null;
     if (!existing)
-      name = prompt(
+      name = await promptModal(
         'Juodraščio pavadinimas?',
         inputs.nih0.value || 'Juodraštis',
       );
@@ -171,23 +172,26 @@ function bind() {
       dirty = false;
     } else showToast('Nėra išsaugoto įrašo.', { type: 'error' });
   });
-  $('#renameDraftBtn').addEventListener('click', () => {
+  $('#renameDraftBtn').addEventListener('click', async () => {
     const id = inputs.draftSelect.value;
     if (!id) {
       showToast('Pasirinkite juodraštį.');
       return;
     }
     const drafts = getDrafts();
-    const newName = prompt('Naujas pavadinimas', drafts[id]?.name || '');
+    const newName = await promptModal(
+      'Naujas pavadinimas',
+      drafts[id]?.name || '',
+    );
     if (newName) renameLS(id, newName);
   });
-  $('#deleteDraftBtn').addEventListener('click', () => {
+  $('#deleteDraftBtn').addEventListener('click', async () => {
     const id = inputs.draftSelect.value;
     if (!id) {
       showToast('Pasirinkite juodraštį.');
       return;
     }
-    if (confirm('Ištrinti juodraštį?')) {
+    if (await confirmModal('Ištrinti juodraštį?')) {
       deleteLS(id);
       inputs.draftSelect.value = '';
     }
@@ -272,8 +276,8 @@ function bind() {
   activateFromHash();
 
   // New patient
-  $('#newPatientBtn').addEventListener('click', () => {
-    if (confirm('Išvalyti visus laukus naujam pacientui?')) {
+  $('#newPatientBtn').addEventListener('click', async () => {
+    if (await confirmModal('Išvalyti visus laukus naujam pacientui?')) {
       document.querySelectorAll('input, textarea, select').forEach((el) => {
         if (el.type === 'checkbox') el.checked = false;
         else if (

--- a/js/modal.js
+++ b/js/modal.js
@@ -1,0 +1,115 @@
+export function showModal({ title = '', message = '', input, buttons = [] }) {
+  return new Promise((resolve) => {
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+
+    const dialog = document.createElement('div');
+    dialog.className = 'modal';
+    dialog.setAttribute('role', 'dialog');
+    dialog.setAttribute('aria-modal', 'true');
+    const titleId = `modal-title-${Date.now()}`;
+    dialog.setAttribute('aria-labelledby', titleId);
+
+    const h2 = document.createElement('h2');
+    h2.id = titleId;
+    h2.textContent = title;
+    dialog.appendChild(h2);
+
+    if (message) {
+      const p = document.createElement('p');
+      p.textContent = message;
+      dialog.appendChild(p);
+    }
+
+    let inputEl;
+    if (input !== undefined) {
+      inputEl = document.createElement('input');
+      inputEl.type = 'text';
+      inputEl.value = input?.value || '';
+      if (input?.placeholder) inputEl.placeholder = input.placeholder;
+      inputEl.setAttribute('aria-label', title);
+      dialog.appendChild(inputEl);
+    }
+
+    const actions = document.createElement('div');
+    actions.className = 'actions';
+    dialog.appendChild(actions);
+
+    const resolveAndCleanup = (val) => {
+      overlay.removeEventListener('keydown', trap);
+      overlay.remove();
+      lastFocused?.focus();
+      resolve(val);
+    };
+
+    buttons.forEach((btn, idx) => {
+      const b = document.createElement('button');
+      b.type = 'button';
+      b.textContent = btn.label;
+      if (btn.class) b.className = btn.class;
+      b.addEventListener('click', () => {
+        const v =
+          typeof btn.value === 'function'
+            ? btn.value(inputEl?.value)
+            : btn.value;
+        resolveAndCleanup(v);
+      });
+      actions.appendChild(b);
+      if (btn.autofocus) setTimeout(() => b.focus(), 0);
+    });
+
+    overlay.appendChild(dialog);
+    document.body.appendChild(overlay);
+
+    const focusable = dialog.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    const lastFocused = document.activeElement;
+
+    const trap = (e) => {
+      if (e.key === 'Tab') {
+        if (focusable.length === 0) return;
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      } else if (e.key === 'Escape') {
+        resolveAndCleanup(null);
+      }
+    };
+    overlay.addEventListener('keydown', trap);
+
+    (inputEl || first)?.focus();
+  });
+}
+
+export function confirmModal(title) {
+  return showModal({
+    title,
+    buttons: [
+      { label: 'OK', value: true, class: 'primary', autofocus: true },
+      { label: 'Cancel', value: false },
+    ],
+  });
+}
+
+export function promptModal(title, defaultValue = '') {
+  return showModal({
+    title,
+    input: { value: defaultValue },
+    buttons: [
+      {
+        label: 'OK',
+        value: (v) => v,
+        class: 'primary',
+        autofocus: true,
+      },
+      { label: 'Cancel', value: null },
+    ],
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable modal component with focus trapping and ARIA
- replace confirm/prompt usage with async modal
- style modal to match theme

## Testing
- `npm test` *(fails: Cannot find package 'jsdom' imported from test/accessibility.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a56f8202508320a5a98e3050ed16fc