### PR TITLE
Reorder NIHSS tab and style contraindication lists as buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,11 +63,11 @@
   <a href="#arrival" data-section="arrival" class="tab"
     ><span class="tab-icon">🚑</span>Paciento atvykimas</a
   >
-  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
-    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
-  >
   <a href="#nihss" data-section="nihss" class="tab"
     ><span class="tab-icon">🧮</span>NIHSS</a
+  >
+  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
   >
   <a href="#decision" data-section="decision" class="tab"
     ><span class="tab-icon">☑️</span>Sprendimas</a
@@ -288,7 +288,7 @@
                 <summary>Kontraindikacijos trombolizei</summary>
                 <ul class="contra-list">
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -299,7 +299,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -310,7 +310,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -320,7 +320,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -330,7 +330,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -340,7 +340,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -350,7 +350,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -360,7 +360,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -370,7 +370,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -380,7 +380,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -390,7 +390,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -400,7 +400,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -410,7 +410,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -420,7 +420,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -431,7 +431,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -441,7 +441,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -451,7 +451,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -461,7 +461,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -471,7 +471,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -482,7 +482,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -492,7 +492,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -507,7 +507,7 @@
                 <summary>Kontraindikacijos trombektomijai</summary>
                 <ul class="contra-list">
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -520,7 +520,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -532,7 +532,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -542,7 +542,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -553,7 +553,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -563,7 +563,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -573,7 +573,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -583,7 +583,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -594,7 +594,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -606,7 +606,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -619,7 +619,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -629,7 +629,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -639,7 +639,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -649,7 +649,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -661,156 +661,6 @@
                   </li>
                 </ul>
               </details>
-            </div>
-          </form>
-        </section>
-
-
-              <!-- Pasiruošimas trombolizei -->
-        <section id="thrombolysis" class="card hidden">
-          <h2>Pasiruošimas trombolizei</h2>
-          <form>
-            <div class="grid-3">
-              <div>
-                <label for="p_weight">Svoris (kg)</label>
-                <input
-                  id="p_weight"
-                  type="number"
-                  min="1"
-                  max="300"
-                  step="0.1"
-                  placeholder="kg"
-                />
-              </div>
-              <div>
-                <label for="p_bp">AKS (mmHg)</label>
-                <input id="p_bp" type="text" placeholder="pvz. 178/92" />
-              </div>
-              <div>
-                <label for="p_inr">INR</label>
-                <input id="p_inr" type="number" step="0.1" />
-              </div>
-            </div>
-            <div class="mt-10">
-              <button type="button" id="bpCorrBtn" class="btn">
-                AKS korekcija
-              </button>
-              <div id="bpMedList" class="hidden mt-10">
-                <button
-                  type="button"
-                  class="btn bp-med"
-                  data-med="Labetololis"
-                  data-dose="10 mg"
-                >
-                  Labetololis
-                </button>
-                <button
-                  type="button"
-                  class="btn bp-med"
-                  data-med="Enalaprilis"
-                  data-dose="1.25 mg"
-                >
-                  Enalaprilis
-                </button>
-                <button
-                  type="button"
-                  class="btn bp-med"
-                  data-med="Metoprololis"
-                  data-dose="5 mg"
-                >
-                  Metoprololis
-                </button>
-                <button
-                  type="button"
-                  class="btn bp-med"
-                  data-med="Natrio nitroprusidas"
-                  data-dose="0.3 µg/kg/min"
-                >
-                  Natrio nitroprusidas
-                </button>
-                <button
-                  type="button"
-                  class="btn bp-med"
-                  data-med="Kita"
-                  data-dose=""
-                >
-                  Kita
-                </button>
-              </div>
-              <div id="bpEntries" class="mt-10"></div>
-            </div>
-            <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
-            <div class="grid-2">
-              <div>
-                <label for="drug_type">Vaistas</label>
-                <select id="drug_type">
-                  <option value="tnk">
-                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
-                  </option>
-                  <option value="tpa">
-                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
-                    per 60 min
-                  </option>
-                </select>
-              </div>
-              <div>
-                <label>Koncentracija (mg/ml)</label>
-                <input
-                  id="drug_conc"
-                  type="number"
-                  step="0.01"
-                  placeholder="pvz. 5"
-                />
-              </div>
-            </div>
-            <div class="grid-2 mt-10">
-              <div>
-                <label for="dose_total">Bendra dozė (mg)</label>
-                <input id="dose_total" type="number" step="0.1" readonly />
-              </div>
-              <div>
-                <label for="dose_volume">Tūris (ml)</label>
-                <input id="dose_volume" type="number" step="0.1" readonly />
-              </div>
-            </div>
-            <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
-              <div>
-                <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
-                <input id="tpa_bolus" type="text" readonly />
-              </div>
-              <div>
-                <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
-                <input id="tpa_infusion" type="text" readonly />
-              </div>
-            </div>
-            <div class="section-actions mt-10">
-              <span class="mini"
-                >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši
-                skaičiuoklė – pagalbinė.</span
-              >
-            </div>
-            <div class="section-actions mt-10">
-              <button type="button" id="startThrombolysis" class="btn">
-                Pradėta trombolizė
-              </button>
-            </div>
-            <div id="thrombolysisStartRow" class="mt-10 hidden">
-              <label for="t_thrombolysis">Trombolizė pradėta</label>
-              <div class="row">
-  <div class="input-group">
-    <input
-      id="t_thrombolysis"
-      class="time-input"
-      type="datetime-local"
-      placeholder="YYYY-MM-DD HH:MM"
-      step="60"
-    />
-    <button type="button" class="btn ghost" data-picker="t_thrombolysis" aria-label="Pasirinkti datą ir laiką">📅</button>
-    <button type="button" class="btn ghost" data-now="t_thrombolysis" aria-label="Dabar">🕒</button>
-    <button type="button" class="btn ghost" data-stepdown="t_thrombolysis" aria-label="−5 min">−5</button>
-    <button type="button" class="btn ghost" data-stepup="t_thrombolysis" aria-label="+5 min">+5</button>
-  </div>
-</div>
             </div>
           </form>
         </section>
@@ -1003,6 +853,156 @@
                 </div>
               </div>
             </fieldset>
+          </form>
+        </section>
+
+
+              <!-- Pasiruošimas trombolizei -->
+        <section id="thrombolysis" class="card hidden">
+          <h2>Pasiruošimas trombolizei</h2>
+          <form>
+            <div class="grid-3">
+              <div>
+                <label for="p_weight">Svoris (kg)</label>
+                <input
+                  id="p_weight"
+                  type="number"
+                  min="1"
+                  max="300"
+                  step="0.1"
+                  placeholder="kg"
+                />
+              </div>
+              <div>
+                <label for="p_bp">AKS (mmHg)</label>
+                <input id="p_bp" type="text" placeholder="pvz. 178/92" />
+              </div>
+              <div>
+                <label for="p_inr">INR</label>
+                <input id="p_inr" type="number" step="0.1" />
+              </div>
+            </div>
+            <div class="mt-10">
+              <button type="button" id="bpCorrBtn" class="btn">
+                AKS korekcija
+              </button>
+              <div id="bpMedList" class="hidden mt-10">
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Labetololis"
+                  data-dose="10 mg"
+                >
+                  Labetololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Enalaprilis"
+                  data-dose="1.25 mg"
+                >
+                  Enalaprilis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Metoprololis"
+                  data-dose="5 mg"
+                >
+                  Metoprololis
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Natrio nitroprusidas"
+                  data-dose="0.3 µg/kg/min"
+                >
+                  Natrio nitroprusidas
+                </button>
+                <button
+                  type="button"
+                  class="btn bp-med"
+                  data-med="Kita"
+                  data-dose=""
+                >
+                  Kita
+                </button>
+              </div>
+              <div id="bpEntries" class="mt-10"></div>
+            </div>
+            <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
+            <div class="grid-2">
+              <div>
+                <label for="drug_type">Vaistas</label>
+                <select id="drug_type">
+                  <option value="tnk">
+                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                  </option>
+                  <option value="tpa">
+                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                    per 60 min
+                  </option>
+                </select>
+              </div>
+              <div>
+                <label>Koncentracija (mg/ml)</label>
+                <input
+                  id="drug_conc"
+                  type="number"
+                  step="0.01"
+                  placeholder="pvz. 5"
+                />
+              </div>
+            </div>
+            <div class="grid-2 mt-10">
+              <div>
+                <label for="dose_total">Bendra dozė (mg)</label>
+                <input id="dose_total" type="number" step="0.1" readonly />
+              </div>
+              <div>
+                <label for="dose_volume">Tūris (ml)</label>
+                <input id="dose_volume" type="number" step="0.1" readonly />
+              </div>
+            </div>
+            <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
+              <div>
+                <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
+                <input id="tpa_bolus" type="text" readonly />
+              </div>
+              <div>
+                <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                <input id="tpa_infusion" type="text" readonly />
+              </div>
+            </div>
+            <div class="section-actions mt-10">
+              <span class="mini"
+                >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši
+                skaičiuoklė – pagalbinė.</span
+              >
+            </div>
+            <div class="section-actions mt-10">
+              <button type="button" id="startThrombolysis" class="btn">
+                Pradėta trombolizė
+              </button>
+            </div>
+            <div id="thrombolysisStartRow" class="mt-10 hidden">
+              <label for="t_thrombolysis">Trombolizė pradėta</label>
+              <div class="row">
+  <div class="input-group">
+    <input
+      id="t_thrombolysis"
+      class="time-input"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button type="button" class="btn ghost" data-picker="t_thrombolysis" aria-label="Pasirinkti datą ir laiką">📅</button>
+    <button type="button" class="btn ghost" data-now="t_thrombolysis" aria-label="Dabar">🕒</button>
+    <button type="button" class="btn ghost" data-stepdown="t_thrombolysis" aria-label="−5 min">−5</button>
+    <button type="button" class="btn ghost" data-stepup="t_thrombolysis" aria-label="+5 min">+5</button>
+  </div>
+</div>
+            </div>
           </form>
         </section>
 

--- a/templates/index.njk
+++ b/templates/index.njk
@@ -10,8 +10,8 @@
     <main class="px-0">
       {% include "sections/activation.njk" %}
       {% include "sections/arrival.njk" %}
-      {% include "sections/thrombolysis.njk" %}
       {% include "sections/nihss.njk" %}
+      {% include "sections/thrombolysis.njk" %}
       {% include "sections/decision.njk" %}
       {% include "sections/summary.njk" %}
       {% include "partials/settings.njk" %}

--- a/templates/partials/nav.njk
+++ b/templates/partials/nav.njk
@@ -5,11 +5,11 @@
   <a href="#arrival" data-section="arrival" class="tab"
     ><span class="tab-icon">🚑</span>Paciento atvykimas</a
   >
-  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
-    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
-  >
   <a href="#nihss" data-section="nihss" class="tab"
     ><span class="tab-icon">🧮</span>NIHSS</a
+  >
+  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+    ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
   >
   <a href="#decision" data-section="decision" class="tab"
     ><span class="tab-icon">☑️</span>Sprendimas</a

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -38,7 +38,7 @@
                 <summary>Kontraindikacijos trombolizei</summary>
                 <ul class="contra-list">
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -49,7 +49,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -60,7 +60,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -70,7 +70,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -80,7 +80,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -90,7 +90,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -100,7 +100,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -110,7 +110,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -120,7 +120,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -130,7 +130,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -140,7 +140,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -150,7 +150,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -160,7 +160,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -170,7 +170,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -181,7 +181,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -191,7 +191,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -201,7 +201,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -211,7 +211,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -221,7 +221,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -232,7 +232,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -242,7 +242,7 @@
                   </label>
                 </li>
                 <li>
-                  <label>
+                  <label class="pill">
                     <input
                       type="checkbox"
                       name="arrival_contra"
@@ -257,7 +257,7 @@
                 <summary>Kontraindikacijos trombektomijai</summary>
                 <ul class="contra-list">
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -270,7 +270,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -282,7 +282,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -292,7 +292,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -303,7 +303,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -313,7 +313,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -323,7 +323,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -333,7 +333,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -344,7 +344,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -356,7 +356,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -369,7 +369,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -379,7 +379,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -389,7 +389,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"
@@ -399,7 +399,7 @@
                     </label>
                   </li>
                   <li>
-                    <label>
+                    <label class="pill">
                       <input
                         type="checkbox"
                         name="arrival_mt_contra"


### PR DESCRIPTION
## Summary
- move NIHSS navigation tab before trombolysis and adjust section order
- display thrombolysis and thrombectomy contraindications as pill-style buttons

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7092599088320bd86007c13ab3359