### PR TITLE
Align content width with top bar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -131,8 +131,8 @@ h1 {
   margin-top: 0;
 }
 main {
-  width: 1200px;
-  margin: 12px auto;
+  width: 100%;
+  margin: 12px 0;
   padding: 0 16px;
 }
 
@@ -753,7 +753,6 @@ section[data-tab='Intervencijos'] h3 {
   gap: 8px;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
 }
-
 
 .symptoms {
   display: flex;


### PR DESCRIPTION
## Summary
- ensure main content width follows header width by letting grid column control its size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a788b791808320a0c653330acbba13