### PR TITLE
Handle negative arrival time diff

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -7,7 +7,7 @@ export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
   }
   if (!lkwValue || !doorValue) return '';
   const diff = (new Date(doorValue) - new Date(lkwValue)) / 36e5;
-  if (!isFinite(diff)) return '';
+  if (!isFinite(diff) || diff < 0) return '';
   if (diff <= 4.5) {
     return 'Indikuotina trombolizė / trombektomija.';
   }

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -54,3 +54,12 @@ test('over 9 hours', () => {
     'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
   );
 });
+
+test('negative diff returns empty message', () => {
+  const msg = computeArrivalMessage({
+    lkwType: 'known',
+    lkwValue: '2024-01-01T10:00',
+    doorValue: '2024-01-01T09:00',
+  });
+  assert.equal(msg, '');
+});


### PR DESCRIPTION
## Summary
- return empty message when arrival time diff is negative
- test that negative diff yields empty message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d256f9a8832097787d4ea7424dcd