### PR TITLE
feat: version local drafts and migrate old payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Stroke Team App
+
+## Draft storage schema
+
+Drafts saved to `localStorage` are wrapped in an object with a `version` number.  The
+current schema version is **1**, stored as `{ version: 1, data: <payload> }`.
+Older drafts without a version are automatically migrated when loaded.

--- a/js/storage.js
+++ b/js/storage.js
@@ -5,12 +5,27 @@ import { updateAge } from './age.js';
 const { state } = dom;
 
 const LS_KEY = 'insultoKomandaDrafts_v1';
+// Current version of the payload schema stored in localStorage
+const SCHEMA_VERSION = 1;
 
 export function getDrafts() {
   const raw = localStorage.getItem(LS_KEY);
   if (!raw) return {};
   try {
-    return JSON.parse(raw);
+    const drafts = JSON.parse(raw);
+    let migrated = false;
+    Object.values(drafts).forEach((d) => {
+      if (
+        !d.data ||
+        typeof d.data !== 'object' ||
+        d.data.version === undefined
+      ) {
+        d.data = { version: 0, data: d.data };
+        migrated = true;
+      }
+    });
+    if (migrated) setDrafts(drafts);
+    return drafts;
   } catch (e) {
     console.error(e);
     localStorage.removeItem(LS_KEY);
@@ -87,57 +102,64 @@ export function getPayload() {
 
 export function setPayload(p) {
   if (!p) return;
+  const payload = p.version !== undefined ? p.data : p;
   const inputs = dom.getInputs();
-  if (inputs.weight) inputs.weight.value = p.p_weight || '';
-  if (inputs.bp) inputs.bp.value = p.p_bp || '';
-  if (inputs.inr) inputs.inr.value = p.p_inr || '';
-  if (inputs.nih0) inputs.nih0.value = p.p_nihss0 || '';
-  if (inputs.lkw) inputs.lkw.value = p.t_lkw || '';
-  if (inputs.door) inputs.door.value = p.t_door || '';
-  if (inputs.d_time) inputs.d_time.value = p.d_time || '';
-  if (inputs.d_decision) setRadioValue(inputs.d_decision, p.d_decision || '');
-  if (inputs.drugType) inputs.drugType.value = p.drug_type || 'tnk';
-  if (inputs.drugConc) inputs.drugConc.value = p.drug_conc || '';
-  if (inputs.doseTotal) inputs.doseTotal.value = p.dose_total || '';
-  if (inputs.doseVol) inputs.doseVol.value = p.dose_volume || '';
-  if (inputs.tpaBolus) inputs.tpaBolus.value = p.tpa_bolus || '';
-  if (inputs.tpaInf) inputs.tpaInf.value = p.tpa_infusion || '';
+  if (inputs.weight) inputs.weight.value = payload.p_weight || '';
+  if (inputs.bp) inputs.bp.value = payload.p_bp || '';
+  if (inputs.inr) inputs.inr.value = payload.p_inr || '';
+  if (inputs.nih0) inputs.nih0.value = payload.p_nihss0 || '';
+  if (inputs.lkw) inputs.lkw.value = payload.t_lkw || '';
+  if (inputs.door) inputs.door.value = payload.t_door || '';
+  if (inputs.d_time) inputs.d_time.value = payload.d_time || '';
+  if (inputs.d_decision)
+    setRadioValue(inputs.d_decision, payload.d_decision || '');
+  if (inputs.drugType) inputs.drugType.value = payload.drug_type || 'tnk';
+  if (inputs.drugConc) inputs.drugConc.value = payload.drug_conc || '';
+  if (inputs.doseTotal) inputs.doseTotal.value = payload.dose_total || '';
+  if (inputs.doseVol) inputs.doseVol.value = payload.dose_volume || '';
+  if (inputs.tpaBolus) inputs.tpaBolus.value = payload.tpa_bolus || '';
+  if (inputs.tpaInf) inputs.tpaInf.value = payload.tpa_infusion || '';
   if (inputs.lkw_type)
-    setRadioValue(inputs.lkw_type, p.arrival_lkw_type || 'known');
+    setRadioValue(inputs.lkw_type, payload.arrival_lkw_type || 'known');
   if (inputs.arrival_symptoms)
-    inputs.arrival_symptoms.value = p.arrival_symptoms || '';
-  const contraVals = (p.arrival_contra || '').split(/;\s*/).filter(Boolean);
+    inputs.arrival_symptoms.value = payload.arrival_symptoms || '';
+  const contraVals = (payload.arrival_contra || '')
+    .split(/;\s*/)
+    .filter(Boolean);
   (inputs.arrival_contra || []).forEach((cb) => {
     cb.checked = contraVals.includes(cb.value);
   });
-  if (inputs.a_personal) inputs.a_personal.value = p.a_personal || '';
-  if (inputs.a_name) inputs.a_name.value = p.a_name || '';
-  if (inputs.a_dob) inputs.a_dob.value = p.a_dob || '';
+  if (inputs.a_personal) inputs.a_personal.value = payload.a_personal || '';
+  if (inputs.a_name) inputs.a_name.value = payload.a_name || '';
+  if (inputs.a_dob) inputs.a_dob.value = payload.a_dob || '';
   updateAge();
-  if (inputs.a_sym_face) setRadioValue(inputs.a_sym_face, p.a_sym_face || '');
-  if (inputs.a_sym_arm) setRadioValue(inputs.a_sym_arm, p.a_sym_arm || '');
-  if (inputs.a_sym_speech) setRadioValue(inputs.a_sym_speech, p.a_sym_speech || '');
+  if (inputs.a_sym_face)
+    setRadioValue(inputs.a_sym_face, payload.a_sym_face || '');
+  if (inputs.a_sym_arm)
+    setRadioValue(inputs.a_sym_arm, payload.a_sym_arm || '');
+  if (inputs.a_sym_speech)
+    setRadioValue(inputs.a_sym_speech, payload.a_sym_speech || '');
   if (inputs.a_sym_balance)
-    setRadioValue(inputs.a_sym_balance, p.a_sym_balance || '');
+    setRadioValue(inputs.a_sym_balance, payload.a_sym_balance || '');
   if (inputs.a_sym_conscious)
-    setRadioValue(inputs.a_sym_conscious, p.a_sym_conscious || '');
-  if (inputs.a_warfarin) inputs.a_warfarin.checked = !!p.a_drug_warfarin;
-  if (inputs.a_apixaban) inputs.a_apixaban.checked = !!p.a_drug_apixaban;
+    setRadioValue(inputs.a_sym_conscious, payload.a_sym_conscious || '');
+  if (inputs.a_warfarin) inputs.a_warfarin.checked = !!payload.a_drug_warfarin;
+  if (inputs.a_apixaban) inputs.a_apixaban.checked = !!payload.a_drug_apixaban;
   if (inputs.a_rivaroxaban)
-    inputs.a_rivaroxaban.checked = !!p.a_drug_rivaroxaban;
+    inputs.a_rivaroxaban.checked = !!payload.a_drug_rivaroxaban;
   if (inputs.a_dabigatran)
-    inputs.a_dabigatran.checked = !!p.a_drug_dabigatran;
-  if (inputs.a_edoxaban) inputs.a_edoxaban.checked = !!p.a_drug_edoxaban;
-  if (inputs.a_unknown) inputs.a_unknown.checked = !!p.a_drug_unknown;
-  if (inputs.a_lkw) setRadioValue(inputs.a_lkw, p.a_lkw || '');
-  if (inputs.a_glucose) inputs.a_glucose.value = p.a_glucose || '';
-  if (inputs.a_aks) inputs.a_aks.value = p.a_aks || '';
-  if (inputs.a_hr) inputs.a_hr.value = p.a_hr || '';
-  if (inputs.a_spo2) inputs.a_spo2.value = p.a_spo2 || '';
-  if (inputs.a_temp) inputs.a_temp.value = p.a_temp || '';
-  if (inputs.def_tnk) inputs.def_tnk.value = p.def_tnk || 5;
-  if (inputs.def_tpa) inputs.def_tpa.value = p.def_tpa || 1;
-  if (inputs.autosave) inputs.autosave.value = p.autosave || 'on';
+    inputs.a_dabigatran.checked = !!payload.a_drug_dabigatran;
+  if (inputs.a_edoxaban) inputs.a_edoxaban.checked = !!payload.a_drug_edoxaban;
+  if (inputs.a_unknown) inputs.a_unknown.checked = !!payload.a_drug_unknown;
+  if (inputs.a_lkw) setRadioValue(inputs.a_lkw, payload.a_lkw || '');
+  if (inputs.a_glucose) inputs.a_glucose.value = payload.a_glucose || '';
+  if (inputs.a_aks) inputs.a_aks.value = payload.a_aks || '';
+  if (inputs.a_hr) inputs.a_hr.value = payload.a_hr || '';
+  if (inputs.a_spo2) inputs.a_spo2.value = payload.a_spo2 || '';
+  if (inputs.a_temp) inputs.a_temp.value = payload.a_temp || '';
+  if (inputs.def_tnk) inputs.def_tnk.value = payload.def_tnk || 5;
+  if (inputs.def_tpa) inputs.def_tpa.value = payload.def_tpa || 1;
+  if (inputs.autosave) inputs.autosave.value = payload.autosave || 'on';
   state.autosave = inputs.autosave?.value || 'on';
   updateDrugDefaults();
 }
@@ -151,7 +173,10 @@ export function saveLS(id, name) {
     drafts[draftId]?.name ||
     inputs.nih0?.value ||
     `Juodraštis ${draftId}`;
-  drafts[draftId] = { name: draftName, data: getPayload() };
+  drafts[draftId] = {
+    name: draftName,
+    data: { version: SCHEMA_VERSION, data: getPayload() },
+  };
   setDrafts(drafts);
   updateDraftSelect(draftId);
   return draftId;
@@ -159,7 +184,10 @@ export function saveLS(id, name) {
 
 export function loadLS(id) {
   const drafts = getDrafts();
-  return drafts[id] ? drafts[id].data : null;
+  const rec = drafts[id];
+  if (!rec) return null;
+  const d = rec.data;
+  return d && d.version !== undefined ? d.data : d;
 }
 
 export function deleteLS(id) {

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -82,7 +82,7 @@ Object.defineProperty(global, 'navigator', {
 
 let inputs = null;
 const { getInputs } = await import('../js/state.js');
-const { saveLS, loadLS, deleteLS, setPayload } = await import(
+const { saveLS, loadLS, deleteLS, setPayload, getDrafts } = await import(
   '../js/storage.js'
 );
 inputs = getInputs();
@@ -112,6 +112,9 @@ test('localStorage handles multiple records', { concurrency: false }, () => {
   deleteLS('d1');
   assert.strictEqual(loadLS('d1'), null);
   assert.strictEqual(loadLS('d2').p_nihss0, '2');
+  const drafts = getDrafts();
+  assert.strictEqual(drafts.d1.data.version, 1);
+  assert.strictEqual(drafts.d2.data.version, 1);
 });
 
 test(
@@ -143,3 +146,14 @@ test(
     assert.strictEqual(getEl('#summary').value, global.__copied);
   },
 );
+
+test('getDrafts migrates unversioned data', () => {
+  localStorageStub.store = {
+    insultoKomandaDrafts_v1: JSON.stringify({
+      old: { name: 'Old', data: { p_nihss0: '1' } },
+    }),
+  };
+  const drafts = getDrafts();
+  assert.strictEqual(drafts.old.data.version, 0);
+  assert.strictEqual(drafts.old.data.data.p_nihss0, '1');
+});


### PR DESCRIPTION
## Summary
- wrap saved localStorage drafts with schema version info
- migrate and unwrap older draft payloads on load
- document current draft schema

## Testing
- `npm test` *(fails: Error: Cannot find package '/workspace/Stroke-team-app/node_modules/jsdom/index.js' imported from /workspace/Stroke-team-app/test/accessibility.test.js)*
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a578d89880832088b68308bf44728e