### PR TITLE
Modernize date and time inputs with icon controls

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,7 +15,7 @@ function timeInput(id, wrapperId = '', wrapperClass = 'row') {
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
-    <button class="btn ghost" data-now="${id}">Dabar</button>
+    <button type="button" class="btn ghost" data-now="${id}" aria-label="Dabar">🕒</button>
   </div>
 </div>`;
 }
@@ -29,14 +29,20 @@ function render(template) {
     return render(partial);
   });
   // macros
-  template = template.replace(/\{\{\s*macros\.actionButton\((.*?)\)\s*\}\}/g, (_, args) => {
-    const parsed = eval(`[${args}]`);
-    return macros.actionButton(...parsed);
-  });
-  template = template.replace(/\{\{\s*macros\.timeInput\((.*?)\)\s*\}\}/g, (_, args) => {
-    const parsed = eval(`[${args}]`);
-    return macros.timeInput(...parsed);
-  });
+  template = template.replace(
+    /\{\{\s*macros\.actionButton\((.*?)\)\s*\}\}/g,
+    (_, args) => {
+      const parsed = eval(`[${args}]`);
+      return macros.actionButton(...parsed);
+    },
+  );
+  template = template.replace(
+    /\{\{\s*macros\.timeInput\((.*?)\)\s*\}\}/g,
+    (_, args) => {
+      const parsed = eval(`[${args}]`);
+      return macros.timeInput(...parsed);
+    },
+  );
   return template;
 }
 

--- a/css/style.css
+++ b/css/style.css
@@ -263,6 +263,8 @@ textarea {
   right: 8px;
   top: 50%;
   transform: translateY(-50%);
+  min-width: 2.5rem;
+  padding: 4px 6px;
 }
 
 input[type='date']::-webkit-calendar-picker-indicator,

--- a/index.html
+++ b/index.html
@@ -94,7 +94,21 @@
                 </div>
                 <div>
                   <label for="a_dob">Gimimo data</label>
-                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" />
+                  <div class="input-group">
+                    <input
+                      id="a_dob"
+                      type="date"
+                      placeholder="YYYY-MM-DD"
+                    />
+                    <button
+                      type="button"
+                      class="btn ghost"
+                      data-picker="a_dob"
+                      aria-label="Pasirinkti datą"
+                    >
+                      📅
+                    </button>
+                  </div>
                   <div id="a_age_display" class="subtle"></div>
                   <input id="a_age" type="hidden" />
                 </div>
@@ -220,7 +234,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
-    <button class="btn ghost" data-now="t_door">Dabar</button>
+    <button type="button" class="btn ghost" data-now="t_door" aria-label="Dabar">🕒</button>
   </div>
 </div>
             </fieldset>
@@ -249,14 +263,14 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
-    <button class="btn ghost" data-now="t_lkw">Dabar</button>
+    <button type="button" class="btn ghost" data-now="t_lkw" aria-label="Dabar">🕒</button>
   </div>
 </div>
             </fieldset>
 
             <fieldset>
               <legend>Simptomai</legend>
-              <textarea id="arrival_symptoms" rows="3"></textarea>
+              <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 
             <fieldset>
@@ -558,7 +572,7 @@
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div class="grid-2">
               <div>
-                <label>Vaistas</label>
+                <label for="drug_type">Vaistas</label>
                 <select id="drug_type">
                   <option value="tnk">
                     Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
@@ -581,21 +595,21 @@
             </div>
             <div class="grid-2 mt-10">
               <div>
-                <label>Bendra dozė (mg)</label>
+                <label for="dose_total">Bendra dozė (mg)</label>
                 <input id="dose_total" type="number" step="0.1" readonly />
               </div>
               <div>
-                <label>Tūris (ml)</label>
+                <label for="dose_volume">Tūris (ml)</label>
                 <input id="dose_volume" type="number" step="0.1" readonly />
               </div>
             </div>
             <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
               <div>
-                <label>Bolius 10% (mg / ml)</label>
+                <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
                 <input id="tpa_bolus" type="text" readonly />
               </div>
               <div>
-                <label>Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
                 <input id="tpa_infusion" type="text" readonly />
               </div>
             </div>
@@ -821,7 +835,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
-    <button class="btn ghost" data-now="d_time">Dabar</button>
+    <button type="button" class="btn ghost" data-now="d_time" aria-label="Dabar">🕒</button>
   </div>
 </div>
             </fieldset>

--- a/js/app.js
+++ b/js/app.js
@@ -53,6 +53,14 @@ function bind() {
     b.addEventListener('click', () => setNow(b.getAttribute('data-now'))),
   );
 
+  // Date picker buttons
+  $$('button[data-picker]').forEach((b) =>
+    b.addEventListener('click', () => {
+      const target = document.getElementById(b.getAttribute('data-picker'));
+      target?.showPicker?.();
+    }),
+  );
+
   // Drug defaults
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>
     el.addEventListener('input', updateDrugDefaults),

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -11,7 +11,14 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
-    <button class="btn ghost" data-now="{{ id }}">Dabar</button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-now="{{ id }}"
+      aria-label="Dabar"
+    >
+      🕒
+    </button>
   </div>
 </div>
 {% endmacro %}

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -14,7 +14,21 @@
                 </div>
                 <div>
                   <label for="a_dob">Gimimo data</label>
-                  <input id="a_dob" type="date" placeholder="YYYY-MM-DD" />
+                  <div class="input-group">
+                    <input
+                      id="a_dob"
+                      type="date"
+                      placeholder="YYYY-MM-DD"
+                    />
+                    <button
+                      type="button"
+                      class="btn ghost"
+                      data-picker="a_dob"
+                      aria-label="Pasirinkti datą"
+                    >
+                      📅
+                    </button>
+                  </div>
                   <div id="a_age_display" class="subtle"></div>
                   <input id="a_age" type="hidden" />
                 </div>

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -28,7 +28,7 @@
 
             <fieldset>
               <legend>Simptomai</legend>
-              <textarea id="arrival_symptoms" rows="3"></textarea>
+              <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 
             <fieldset>

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -74,7 +74,7 @@
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div class="grid-2">
               <div>
-                <label>Vaistas</label>
+                <label for="drug_type">Vaistas</label>
                 <select id="drug_type">
                   <option value="tnk">
                     Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
@@ -97,21 +97,21 @@
             </div>
             <div class="grid-2 mt-10">
               <div>
-                <label>Bendra dozė (mg)</label>
+                <label for="dose_total">Bendra dozė (mg)</label>
                 <input id="dose_total" type="number" step="0.1" readonly />
               </div>
               <div>
-                <label>Tūris (ml)</label>
+                <label for="dose_volume">Tūris (ml)</label>
                 <input id="dose_volume" type="number" step="0.1" readonly />
               </div>
             </div>
             <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
               <div>
-                <label>Bolius 10% (mg / ml)</label>
+                <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
                 <input id="tpa_bolus" type="text" readonly />
               </div>
               <div>
-                <label>Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
                 <input id="tpa_infusion" type="text" readonly />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Replace textual "Dabar" buttons with clock icons on datetime inputs
- Add calendar picker button for birth date and handler to open native picker
- Improve input-group button styling and label key form controls for accessibility

## Testing
- `npm test` *(fails: localStorage handles multiple records – Cannot read properties of undefined (reading 'data'))*

------
https://chatgpt.com/codex/tasks/task_e_68a5b6baa3688320b5ffcdf307e78ed2