### PR TITLE
Hide decision section until tab is selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -790,7 +790,7 @@
 
 
               <!-- Sprendimas -->
-        <section id="decision" class="card">
+        <section id="decision" class="card hidden">
           <h2>Sprendimas</h2>
           <form>
             <fieldset>

--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -1,5 +1,5 @@
         <!-- Sprendimas -->
-        <section id="decision" class="card">
+        <section id="decision" class="card hidden">
           <h2>Sprendimas</h2>
           <form>
             <fieldset>


### PR DESCRIPTION
## Summary
- Hide the "Sprendimas" decision section by default so it no longer shows beneath other tabs.

## Testing
- `npm test` *(fails: Cannot find package 'jsdom'; localStorage handles multiple records)*

------
https://chatgpt.com/codex/tasks/task_e_68a596616d2c83209a544465f12711f3