### PR TITLE
Fix navigation text overflow

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -168,7 +168,8 @@ nav .tab {
   align-items: center;
   gap: 8px;
   width: 100%;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
   padding: 10px 12px;
   border: 1px solid var(--line);
   border-radius: 10px;
@@ -963,7 +964,6 @@ details summary::-webkit-details-marker {
 details .card {
   margin-top: 8px;
 }
-
 
 .nihss-layout {
   display: grid;


### PR DESCRIPTION
## Summary
- allow navigation tabs to wrap text and break long words to remove horizontal scrollbar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d8c2c1ec8320aa6e6c35e1a69889