### PR TITLE
Add vital sign validation on activation page

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -1,0 +1,63 @@
+import * as dom from './state.js';
+
+function setValidity(el, valid, message) {
+  if (!el) return valid;
+  if (valid) {
+    el.classList.remove('invalid');
+    el.setCustomValidity?.('');
+  } else {
+    el.classList.add('invalid');
+    el.setCustomValidity?.(message);
+  }
+  return valid;
+}
+
+function parseLocaleFloat(str) {
+  return parseFloat(str.replace(',', '.'));
+}
+
+export function validateGlucose(el) {
+  const v = parseLocaleFloat(el.value || '');
+  const ok = !el.value || (Number.isFinite(v) && v >= 2.8 && v <= 22);
+  return setValidity(el, ok, 'Gliukozė turi būti 2.8–22 mmol/l.');
+}
+
+export function validateAks(el) {
+  const val = (el.value || '').trim();
+  const match = val.match(/^\d{2,3}\s*\/\s*\d{2,3}$/);
+  return setValidity(el, !val || !!match, 'AKS įveskite formatu "120/80".');
+}
+
+export function validateHr(el) {
+  const v = parseInt(el.value, 10);
+  const ok = !el.value || (Number.isFinite(v) && v >= 30 && v <= 250);
+  return setValidity(el, ok, 'ŠSD turi būti 30–250.');
+}
+
+export function validateSpo2(el) {
+  const v = parseInt(el.value, 10);
+  const ok = !el.value || (Number.isFinite(v) && v >= 50 && v <= 100);
+  return setValidity(el, ok, 'SpO₂ turi būti 50–100.');
+}
+
+export function validateTemp(el) {
+  const v = parseLocaleFloat(el.value || '');
+  const ok = !el.value || (Number.isFinite(v) && v >= 30 && v <= 43);
+  return setValidity(el, ok, 'Temperatūra turi būti 30–43 °C.');
+}
+
+export function initActivation() {
+  const handlers = [
+    [dom.getAGlucoseInput(), validateGlucose],
+    [dom.getAAksInput(), validateAks],
+    [dom.getAHrInput(), validateHr],
+    [dom.getASpo2Input(), validateSpo2],
+    [dom.getATempInput(), validateTemp],
+  ];
+  handlers.forEach(([el, fn]) => {
+    if (!el) return;
+    const cb = () => fn(el);
+    el.addEventListener('input', cb);
+    fn(el);
+  });
+}

--- a/js/app.js
+++ b/js/app.js
@@ -6,6 +6,7 @@ import { showToast } from './toast.js';
 import { confirmModal, promptModal } from './modal.js';
 import { updateAge } from './age.js';
 import { initArrival } from './arrival.js';
+import { initActivation } from './activation.js';
 import { autoSetContraDecision } from './decision.js';
 import {
   saveLS,
@@ -396,6 +397,7 @@ function bind() {
   initNIHSS();
   updateDrugDefaults();
   updateAge();
+  initActivation();
   initArrival();
   updateDraftSelect();
   // Apply initial section visibility only after successful setup

--- a/test/activationValidation.test.js
+++ b/test/activationValidation.test.js
@@ -1,0 +1,86 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+function createEl() {
+  return {
+    value: '',
+    classList: {
+      classes: new Set(),
+      add(c) {
+        this.classes.add(c);
+      },
+      remove(c) {
+        this.classes.delete(c);
+      },
+      contains(c) {
+        return this.classes.has(c);
+      },
+    },
+    setCustomValidity: () => {},
+  };
+}
+
+async function loadModule() {
+  global.document = {
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+  };
+  return import('../js/activation.js');
+}
+
+test('validateGlucose enforces 2.8-22 range', async () => {
+  const { validateGlucose } = await loadModule();
+  const el = createEl();
+  el.value = '1';
+  validateGlucose(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '5';
+  validateGlucose(el);
+  assert(!el.classList.contains('invalid'));
+});
+
+test('validateAks requires systolic/diastolic format', async () => {
+  const { validateAks } = await loadModule();
+  const el = createEl();
+  el.value = '120';
+  validateAks(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '120/80';
+  validateAks(el);
+  assert(!el.classList.contains('invalid'));
+});
+
+test('validateHr checks 30-250 bpm', async () => {
+  const { validateHr } = await loadModule();
+  const el = createEl();
+  el.value = '10';
+  validateHr(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '70';
+  validateHr(el);
+  assert(!el.classList.contains('invalid'));
+});
+
+test('validateSpo2 checks 50-100%', async () => {
+  const { validateSpo2 } = await loadModule();
+  const el = createEl();
+  el.value = '30';
+  validateSpo2(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '98';
+  validateSpo2(el);
+  assert(!el.classList.contains('invalid'));
+});
+
+test('validateTemp checks 30-43°C', async () => {
+  const { validateTemp } = await loadModule();
+  const el = createEl();
+  el.value = '25';
+  validateTemp(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '37';
+  validateTemp(el);
+  assert(!el.classList.contains('invalid'));
+});
+


### PR DESCRIPTION
## Summary
- validate glucose, blood pressure, heart rate, SpO₂ and temperature inputs on activation
- initialize vital sign validation during app setup
- test vital sign validators

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a70afa0af48320be18d5b1680a84a9