### PR TITLE
Add time-input class to time fields to avoid overlap

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,6 +11,7 @@ function timeInput(id, wrapperId = '', wrapperClass = 'row') {
   <div class="input-group">
     <input
       id="${id}"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"

--- a/index.html
+++ b/index.html
@@ -230,6 +230,7 @@
   <div class="input-group">
     <input
       id="t_door"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
@@ -262,6 +263,7 @@
   <div class="input-group">
     <input
       id="t_lkw"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
@@ -798,6 +800,7 @@
   <div class="input-group">
     <input
       id="t_thrombolysis"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"
@@ -1015,6 +1018,7 @@
   <div class="input-group">
     <input
       id="d_time"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -7,6 +7,7 @@
   <div class="input-group">
     <input
       id="{{ id }}"
+      class="time-input"
       type="datetime-local"
       placeholder="YYYY-MM-DD HH:MM"
       step="60"


### PR DESCRIPTION
## Summary
- Add `.time-input` class to datetime fields so text no longer overlaps picker buttons
- Update build script and built HTML to include the new class

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7041428688320bd5e7c0ca7b080ff