### PR TITLE
Add label for decision time input

### DIFF
--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -4,6 +4,7 @@
           <form>
             <fieldset>
               <legend>Sprendimo laikas</legend>
+              <label for="d_time">Sprendimo laikas</label>
               {{ macros.timeInput('d_time') }}
             </fieldset>
             <fieldset class="mt-10">


### PR DESCRIPTION
## Summary
- add explicit label for the `d_time` input in decision section so users can see field description and label associates with input

## Testing
- `npm test` *(fails: Cannot find package 'jsdom'; localStorage test error)*

------
https://chatgpt.com/codex/tasks/task_e_68a584f4e63c8320bec99e5d4f7ff02e