### PR TITLE
Use nth-of-type for time picker buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -240,7 +240,7 @@ select {
 
 input[type='date'],
 input[type='datetime-local'] {
-  padding-right: 5rem;
+  padding-right: calc(10rem + 32px);
 }
 
 input[type='text']:focus-visible,
@@ -282,6 +282,14 @@ textarea {
   right: calc(2.5rem + 16px);
 }
 
+.input-group button:nth-of-type(2) {
+  right: calc(5rem + 24px);
+}
+
+.input-group button:nth-of-type(1) {
+  right: calc(7.5rem + 32px);
+}
+
 input[type='date']::-webkit-calendar-picker-indicator,
 input[type='datetime-local']::-webkit-calendar-picker-indicator {
   filter: invert(1);
@@ -297,7 +305,7 @@ input[type='datetime-local']::-webkit-calendar-picker-indicator:hover {
 .time-input {
   width: 100%;
   padding: 9px 10px;
-  padding-right: 5rem;
+  padding-right: calc(10rem + 32px);
   border: 1px solid var(--line);
   border-radius: 10px;
   background: #0f1620;


### PR DESCRIPTION
## Summary
- position calendar and now buttons with nth-of-type selectors
- widen padding on date inputs to accommodate four-button controls

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb274458832090c975878b42055b