### PR TITLE
Make summary textarea read-only and accessible

### DIFF
--- a/index.html
+++ b/index.html
@@ -938,6 +938,8 @@
             id="summary"
             class="summary mono"
             placeholder="Santrauka generuojama automatiškai"
+            readonly
+            aria-label="Santrauka"
           ></textarea>
           <div class="sticky-actions">
             <button id="copySummaryBtn" title="Kopijuoti santrauką" class="btn">📋 <span class="btn-label">Kopijuoti</span></button>


### PR DESCRIPTION
## Summary
- mark summary textarea as read-only
- add accessibility label to summary textarea

## Testing
- `npm test` *(fails: Cannot find package '/workspace/Stroke-team-app/node_modules/jsdom/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68a57d0bd6308320b735da9e6a1c7dbc