### PR TITLE
Use local time for setNow

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -1,5 +1,6 @@
+const pad = (n) => String(n).padStart(2, '0');
+
 export function toLocalInputValue(d) {
-  const pad = (n) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
@@ -13,7 +14,7 @@ export function setNow(id) {
   if (!el) return;
   const now = new Date();
   if (el.type === 'time') {
-    el.value = now.toISOString().slice(11, 16);
+    el.value = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
   } else {
     el.value = toLocalInputValue(now);
   }

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -1,0 +1,38 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const el = {
+  type: 'time',
+  value: '',
+  dispatched: [],
+  dispatchEvent(evt) {
+    this.dispatched.push(evt.type);
+  },
+};
+
+global.document = {
+  getElementById: () => el,
+};
+
+test('setNow sets local HH:MM and triggers change', async () => {
+  const RealDate = Date;
+  const fixed = new RealDate('2024-01-02T03:04:05');
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) return new RealDate(fixed);
+      return new RealDate(...args);
+    }
+    static now() {
+      return fixed.getTime();
+    }
+  };
+
+  const { setNow } = await import('../js/time.js');
+
+  setNow('time-input');
+
+  assert.equal(el.value, '03:04');
+  assert.deepEqual(el.dispatched, ['input', 'change']);
+
+  global.Date = RealDate;
+});


### PR DESCRIPTION
## Summary
- Format time inputs using local hours and minutes instead of UTC
- Add unit test to ensure setNow fires input and change events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6df07a4ac8320855529f52af1234b