### PR TITLE
feat: add mobile nav toggle

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,9 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 
-function actionButton(id, title, icon, label, classes = '') {
+function actionButton(id, title, icon, label, classes = '', attrs = '') {
   const cls = classes ? `btn ${classes}` : 'btn';
-  return `<button id="${id}"${title ? ` title="${title}"` : ''} class="${cls}">${icon} <span class="btn-label">${label}</span></button>`;
+  const attr = attrs ? ` ${attrs}` : '';
+  return `<button id="${id}"${title ? ` title="${title}"` : ''} class="${cls}"${attr}>${icon} <span class="btn-label">${label}</span></button>`;
 }
 
 function timeInput(id, wrapperId = '', wrapperClass = 'row') {

--- a/css/style.css
+++ b/css/style.css
@@ -228,6 +228,31 @@ nav .tab:focus-visible {
 .tab-icon {
   width: 1.5rem;
 }
+
+@media (max-width: 768px) {
+  .layout-main {
+    display: block;
+  }
+  #navToggle {
+    display: inline-flex;
+    margin-bottom: 12px;
+  }
+  nav {
+    display: none;
+    position: fixed;
+    top: var(--header-height);
+    left: 0;
+    right: 0;
+    background: #152231;
+    padding: 12px;
+    z-index: 1000;
+    max-height: calc(100vh - var(--header-height));
+    overflow-y: auto;
+  }
+  body.nav-open nav {
+    display: block;
+  }
+}
 section.card {
   background: rgba(18, 26, 36, 0.6);
   backdrop-filter: blur(10px);

--- a/index.html
+++ b/index.html
@@ -41,8 +41,8 @@
 </header>
 
   <div class="wrap layout-main">
-    <button id="navToggle" class="btn">☰ <span class="btn-label">Meniu</span></button>
-    <nav>
+    <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
+    <nav id="mainNav">
   <a href="#activation" data-section="activation" class="tab active"
     ><span class="tab-icon">🚨</span>Aktyvacija</a
   >

--- a/js/app.js
+++ b/js/app.js
@@ -289,6 +289,7 @@ function bind() {
   // Navigation
   const tabs = $$('nav .tab');
   const sections = $$('main > section');
+  const navToggle = $('#navToggle');
   const showSection = (id) => {
     sections.forEach((s) => {
       const active = s.id === id;
@@ -314,13 +315,15 @@ function bind() {
     if (id === 'decision' && inputs.d_time && !inputs.d_time.value)
       setNow('d_time');
     document.body.classList.remove('nav-open');
+    navToggle.setAttribute('aria-expanded', 'false');
   };
   const activateFromHash = () => {
     const id = location.hash.slice(1) || tabs[0]?.dataset.section;
     if (id) showSection(id);
   };
-  $('#navToggle').addEventListener('click', () => {
-    document.body.classList.toggle('nav-open');
+  navToggle.addEventListener('click', () => {
+    const open = document.body.classList.toggle('nav-open');
+    navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
   });
   tabs.forEach((tab, index) => {
     tab.addEventListener('click', (e) => {

--- a/templates/index.njk
+++ b/templates/index.njk
@@ -5,7 +5,7 @@
   <div id="toastContainer" class="toast-container"></div>
   {% include "partials/header.njk" %}
   <div class="wrap layout-main">
-    {{ macros.actionButton('navToggle', '', '☰', 'Meniu') }}
+    {{ macros.actionButton('navToggle', '', '☰', 'Meniu', '', 'aria-expanded="false" aria-controls="mainNav"') }}
     {% include "partials/nav.njk" %}
     <main class="px-0">
       {% include "sections/activation.njk" %}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -1,5 +1,5 @@
-{% macro actionButton(id, title, icon, label, classes='') %}
-<button id="{{ id }}"{% if title %} title="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}">{{ icon }} <span class="btn-label">{{ label }}</span></button>
+{% macro actionButton(id, title, icon, label, classes='', attrs='') %}
+<button id="{{ id }}"{% if title %} title="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}" {{ attrs|safe }}>{{ icon }} <span class="btn-label">{{ label }}</span></button>
 {% endmacro %}
 
 {% macro timeInput(id, wrapperId='', wrapperClass='row') %}

--- a/templates/partials/nav.njk
+++ b/templates/partials/nav.njk
@@ -1,4 +1,4 @@
-<nav>
+<nav id="mainNav">
   <a href="#activation" data-section="activation" class="tab active"
     ><span class="tab-icon">🚨</span>Aktyvacija</a
   >


### PR DESCRIPTION
## Summary
- make nav menu collapsible with a menu button for small screens
- toggle navigation visibility and aria state via JavaScript
- adjust templates and build script for new nav markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8baa66bdc8320b35c377ce34eba9e