### PR TITLE
Add patient management and selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
       </div>
     </div>
     <div class="header-actions">
+      <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
       <button id="newPatientBtn" title="Naujas pacientas" class="btn">🆕 <span class="btn-label">Naujas</span></button>
       <button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn">💾 <span class="btn-label">Išsaugoti</span></button>
       <details class="more-actions">

--- a/js/app.js
+++ b/js/app.js
@@ -18,6 +18,7 @@ import {
   updateDraftSelect,
   getDrafts,
 } from './storage.js';
+import { addPatient, switchPatient } from './patients.js';
 
 function initNIHSS() {
   $$('.nihss-calc').forEach((calc) => {
@@ -42,6 +43,28 @@ function initNIHSS() {
 function bind() {
   const inputs = getInputs();
   let dirty = false;
+  const patientSelect = $('#patientSelect');
+  const patientIds = [];
+
+  const updatePatientSelect = (selectedId) => {
+    if (!patientSelect) return;
+    patientSelect.innerHTML = '';
+    patientIds.forEach((id, idx) => {
+      const opt = document.createElement('option');
+      opt.value = id;
+      opt.textContent = `Pacientas ${idx + 1}`;
+      patientSelect.appendChild(opt);
+    });
+    if (selectedId) patientSelect.value = selectedId;
+  };
+
+  patientSelect?.addEventListener('change', () => {
+    switchPatient(patientSelect.value);
+  });
+
+  const firstId = addPatient();
+  patientIds.push(firstId);
+  updatePatientSelect(firstId);
   const header = document.querySelector('header');
   const setHeaderHeight = () =>
     document.documentElement.style.setProperty(
@@ -348,25 +371,10 @@ function bind() {
   window.addEventListener('popstate', activateFromHash);
 
   // New patient
-  $('#newPatientBtn').addEventListener('click', async () => {
-    if (await confirmModal('Išvalyti visus laukus naujam pacientui?')) {
-      document.querySelectorAll('input, textarea, select').forEach((el) => {
-        if (el.type === 'checkbox' || el.type === 'radio') {
-          el.checked = false;
-          el.removeAttribute('checked');
-          el.closest('.pill')?.classList.remove('checked');
-        } else if (
-          el.id !== 'def_tnk' &&
-          el.id !== 'def_tpa' &&
-          el.id !== 'autosave'
-        )
-          el.value = '';
-        el.classList.remove('invalid');
-        if (el.setCustomValidity) el.setCustomValidity('');
-      });
-      updateDrugDefaults();
-      $('#summary').value = '';
-    }
+  $('#newPatientBtn').addEventListener('click', () => {
+    const id = addPatient();
+    patientIds.push(id);
+    updatePatientSelect(id);
   });
 
   // Autosave

--- a/js/patients.js
+++ b/js/patients.js
@@ -1,0 +1,47 @@
+import { getPayload, setPayload } from './storage.js';
+
+const patients = {};
+let activeId = null;
+let counter = 1;
+
+function generateId() {
+  return `p${counter++}`;
+}
+
+export function addPatient() {
+  const current = getPayload();
+  if (activeId) patients[activeId] = current;
+  const id = generateId();
+  patients[id] = { ...current };
+  activeId = id;
+  setPayload(patients[id]);
+  return id;
+}
+
+export function switchPatient(id) {
+  if (!patients[id]) return;
+  if (activeId) patients[activeId] = getPayload();
+  activeId = id;
+  setPayload(patients[id]);
+}
+
+export function removePatient(id) {
+  if (!patients[id]) return;
+  delete patients[id];
+  if (activeId === id) {
+    const nextId = Object.keys(patients)[0];
+    activeId = nextId || null;
+    if (nextId) setPayload(patients[nextId]);
+  }
+}
+
+export function getActivePatient() {
+  return activeId;
+}
+
+export default {
+  addPatient,
+  switchPatient,
+  removePatient,
+  getActivePatient,
+};


### PR DESCRIPTION
## Summary
- Add patients.js module to handle multiple patient records
- Introduce patient selector dropdown and integrate switching in app.js
- Replace form clearing with patient duplication on new patient action

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a72b8a4c14832095225e88de4c18bf