### PR TITLE
Add picker button to time inputs and adjust styles

### DIFF
--- a/build.js
+++ b/build.js
@@ -15,6 +15,7 @@ function timeInput(id, wrapperId = '', wrapperClass = 'row') {
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
+    <button type="button" class="btn ghost" data-picker="${id}" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="${id}" aria-label="Dabar">🕒</button>
   </div>
 </div>`;

--- a/css/style.css
+++ b/css/style.css
@@ -240,7 +240,7 @@ select {
 
 input[type='date'],
 input[type='datetime-local'] {
-  padding-right: 2.5rem;
+  padding-right: 5rem;
 }
 
 input[type='text']:focus-visible,
@@ -268,11 +268,18 @@ textarea {
 
 .input-group button {
   position: absolute;
-  right: 8px;
   top: 50%;
   transform: translateY(-50%);
   min-width: 2.5rem;
   padding: 4px 6px;
+}
+
+.input-group button:last-of-type {
+  right: 8px;
+}
+
+.input-group button:nth-last-of-type(2) {
+  right: calc(2.5rem + 16px);
 }
 
 input[type='date']::-webkit-calendar-picker-indicator,
@@ -290,6 +297,7 @@ input[type='datetime-local']::-webkit-calendar-picker-indicator:hover {
 .time-input {
   width: 100%;
   padding: 9px 10px;
+  padding-right: 5rem;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: #0f1620;

--- a/index.html
+++ b/index.html
@@ -234,6 +234,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
+    <button type="button" class="btn ghost" data-picker="t_door" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_door" aria-label="Dabar">🕒</button>
   </div>
 </div>
@@ -263,6 +264,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
+    <button type="button" class="btn ghost" data-picker="t_lkw" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_lkw" aria-label="Dabar">🕒</button>
   </div>
 </div>
@@ -796,6 +798,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
+    <button type="button" class="btn ghost" data-picker="t_thrombolysis" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_thrombolysis" aria-label="Dabar">🕒</button>
   </div>
 </div>
@@ -1010,6 +1013,7 @@
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
     />
+    <button type="button" class="btn ghost" data-picker="d_time" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="d_time" aria-label="Dabar">🕒</button>
   </div>
 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -109,12 +109,17 @@ function bind() {
         const entry = document.createElement('div');
         entry.className = 'bp-entry mt-10';
         const id = `bp_time_${Date.now()}`;
-        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-now="${id}">Dabar</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
         entry
           .querySelector(`[data-now="${id}"]`)
           .addEventListener('click', () => setNow(id));
+        entry
+          .querySelector(`[data-picker="${id}"]`)
+          .addEventListener('click', () =>
+            document.getElementById(id)?.showPicker(),
+          );
       });
     });
   }

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -14,6 +14,14 @@
     <button
       type="button"
       class="btn ghost"
+      data-picker="{{ id }}"
+      aria-label="Pasirinkti datą ir laiką"
+    >
+      📅
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
       data-now="{{ id }}"
       aria-label="Dabar"
     >


### PR DESCRIPTION
## Summary
- Add calendar picker button to time inputs via `data-picker` attribute
- Update CSS to position two control buttons and expand padding
- Include picker button in dynamic time entries and compile updated markup

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6dff197848320b6b7fa4af6e2bddb