### PR TITLE
Auto-select conservative decision when contraindications present

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@ import { showToast } from './toast.js';
 import { confirmModal, promptModal } from './modal.js';
 import { updateAge } from './age.js';
 import { initArrival } from './arrival.js';
+import { autoSetContraDecision } from './decision.js';
 import {
   saveLS,
   loadLS,
@@ -137,6 +138,19 @@ function bind() {
   };
   lkwOptions.forEach((o) => o.addEventListener('change', updateLKW));
   updateLKW();
+
+  // Auto decision when contraindications or unknown onset time
+  const updateDecision = () =>
+    autoSetContraDecision({
+      lkwTypeInputs: inputs.lkw_type,
+      arrivalContraInputs: inputs.arrival_contra || [],
+      decisionInputs: inputs.d_decision || [],
+    });
+  inputs.lkw_type.forEach((o) => o.addEventListener('change', updateDecision));
+  (inputs.arrival_contra || []).forEach((c) =>
+    c.addEventListener('change', updateDecision),
+  );
+  updateDecision();
 
   // Save/Load/Export/Import
   const saveStatus = document.getElementById('saveStatus');

--- a/js/decision.js
+++ b/js/decision.js
@@ -1,0 +1,18 @@
+export function autoSetContraDecision({
+  lkwTypeInputs = [],
+  arrivalContraInputs = [],
+  decisionInputs = [],
+} = {}) {
+  const val =
+    'Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika';
+  const decision = decisionInputs.find((d) => d.value === val);
+  if (!decision) return;
+  const lkwUnknown = lkwTypeInputs.find((o) => o.checked)?.value === 'unknown';
+  const hasContra = arrivalContraInputs.some((c) => c.checked);
+  if (lkwUnknown || hasContra) {
+    if (!decision.checked) {
+      decision.checked = true;
+      decision.dispatchEvent(new Event('change'));
+    }
+  }
+}

--- a/test/decision.test.js
+++ b/test/decision.test.js
@@ -1,0 +1,53 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { autoSetContraDecision } from '../js/decision.js';
+
+test('selects contraindicated decision when contraindication checked', () => {
+  const dom = new JSDOM(
+    `<!doctype html><input type="radio" name="lkw_type" value="known" checked><input type="radio" name="lkw_type" value="unknown"><input type="checkbox" name="arrival_contra"><input type="radio" name="d_decision" value="Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika"><input type="radio" name="d_decision" value="other">`,
+  );
+  const { document, Event } = dom.window;
+  global.Event = Event;
+  const lkw = Array.from(document.querySelectorAll('input[name="lkw_type"]'));
+  const contra = Array.from(
+    document.querySelectorAll('input[name="arrival_contra"]'),
+  );
+  const decision = Array.from(
+    document.querySelectorAll('input[name="d_decision"]'),
+  );
+  autoSetContraDecision({
+    lkwTypeInputs: lkw,
+    arrivalContraInputs: contra,
+    decisionInputs: decision,
+  });
+  assert.equal(decision[0].checked, false);
+  contra[0].checked = true;
+  autoSetContraDecision({
+    lkwTypeInputs: lkw,
+    arrivalContraInputs: contra,
+    decisionInputs: decision,
+  });
+  assert.equal(decision[0].checked, true);
+});
+
+test('selects contraindicated decision when onset unknown', () => {
+  const dom = new JSDOM(
+    `<!doctype html><input type="radio" name="lkw_type" value="known"><input type="radio" name="lkw_type" value="unknown" checked><input type="checkbox" name="arrival_contra"><input type="radio" name="d_decision" value="Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika"><input type="radio" name="d_decision" value="other">`,
+  );
+  const { document, Event } = dom.window;
+  global.Event = Event;
+  const lkw = Array.from(document.querySelectorAll('input[name="lkw_type"]'));
+  const contra = Array.from(
+    document.querySelectorAll('input[name="arrival_contra"]'),
+  );
+  const decision = Array.from(
+    document.querySelectorAll('input[name="d_decision"]'),
+  );
+  autoSetContraDecision({
+    lkwTypeInputs: lkw,
+    arrivalContraInputs: contra,
+    decisionInputs: decision,
+  });
+  assert.equal(decision[0].checked, true);
+});


### PR DESCRIPTION
## Summary
- auto-select "Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktiką" when onset is unknown or any thrombolysis contraindication is checked
- expose `autoSetContraDecision` helper and wire it into app initialization
- test auto-selection for contraindications and unknown onset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c567c4508320aa43fb0b59aa0f79