### PR TITLE
Update activation symptoms

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,23 +123,24 @@
                   paralyžius</label
                 >
                 <label class="pill"
-                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
-                  silpnumas</label
-                >
-                <label class="pill"
                   ><input id="a_speech" name="a_speech" type="checkbox" />Kalbos
                   sutrikimas</label
                 >
                 <label class="pill"
-                  ><input id="a_balance" name="a_balance" type="checkbox" />Pusiausvyros
-                  sutrikimas</label
+                  ><input id="a_commands" name="a_commands" type="checkbox" />Paliepimų
+                  nevykdo</label
                 >
                 <label class="pill"
-                  ><input
-                    id="a_conscious"
-                    name="a_conscious"
-                    type="checkbox"
-                  />Sąmonės/kvėpavimo sutrikimas</label
+                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_leg" name="a_leg" type="checkbox" />Kojos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_gaze" name="a_gaze" type="checkbox" />Žvilgsnis
+                  fiksuotas ar nukrypęs</label
                 >
               </div>
             </fieldset>

--- a/js/state.js
+++ b/js/state.js
@@ -37,10 +37,11 @@ export const getANameInput = () => $('#a_name');
 export const getADobInput = () => $('#a_dob');
 export const getAAgeInput = () => $('#a_age');
 export const getASymFaceInputs = () => $$('input[name="a_face"]');
-export const getASymArmInputs = () => $$('input[name="a_arm"]');
 export const getASymSpeechInputs = () => $$('input[name="a_speech"]');
-export const getASymBalanceInputs = () => $$('input[name="a_balance"]');
-export const getASymConsciousInputs = () => $$('input[name="a_conscious"]');
+export const getASymCommandsInputs = () => $$('input[name="a_commands"]');
+export const getASymArmInputs = () => $$('input[name="a_arm"]');
+export const getASymLegInputs = () => $$('input[name="a_leg"]');
+export const getASymGazeInputs = () => $$('input[name="a_gaze"]');
 export const getAWarfarinInput = () => $('#a_warfarin');
 export const getAApixabanInput = () => $('#a_apixaban');
 export const getARivaroxabanInput = () => $('#a_rivaroxaban');
@@ -86,10 +87,11 @@ export function getInputs() {
     a_dob: getADobInput(),
     a_age: getAAgeInput(),
     a_sym_face: getASymFaceInputs(),
-    a_sym_arm: getASymArmInputs(),
     a_sym_speech: getASymSpeechInputs(),
-    a_sym_balance: getASymBalanceInputs(),
-    a_sym_conscious: getASymConsciousInputs(),
+    a_sym_commands: getASymCommandsInputs(),
+    a_sym_arm: getASymArmInputs(),
+    a_sym_leg: getASymLegInputs(),
+    a_sym_gaze: getASymGazeInputs(),
     a_warfarin: getAWarfarinInput(),
     a_apixaban: getAApixabanInput(),
     a_rivaroxaban: getARivaroxabanInput(),

--- a/js/storage.js
+++ b/js/storage.js
@@ -85,10 +85,11 @@ export function getPayload() {
     a_dob: inputs.a_dob?.value || '',
     a_age: inputs.a_age?.value || '',
     a_sym_face: getRadioValue(inputs.a_sym_face || []),
-    a_sym_arm: getRadioValue(inputs.a_sym_arm || []),
     a_sym_speech: getRadioValue(inputs.a_sym_speech || []),
-    a_sym_balance: getRadioValue(inputs.a_sym_balance || []),
-    a_sym_conscious: getRadioValue(inputs.a_sym_conscious || []),
+    a_sym_commands: getRadioValue(inputs.a_sym_commands || []),
+    a_sym_arm: getRadioValue(inputs.a_sym_arm || []),
+    a_sym_leg: getRadioValue(inputs.a_sym_leg || []),
+    a_sym_gaze: getRadioValue(inputs.a_sym_gaze || []),
     a_drug_warfarin: inputs.a_warfarin?.checked || false,
     a_drug_apixaban: inputs.a_apixaban?.checked || false,
     a_drug_rivaroxaban: inputs.a_rivaroxaban?.checked || false,
@@ -145,14 +146,16 @@ export function setPayload(p) {
   updateAge();
   if (inputs.a_sym_face)
     setRadioValue(inputs.a_sym_face, payload.a_sym_face || '');
-  if (inputs.a_sym_arm)
-    setRadioValue(inputs.a_sym_arm, payload.a_sym_arm || '');
   if (inputs.a_sym_speech)
     setRadioValue(inputs.a_sym_speech, payload.a_sym_speech || '');
-  if (inputs.a_sym_balance)
-    setRadioValue(inputs.a_sym_balance, payload.a_sym_balance || '');
-  if (inputs.a_sym_conscious)
-    setRadioValue(inputs.a_sym_conscious, payload.a_sym_conscious || '');
+  if (inputs.a_sym_commands)
+    setRadioValue(inputs.a_sym_commands, payload.a_sym_commands || '');
+  if (inputs.a_sym_arm)
+    setRadioValue(inputs.a_sym_arm, payload.a_sym_arm || '');
+  if (inputs.a_sym_leg)
+    setRadioValue(inputs.a_sym_leg, payload.a_sym_leg || '');
+  if (inputs.a_sym_gaze)
+    setRadioValue(inputs.a_sym_gaze, payload.a_sym_gaze || '');
   if (inputs.a_warfarin) inputs.a_warfarin.checked = !!payload.a_drug_warfarin;
   if (inputs.a_apixaban) inputs.a_apixaban.checked = !!payload.a_drug_apixaban;
   if (inputs.a_rivaroxaban)

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -43,23 +43,24 @@
                   paralyžius</label
                 >
                 <label class="pill"
-                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
-                  silpnumas</label
-                >
-                <label class="pill"
                   ><input id="a_speech" name="a_speech" type="checkbox" />Kalbos
                   sutrikimas</label
                 >
                 <label class="pill"
-                  ><input id="a_balance" name="a_balance" type="checkbox" />Pusiausvyros
-                  sutrikimas</label
+                  ><input id="a_commands" name="a_commands" type="checkbox" />Paliepimų
+                  nevykdo</label
                 >
                 <label class="pill"
-                  ><input
-                    id="a_conscious"
-                    name="a_conscious"
-                    type="checkbox"
-                  />Sąmonės/kvėpavimo sutrikimas</label
+                  ><input id="a_arm" name="a_arm" type="checkbox" />Rankos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_leg" name="a_leg" type="checkbox" />Kojos
+                  silpnumas</label
+                >
+                <label class="pill"
+                  ><input id="a_gaze" name="a_gaze" type="checkbox" />Žvilgsnis
+                  fiksuotas ar nukrypęs</label
                 >
               </div>
             </fieldset>


### PR DESCRIPTION
## Summary
- Replace activation symptom checklist with six-item list: face paralysis, speech disorder, command inability, arm weakness, leg weakness, and fixed/deviated gaze
- Adjust state helpers to expose new symptom inputs
- Extend storage to save and restore the updated symptom flags

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a721aa6c9c8320b01e1d38f0a7ec4d