### PR TITLE
Replace symptom table with pill checkbox layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -771,21 +771,10 @@ section[data-tab='Intervencijos'] h3 {
   }
 }
 
-table.tbl {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-table.tbl th,
-table.tbl td {
-  border: 1px solid var(--line);
-  padding: 4px;
-  text-align: center;
-}
-
-table.tbl th:first-child,
-table.tbl td:first-child {
-  text-align: left;
+.symptoms {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 .cols-2 {
   grid-template-columns: repeat(2, 1fr);

--- a/index.html
+++ b/index.html
@@ -103,118 +103,31 @@
 
             <fieldset>
               <legend>Simptomai</legend>
-              <table class="tbl">
-                <thead>
-                  <tr>
-                    <th>Sutrikimas</th>
-                    <th>Taip</th>
-                    <th>Ne</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Veido paralyžius</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_face"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_face"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Rankos silpnumas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_arm"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input type="radio" name="a_arm" value="no" />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Kalbos sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_speech"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_speech"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Pusiausvyros sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_balance"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_balance"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Sąmonės/kvėpavimo sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_conscious"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_conscious"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div class="symptoms">
+                <label class="pill"
+                  ><input id="a_face" name="a_face" type="checkbox" />Veido
+                  paralyžius</label
+                >
+                <label class="pill"
+                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_speech" name="a_speech" type="checkbox" />Kalbos
+                  sutrikimas</label
+                >
+                <label class="pill"
+                  ><input id="a_balance" name="a_balance" type="checkbox" />Pusiausvyros
+                  sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    id="a_conscious"
+                    name="a_conscious"
+                    type="checkbox"
+                  />Sąmonės/kvėpavimo sutrikimas</label
+                >
+              </div>
             </fieldset>
 
             <fieldset>
@@ -882,6 +795,7 @@
           <form>
             <fieldset>
               <legend>Sprendimo laikas</legend>
+              <label for="d_time">Sprendimo laikas</label>
               <div class="row">
   <div class="input-group">
     <input

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -23,118 +23,31 @@
 
             <fieldset>
               <legend>Simptomai</legend>
-              <table class="tbl">
-                <thead>
-                  <tr>
-                    <th>Sutrikimas</th>
-                    <th>Taip</th>
-                    <th>Ne</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td>Veido paralyžius</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_face"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_face"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Rankos silpnumas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_arm"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input type="radio" name="a_arm" value="no" />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Kalbos sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_speech"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_speech"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Pusiausvyros sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_balance"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_balance"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>Sąmonės/kvėpavimo sutrikimas</td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_conscious"
-                          value="yes"
-                        />Taip</label
-                      >
-                    </td>
-                    <td>
-                      <label class="pill"
-                        ><input
-                          type="radio"
-                          name="a_conscious"
-                          value="no"
-                        />Ne</label
-                      >
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <div class="symptoms">
+                <label class="pill"
+                  ><input id="a_face" name="a_face" type="checkbox" />Veido
+                  paralyžius</label
+                >
+                <label class="pill"
+                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_speech" name="a_speech" type="checkbox" />Kalbos
+                  sutrikimas</label
+                >
+                <label class="pill"
+                  ><input id="a_balance" name="a_balance" type="checkbox" />Pusiausvyros
+                  sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    id="a_conscious"
+                    name="a_conscious"
+                    type="checkbox"
+                  />Sąmonės/kvėpavimo sutrikimas</label
+                >
+              </div>
             </fieldset>
 
             <fieldset>


### PR DESCRIPTION
## Summary
- render Simptomai symptoms as pill-style checkboxes in a flex container
- drop table styling and add flex-wrapping rules for symptoms

## Testing
- `npm test` *(fails: Cannot find package 'jsdom' and localStorage handles multiple records error)*

------
https://chatgpt.com/codex/tasks/task_e_68a5911c2e288320a5dadc944a0c38ec