### PR TITLE
Make layout main grid responsive to optional aside

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -142,7 +142,9 @@ main > section {
 
 .layout-main {
   display: grid;
-  grid-template-columns: 220px 1fr 220px;
+  grid-template-columns: 220px 1fr;
+  grid-auto-flow: column;
+  grid-auto-columns: 220px;
   gap: 12px;
   align-items: start;
 }


### PR DESCRIPTION
## Summary
- Adjust `.layout-main` grid to define only two columns explicitly and auto-generate a third column when needed

## Testing
- `npm test` *(fails: Cannot find package 'jsdom'; localStorage test TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68a58a1f28988320bc7c9b88092a74cb