### PR TITLE
Add spacing for pill radio options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -331,6 +331,7 @@ input[type='datetime-local']::-webkit-calendar-picker-indicator:hover {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+  margin-bottom: 8px;
   padding: 6px 10px;
   border: 1px solid var(--line);
   border-radius: 999px;


### PR DESCRIPTION
## Summary
- add margin below `.pill` elements to separate radio options

## Testing
- `npm test` *(fails: Cannot find package 'jsdom'; localStorage test also failing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a58516a7b48320b75dd6eb317705e1