### PR TITLE
Handle arrival times beyond 24 hours

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -14,7 +14,10 @@ export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
   if (diff <= 9) {
     return 'Reikalinga KT perfuzija.';
   }
-  return 'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.';
+  if (diff <= 24) {
+    return 'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.';
+  }
+  return 'Reperfuzinis gydymas neindikuotinas.';
 }
 
 export function updateArrivalInfo() {

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -55,6 +55,15 @@ test('over 9 hours', () => {
   );
 });
 
+test('over 24 hours', () => {
+  const msg = computeArrivalMessage({
+    lkwType: 'known',
+    lkwValue: '2024-01-01T00:00',
+    doorValue: '2024-01-02T01:00',
+  });
+  assert.equal(msg, 'Reperfuzinis gydymas neindikuotinas.');
+});
+
 test('negative diff returns empty message', () => {
   const msg = computeArrivalMessage({
     lkwType: 'known',


### PR DESCRIPTION
## Summary
- indicate reperfusion therapy is not applicable when arrival time exceeds 24 hours after last known well
- test arrival message for over-24h differences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6d7b7a0bc8320923f48688978ce8b