### PR TITLE
Prevent nav panel from scrolling when switching sections

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -293,7 +293,7 @@ function bind() {
       e.preventDefault();
       const id = tab.dataset.section;
       showSection(id);
-      if (id) location.hash = id;
+      if (id) history.pushState(null, '', `#${id}`);
     });
     tab.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
@@ -304,11 +304,12 @@ function bind() {
         const id = nextTab.dataset.section;
         nextTab.focus();
         showSection(id);
-        if (id) location.hash = id;
+        if (id) history.pushState(null, '', `#${id}`);
       }
     });
   });
   window.addEventListener('hashchange', activateFromHash);
+  window.addEventListener('popstate', activateFromHash);
 
   // New patient
   $('#newPatientBtn').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- use `history.pushState` to update URL hash without scrolling
- listen to `popstate` events so back/forward navigation activates sections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bea6ccd48320982e2e8d0a58d8cf