### PR TITLE
Fix mobile grid layout on small screens

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -580,6 +580,8 @@ select.invalid {
   }
   .layout-main {
     grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    grid-auto-columns: 1fr;
   }
   nav {
     position: fixed;


### PR DESCRIPTION
## Summary
- ensure main content uses full width on narrow viewports by stacking grid rows vertically

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68a5ff92367c8320bb39a6cfc80eb81c