### PR TITLE
Include patient identity in summary output

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -5,6 +5,8 @@ export function collectSummaryData() {
   const inputs = dom.getInputs();
   const get = (el) => (el && el.value ? el.value : null);
   const patient = {
+    personal: get(inputs.a_personal),
+    name: get(inputs.a_name),
     dob: get(inputs.a_dob),
     weight: get(inputs.weight),
     bp: get(inputs.bp),
@@ -32,11 +34,11 @@ export function collectSummaryData() {
 export function summaryTemplate({ patient, times, drugs, decision }) {
   const parts = [];
   parts.push(
-    `PACIENTAS: gim. data: ${patient.dob ?? '—'}, svoris: ${
-      patient.weight ?? '—'
-    } kg, AKS atvykus: ${patient.bp ?? '—'}. NIHSS pradinis: ${
-      patient.nih0 ?? '—'
-    }.`,
+    `PACIENTAS: ${patient.name ?? '—'} (${patient.personal ?? '—'}), gim. data: ${
+      patient.dob ?? '—'
+    }, svoris: ${patient.weight ?? '—'} kg, AKS atvykus: ${
+      patient.bp ?? '—'
+    }. NIHSS pradinis: ${patient.nih0 ?? '—'}.`,
   );
   parts.push(
     `LAIKAI: LKW: ${times.lkw ?? '—'}, Atvykimas: ${times.door ?? '—'}, Sprendimas: ${

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -57,6 +57,8 @@ test('copySummary builds data object and copies formatted text', async () => {
   const inputs = getInputs();
   const { collectSummaryData, summaryTemplate, copySummary } = await import('../js/summary.js');
 
+  inputs.a_personal.value = '12345678901';
+  inputs.a_name.value = 'Jonas Jonaitis';
   inputs.a_dob.value = '1980-01-01';
   inputs.weight.value = '80';
   inputs.bp.value = '120/80';
@@ -78,7 +80,14 @@ test('copySummary builds data object and copies formatted text', async () => {
 
   const data = collectSummaryData();
   assert.deepEqual(data, {
-    patient: { dob: '1980-01-01', weight: '80', bp: '120/80', nih0: '10' },
+    patient: {
+      personal: '12345678901',
+      name: 'Jonas Jonaitis',
+      dob: '1980-01-01',
+      weight: '80',
+      bp: '120/80',
+      nih0: '10',
+    },
     times: {
       lkw: '2024-01-01T07:00',
       door: '2024-01-01T08:00',

--- a/test/genSummary.test.js
+++ b/test/genSummary.test.js
@@ -55,6 +55,8 @@ test('genSummary generates summary text correctly', async () => {
   const { genSummary } = await import('../js/summary.js');
 
   // populate typical inputs
+  inputs.a_personal.value = '12345678901';
+  inputs.a_name.value = 'Jonas Jonaitis';
   inputs.a_dob.value = '1980-01-01';
   inputs.weight.value = '80';
   inputs.bp.value = '120/80';
@@ -80,7 +82,7 @@ test('genSummary generates summary text correctly', async () => {
   const summary = inputs.summary.value;
   assert(
     summary.includes(
-      'PACIENTAS: gim. data: 1980-01-01, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10.',
+      'PACIENTAS: Jonas Jonaitis (12345678901), gim. data: 1980-01-01, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10.',
     ),
   );
   assert(


### PR DESCRIPTION
## Summary
- add patient name and personal code to collected summary data
- include identity info in generated summary string
- extend summary tests to cover patient identity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6cc9e40708320beb89e62f9c8e6f7