### PR TITLE
Refactor summary generation to use patient payload

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1,7 +1,7 @@
 import { $, $$, state, getInputs } from './state.js';
 import { setNow } from './time.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
-import { genSummary, copySummary } from './summary.js';
+import { collectSummaryData, summaryTemplate, copySummary } from './summary.js';
 import { showToast } from './toast.js';
 import { confirmModal, promptModal } from './modal.js';
 import { updateAge } from './age.js';
@@ -20,7 +20,7 @@ import {
   getActivePatientId,
   setActivePatientId,
 } from './storage.js';
-import { addPatient, switchPatient } from './patients.js';
+import { addPatient, switchPatient, getActivePatient } from './patients.js';
 
 function initNIHSS() {
   $$('.nihss-calc').forEach((calc) => {
@@ -128,8 +128,21 @@ function bind() {
   });
 
   // Summary
-  $('#summary').addEventListener('focus', genSummary);
-  $('#copySummaryBtn').addEventListener('click', copySummary);
+  $('#summary').addEventListener('focus', () => {
+    const patient = getActivePatient();
+    if (!patient) return;
+    const data = collectSummaryData(patient);
+    const text = summaryTemplate(data);
+    inputs.summary.value = text;
+    patient.summary = text;
+  });
+  $('#copySummaryBtn').addEventListener('click', () => {
+    const patient = getActivePatient();
+    if (!patient) return;
+    const data = collectSummaryData(patient);
+    const text = copySummary(data);
+    patient.summary = text;
+  });
 
   // Age calculation
   inputs.a_dob.addEventListener('input', updateAge);
@@ -341,7 +354,15 @@ function bind() {
       t.setAttribute('aria-selected', selected ? 'true' : 'false');
       t.setAttribute('tabindex', selected ? '0' : '-1');
     });
-    if (id === 'summarySec') genSummary();
+    if (id === 'summarySec') {
+      const patient = getActivePatient();
+      if (patient) {
+        const data = collectSummaryData(patient);
+        const text = summaryTemplate(data);
+        inputs.summary.value = text;
+        patient.summary = text;
+      }
+    }
     if (id === 'decision' && inputs.d_time && !inputs.d_time.value)
       setNow('d_time');
     document.body.classList.remove('nav-open');
@@ -394,7 +415,15 @@ function bind() {
       updateSaveStatus();
       dirty = false;
     }
-    if (!$('#summarySec').classList.contains('hidden')) genSummary();
+    if (!$('#summarySec').classList.contains('hidden')) {
+      const patient = getActivePatient();
+      if (patient) {
+        const data = collectSummaryData(patient);
+        const text = summaryTemplate(data);
+        inputs.summary.value = text;
+        patient.summary = text;
+      }
+    }
   });
   document.addEventListener('change', () => {
     dirty = true;

--- a/js/patients.js
+++ b/js/patients.js
@@ -1,4 +1,5 @@
 import { getPayload, setPayload } from './storage.js';
+import { getInputs } from './state.js';
 
 const patients = {};
 let activeId = null;
@@ -9,20 +10,28 @@ function generateId() {
 }
 
 export function addPatient() {
-  const current = getPayload();
+  const inputs = getInputs();
+  const current = { ...getPayload(), summary: inputs.summary?.value || '' };
   if (activeId) patients[activeId] = current;
   const id = generateId();
-  patients[id] = { ...current };
+  patients[id] = { ...current, summary: '' };
   activeId = id;
   setPayload(patients[id]);
+  if (inputs.summary) inputs.summary.value = '';
   return id;
 }
 
 export function switchPatient(id) {
   if (!patients[id]) return;
-  if (activeId) patients[activeId] = getPayload();
+  const inputs = getInputs();
+  if (activeId)
+    patients[activeId] = {
+      ...getPayload(),
+      summary: inputs.summary?.value || '',
+    };
   activeId = id;
   setPayload(patients[id]);
+  if (inputs.summary) inputs.summary.value = patients[id].summary || '';
 }
 
 export function removePatient(id) {
@@ -31,12 +40,16 @@ export function removePatient(id) {
   if (activeId === id) {
     const nextId = Object.keys(patients)[0];
     activeId = nextId || null;
-    if (nextId) setPayload(patients[nextId]);
+    if (nextId) {
+      setPayload(patients[nextId]);
+      const inputs = getInputs();
+      if (inputs.summary) inputs.summary.value = patients[nextId].summary || '';
+    }
   }
 }
 
 export function getActivePatient() {
-  return activeId;
+  return patients[activeId];
 }
 
 export default {

--- a/js/storage.js
+++ b/js/storage.js
@@ -80,6 +80,7 @@ export function getPayload() {
     dose_volume: inputs.doseVol?.value || '',
     tpa_bolus: inputs.tpaBolus?.value || '',
     tpa_infusion: inputs.tpaInf?.value || '',
+    t_thrombolysis: inputs.t_thrombolysis?.value || '',
     arrival_lkw_type: getRadioValue(inputs.lkw_type || []),
     arrival_symptoms: inputs.arrival_symptoms?.value || '',
     arrival_contra: (inputs.arrival_contra || [])
@@ -137,6 +138,8 @@ export function setPayload(p) {
   if (inputs.doseVol) inputs.doseVol.value = payload.dose_volume || '';
   if (inputs.tpaBolus) inputs.tpaBolus.value = payload.tpa_bolus || '';
   if (inputs.tpaInf) inputs.tpaInf.value = payload.tpa_infusion || '';
+  if (inputs.t_thrombolysis)
+    inputs.t_thrombolysis.value = payload.t_thrombolysis || '';
   if (inputs.lkw_type)
     setRadioValue(inputs.lkw_type, payload.arrival_lkw_type || 'known');
   if (inputs.arrival_symptoms)

--- a/js/summary.js
+++ b/js/summary.js
@@ -1,33 +1,31 @@
 import * as dom from './state.js';
 import { showToast } from './toast.js';
 
-export function collectSummaryData() {
-  const inputs = dom.getInputs();
-  const get = (el) => (el && el.value ? el.value : null);
+export function collectSummaryData(payload) {
+  const get = (v) => (v ? v : null);
   const patient = {
-    personal: get(inputs.a_personal),
-    name: get(inputs.a_name),
-    dob: get(inputs.a_dob),
-    weight: get(inputs.weight),
-    bp: get(inputs.bp),
-    nih0: get(inputs.nih0),
+    personal: get(payload.a_personal),
+    name: get(payload.a_name),
+    dob: get(payload.a_dob),
+    weight: get(payload.p_weight),
+    bp: get(payload.p_bp),
+    nih0: get(payload.p_nihss0),
   };
   const times = {
-    lkw: get(inputs.lkw),
-    door: get(inputs.door),
-    decision: get(inputs.d_time),
-    thrombolysis: get(inputs.t_thrombolysis),
+    lkw: get(payload.t_lkw),
+    door: get(payload.t_door),
+    decision: get(payload.d_time),
+    thrombolysis: get(payload.t_thrombolysis),
   };
   const drugs = {
-    type: inputs.drugType?.value || '',
-    conc: get(inputs.drugConc),
-    totalDose: get(inputs.doseTotal),
-    totalVol: get(inputs.doseVol),
-    bolus: get(inputs.tpaBolus),
-    infusion: get(inputs.tpaInf),
+    type: payload.drug_type || '',
+    conc: get(payload.drug_conc),
+    totalDose: get(payload.dose_total),
+    totalVol: get(payload.dose_volume),
+    bolus: get(payload.tpa_bolus),
+    infusion: get(payload.tpa_infusion),
   };
-  const decision =
-    (inputs.d_decision || []).find((n) => n.checked)?.value || null;
+  const decision = payload.d_decision || null;
   return { patient, times, drugs, decision };
 }
 
@@ -59,16 +57,9 @@ export function summaryTemplate({ patient, times, drugs, decision }) {
   return parts.join('\n');
 }
 
-export function genSummary() {
+export function copySummary(data) {
   const inputs = dom.getInputs();
-  const data = collectSummaryData();
   if (inputs.summary) inputs.summary.value = summaryTemplate(data);
-  return data;
-}
-
-export function copySummary() {
-  const inputs = dom.getInputs();
-  genSummary();
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {
       showToast('Nepavyko nukopijuoti: ' + err, { type: 'error' });
@@ -78,4 +69,5 @@ export function copySummary() {
     const ok = document.execCommand('copy');
     if (!ok) showToast('Nepavyko nukopijuoti', { type: 'error' });
   }
+  return inputs.summary.value;
 }

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -55,7 +55,10 @@ test('copySummary builds data object and copies formatted text', async () => {
 
   const { getInputs } = await import('../js/state.js');
   const inputs = getInputs();
-  const { collectSummaryData, summaryTemplate, copySummary } = await import('../js/summary.js');
+  const { getPayload } = await import('../js/storage.js');
+  const { collectSummaryData, summaryTemplate, copySummary } = await import(
+    '../js/summary.js',
+  );
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';
@@ -78,7 +81,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
 
-  const data = collectSummaryData();
+  const data = collectSummaryData(getPayload());
   assert.deepEqual(data, {
     patient: {
       personal: '12345678901',
@@ -106,7 +109,8 @@ test('copySummary builds data object and copies formatted text', async () => {
   });
 
   const expected = summaryTemplate(data);
-  await copySummary();
+  const copied = copySummary(data);
   assert.equal(global.__copied, expected);
   assert.equal(inputs.summary.value, expected);
+  assert.equal(copied, expected);
 });

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -88,9 +88,10 @@ const {
   deletePatient,
   setPayload,
   getPatients,
+  getPayload,
 } = await import('../js/storage.js');
 inputs = getInputs();
-const { copySummary } = await import('../js/summary.js');
+const { copySummary, collectSummaryData } = await import('../js/summary.js');
 
 function resetInputs() {
   inputs = getInputs();
@@ -146,7 +147,7 @@ test(
     inputs.a_dob.value = '';
     setPayload(loadPatient('draft1'));
 
-    await copySummary();
+    await copySummary(collectSummaryData(getPayload()));
 
     assert.ok(global.__copied.includes('PACIENTAS'));
     assert.ok(global.__copied.includes('NIHSS pradinis: 5'));

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-test('genSummary generates summary text correctly', async () => {
+test('summaryTemplate generates summary text correctly', async () => {
   const elements = {};
   function createEl() {
     return {
@@ -52,9 +52,9 @@ test('genSummary generates summary text correctly', async () => {
 
   const { getInputs } = await import('../js/state.js');
   const inputs = getInputs();
-  const { genSummary } = await import('../js/summary.js');
+  const { getPayload } = await import('../js/storage.js');
+  const { collectSummaryData, summaryTemplate } = await import('../js/summary.js');
 
-  // populate typical inputs
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';
   inputs.a_dob.value = '1980-01-01';
@@ -77,9 +77,9 @@ test('genSummary generates summary text correctly', async () => {
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
 
-  genSummary();
+  const data = collectSummaryData(getPayload());
+  const summary = summaryTemplate(data);
 
-  const summary = inputs.summary.value;
   assert(
     summary.includes(
       'PACIENTAS: Jonas Jonaitis (12345678901), gim. data: 1980-01-01, svoris: 80 kg, AKS atvykus: 120/80. NIHSS pradinis: 10.',


### PR DESCRIPTION
## Summary
- build summaries from patient payload objects instead of DOM inputs
- generate and copy summaries via app.js using active patient data
- keep per-patient summary text for quick review when switching

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7376c7d748320b1b5e484736ad38b