### PR TITLE
Reset radio selections on new patient action

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -301,7 +301,7 @@ function bind() {
   $('#newPatientBtn').addEventListener('click', async () => {
     if (await confirmModal('Išvalyti visus laukus naujam pacientui?')) {
       document.querySelectorAll('input, textarea, select').forEach((el) => {
-        if (el.type === 'checkbox') el.checked = false;
+        if (el.type === 'checkbox' || el.type === 'radio') el.checked = false;
         else if (
           el.id !== 'def_tnk' &&
           el.id !== 'def_tpa' &&


### PR DESCRIPTION
## Summary
- Ensure "Naujas pacientas" clears radio button selections in addition to other fields

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c8680c088320ae1edd9bfe168769