### PR TITLE
Add +/-5 minute controls to time inputs

### DIFF
--- a/build.js
+++ b/build.js
@@ -17,6 +17,8 @@ function timeInput(id, wrapperId = '', wrapperClass = 'row') {
     />
     <button type="button" class="btn ghost" data-picker="${id}" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="${id}" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button>
   </div>
 </div>`;
 }

--- a/index.html
+++ b/index.html
@@ -236,6 +236,8 @@
     />
     <button type="button" class="btn ghost" data-picker="t_door" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_door" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="t_door" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="t_door" aria-label="+5 min">+5</button>
   </div>
 </div>
             </fieldset>
@@ -266,6 +268,8 @@
     />
     <button type="button" class="btn ghost" data-picker="t_lkw" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_lkw" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="t_lkw" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="t_lkw" aria-label="+5 min">+5</button>
   </div>
 </div>
             </fieldset>
@@ -800,6 +804,8 @@
     />
     <button type="button" class="btn ghost" data-picker="t_thrombolysis" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="t_thrombolysis" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="t_thrombolysis" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="t_thrombolysis" aria-label="+5 min">+5</button>
   </div>
 </div>
             </div>
@@ -1015,6 +1021,8 @@
     />
     <button type="button" class="btn ghost" data-picker="d_time" aria-label="Pasirinkti datą ir laiką">📅</button>
     <button type="button" class="btn ghost" data-now="d_time" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="d_time" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="d_time" aria-label="+5 min">+5</button>
   </div>
 </div>
             </fieldset>

--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,22 @@ function bind() {
     }),
   );
 
+  // Step up/down buttons
+  $$('button[data-stepup]').forEach((b) =>
+    b.addEventListener('click', () => {
+      const target = document.getElementById(b.getAttribute('data-stepup'));
+      target?.stepUp(5);
+      target?.dispatchEvent(new Event('input'));
+    }),
+  );
+  $$('button[data-stepdown]').forEach((b) =>
+    b.addEventListener('click', () => {
+      const target = document.getElementById(b.getAttribute('data-stepdown'));
+      target?.stepDown(5);
+      target?.dispatchEvent(new Event('input'));
+    }),
+  );
+
   // Drug defaults and automatic calculator
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>
     el.addEventListener('input', () => {
@@ -109,7 +125,7 @@ function bind() {
         const entry = document.createElement('div');
         entry.className = 'bp-entry mt-10';
         const id = `bp_time_${Date.now()}`;
-        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
         entry
@@ -118,8 +134,22 @@ function bind() {
         entry
           .querySelector(`[data-picker="${id}"]`)
           .addEventListener('click', () =>
-            document.getElementById(id)?.showPicker(),
+            document.getElementById(id)?.showPicker?.(),
           );
+        entry
+          .querySelector(`[data-stepup="${id}"]`)
+          .addEventListener('click', () => {
+            const target = document.getElementById(id);
+            target?.stepUp(5);
+            target?.dispatchEvent(new Event('input'));
+          });
+        entry
+          .querySelector(`[data-stepdown="${id}"]`)
+          .addEventListener('click', () => {
+            const target = document.getElementById(id);
+            target?.stepDown(5);
+            target?.dispatchEvent(new Event('input'));
+          });
       });
     });
   }

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -27,6 +27,22 @@
     >
       🕒
     </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepdown="{{ id }}"
+      aria-label="−5 min"
+    >
+      −5
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepup="{{ id }}"
+      aria-label="+5 min"
+    >
+      +5
+    </button>
   </div>
 </div>
 {% endmacro %}


### PR DESCRIPTION
## Summary
- add −5/+5 controls beside time inputs
- support step buttons for dynamically-added time fields
- handle click events for data-stepup and data-stepdown

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e1c403b48320b918440c0f8bc40d