### PR TITLE
Add collapsible buttons for contraindication sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -964,6 +964,18 @@ details summary {
 details summary::-webkit-details-marker {
   display: none;
 }
+details summary.btn.toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+details summary.btn.toggle .icon {
+  transition: transform 0.2s;
+  display: inline-block;
+}
+details[open] summary.btn.toggle .icon {
+  transform: rotate(90deg);
+}
 details .card {
   margin-top: 8px;
 }

--- a/index.html
+++ b/index.html
@@ -285,7 +285,7 @@
 
             <div class="grid-2 mt-10">
               <details>
-                <summary>Kontraindikacijos trombolizei</summary>
+                <summary class="btn toggle"><span class="icon">▶</span>Kontraindikacijos trombolizei</summary>
                 <ul class="contra-list">
                 <li>
                   <label class="pill">
@@ -504,7 +504,7 @@
                 </ul>
               </details>
               <details>
-                <summary>Kontraindikacijos trombektomijai</summary>
+                <summary class="btn toggle"><span class="icon">▶</span>Kontraindikacijos trombektomijai</summary>
                 <ul class="contra-list">
                   <li>
                     <label class="pill">

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -35,7 +35,7 @@
 
             <div class="grid-2 mt-10">
               <details>
-                <summary>Kontraindikacijos trombolizei</summary>
+                <summary class="btn toggle"><span class="icon">▶</span>Kontraindikacijos trombolizei</summary>
                 <ul class="contra-list">
                 <li>
                   <label class="pill">
@@ -254,7 +254,7 @@
                 </ul>
               </details>
               <details>
-                <summary>Kontraindikacijos trombektomijai</summary>
+                <summary class="btn toggle"><span class="icon">▶</span>Kontraindikacijos trombektomijai</summary>
                 <ul class="contra-list">
                   <li>
                     <label class="pill">


### PR DESCRIPTION
## Summary
- make "Kontraindikacijos trombolizei" and "Kontraindikacijos trombektomijai" sections collapsible buttons with chevron icons
- add CSS to rotate chevron when open for visual feedback

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a70e4cccfc8320a4630ae93c240bfb