### PR TITLE
Handle boundary arrival times

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -8,10 +8,10 @@ export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
   if (!lkwValue || !doorValue) return '';
   const diff = (new Date(doorValue) - new Date(lkwValue)) / 36e5;
   if (!isFinite(diff)) return '';
-  if (diff < 4.5) {
+  if (diff <= 4.5) {
     return 'Indikuotina trombolizė / trombektomija.';
   }
-  if (diff < 9) {
+  if (diff <= 9) {
     return 'Reikalinga KT perfuzija.';
   }
   return 'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.';

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -16,11 +16,29 @@ test('within 4.5 hours', () => {
   assert.equal(msg, 'Indikuotina trombolizė / trombektomija.');
 });
 
+test('exactly 4.5 hours', () => {
+  const msg = computeArrivalMessage({
+    lkwType: 'known',
+    lkwValue: '2024-01-01T07:00',
+    doorValue: '2024-01-01T11:30',
+  });
+  assert.equal(msg, 'Indikuotina trombolizė / trombektomija.');
+});
+
 test('between 4.5 and 9 hours', () => {
   const msg = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T06:00',
     doorValue: '2024-01-01T12:00',
+  });
+  assert.equal(msg, 'Reikalinga KT perfuzija.');
+});
+
+test('exactly 9 hours', () => {
+  const msg = computeArrivalMessage({
+    lkwType: 'known',
+    lkwValue: '2024-01-01T07:00',
+    doorValue: '2024-01-01T16:00',
   });
   assert.equal(msg, 'Reikalinga KT perfuzija.');
 });


### PR DESCRIPTION
## Summary
- include 4.5h and 9h arrivals when determining arrival messages
- test computeArrivalMessage for 4.5 and 9 hour scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d0e97f248320a90565e7ab633e1a