### PR TITLE
feat: compute sleep midpoint for arrival time

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,6 +328,104 @@
   </div>
 </div>
 
+              <div id="sleepTimeRow" class="grid-2 mt-4 hidden">
+                <div>
+                  <label for="t_sleep_start">Miego pradžia</label>
+                  
+<div class="">
+  <div class="input-group">
+    <input
+      id="t_sleep_start"
+      class="time-input"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button
+      type="button"
+      class="btn ghost"
+      data-picker="t_sleep_start"
+      aria-label="Pasirinkti datą ir laiką"
+    >
+      📅
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-now="t_sleep_start"
+      aria-label="Dabar"
+    >
+      🕒
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepdown="t_sleep_start"
+      aria-label="−5 min"
+    >
+      −5
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepup="t_sleep_start"
+      aria-label="+5 min"
+    >
+      +5
+    </button>
+  </div>
+</div>
+
+                </div>
+                <div>
+                  <label for="t_sleep_end">Miego pabaiga</label>
+                  
+<div class="">
+  <div class="input-group">
+    <input
+      id="t_sleep_end"
+      class="time-input"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button
+      type="button"
+      class="btn ghost"
+      data-picker="t_sleep_end"
+      aria-label="Pasirinkti datą ir laiką"
+    >
+      📅
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-now="t_sleep_end"
+      aria-label="Dabar"
+    >
+      🕒
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepdown="t_sleep_end"
+      aria-label="−5 min"
+    >
+      −5
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepup="t_sleep_end"
+      aria-label="+5 min"
+    >
+      +5
+    </button>
+  </div>
+</div>
+
+                </div>
+              </div>
             </fieldset>
 
             <div id="arrival_info" class="info-box mt-10"></div>

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,5 @@
 import { $, $$, getInputs } from './state.js';
-import { setNow } from './time.js';
+import { setNow, triggerChange, sleepMidpoint } from './time.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { collectSummaryData, summaryTemplate, copySummary } from './summary.js';
 import { showToast } from './toast.js';
@@ -211,13 +211,27 @@ function bind() {
   // LKW option handling
   const lkwOptions = inputs.lkw_type;
   const lkwRow = $('#lkwTimeRow');
+  const sleepRow = $('#sleepTimeRow');
+  const updateSleepMid = () => {
+    const val = sleepMidpoint(inputs.sleep_start.value, inputs.sleep_end.value);
+    inputs.lkw.value = val;
+    if (val) triggerChange(inputs.lkw);
+  };
+  inputs.sleep_start?.addEventListener('input', updateSleepMid);
+  inputs.sleep_end?.addEventListener('input', updateSleepMid);
   const updateLKW = () => {
     const val = lkwOptions.find((o) => o.checked)?.value;
     if (val === 'unknown') {
       lkwRow.classList.add('hidden');
+      sleepRow.classList.add('hidden');
       inputs.lkw.value = '';
+    } else if (val === 'sleep') {
+      lkwRow.classList.add('hidden');
+      sleepRow.classList.remove('hidden');
+      updateSleepMid();
     } else {
       lkwRow.classList.remove('hidden');
+      sleepRow.classList.add('hidden');
     }
   };
   lkwOptions.forEach((o) => o.addEventListener('change', updateLKW));

--- a/js/state.js
+++ b/js/state.js
@@ -16,6 +16,8 @@ export const getDoorInput = () => $('#t_door');
 export const getDTimeInput = () => $('#d_time');
 export const getDDecisionInputs = () => $$('input[name="d_decision"]');
 export const getLkwTypeInputs = () => $$('input[name="lkw_type"]');
+export const getSleepStartInput = () => $('#t_sleep_start');
+export const getSleepEndInput = () => $('#t_sleep_end');
 export const getArrivalSymptomsInput = () => $('#arrival_symptoms');
 export const getArrivalContraInputs = () => $$('input[name="arrival_contra"]');
 export const getArrivalMtContraInputs = () =>
@@ -63,6 +65,8 @@ export function getInputs() {
     inr: getInrInput(),
     nih0: getNih0Input(),
     lkw: getLkwInput(),
+    sleep_start: getSleepStartInput(),
+    sleep_end: getSleepEndInput(),
     door: getDoorInput(),
     d_time: getDTimeInput(),
     d_decision: getDDecisionInputs(),

--- a/js/storage.js
+++ b/js/storage.js
@@ -84,6 +84,8 @@ export function getPayload() {
     p_nihss0: inputs.nih0?.value || '',
     nihs_initial: inputs.nih0?.value || '',
     t_lkw: inputs.lkw?.value || '',
+    t_sleep_start: inputs.sleep_start?.value || '',
+    t_sleep_end: inputs.sleep_end?.value || '',
     t_door: inputs.door?.value || '',
     d_time: inputs.d_time?.value || '',
     d_decision: getRadioValue(inputs.d_decision || []),
@@ -143,6 +145,9 @@ export function setPayload(p) {
   if (inputs.nih0)
     inputs.nih0.value = payload.p_nihss0 || payload.nihs_initial || '';
   if (inputs.lkw) inputs.lkw.value = payload.t_lkw || '';
+  if (inputs.sleep_start)
+    inputs.sleep_start.value = payload.t_sleep_start || '';
+  if (inputs.sleep_end) inputs.sleep_end.value = payload.t_sleep_end || '';
   if (inputs.door) inputs.door.value = payload.t_door || '';
   if (inputs.d_time) inputs.d_time.value = payload.d_time || '';
   if (inputs.d_decision)

--- a/js/time.js
+++ b/js/time.js
@@ -20,3 +20,13 @@ export function setNow(id) {
   }
   triggerChange(el);
 }
+
+export function sleepMidpoint(start, end) {
+  if (!start || !end) return '';
+  const s = new Date(start);
+  let e = new Date(end);
+  if (isNaN(s) || isNaN(e)) return '';
+  if (e < s) e = new Date(e.getTime() + 864e5);
+  const mid = new Date((s.getTime() + e.getTime()) / 2);
+  return toLocalInputValue(mid);
+}

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -24,6 +24,16 @@
                 >
               </div>
               {{ timeInput('t_lkw', 'lkwTimeRow', 'row mt-4') }}
+              <div id="sleepTimeRow" class="grid-2 mt-4 hidden">
+                <div>
+                  <label for="t_sleep_start">Miego pradžia</label>
+                  {{ timeInput('t_sleep_start', '', '') }}
+                </div>
+                <div>
+                  <label for="t_sleep_end">Miego pabaiga</label>
+                  {{ timeInput('t_sleep_end', '', '') }}
+                </div>
+              </div>
             </fieldset>
 
             <div id="arrival_info" class="info-box mt-10"></div>

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -36,3 +36,10 @@ test('setNow sets local HH:MM and triggers change', async () => {
 
   global.Date = RealDate;
 });
+
+test('sleepMidpoint computes midpoint across midnight', async () => {
+  const { sleepMidpoint } = await import('../js/time.js');
+  const start = '2024-01-01T22:00';
+  const end = '2024-01-02T06:00';
+  assert.equal(sleepMidpoint(start, end), '2024-01-02T02:00');
+});


### PR DESCRIPTION
## Summary
- add sleep start/end inputs on arrival page and auto-calc midpoint
- persist sleep times in state and storage
- expose `sleepMidpoint` utility with tests

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68ac225b18c88320807262f30881a4cf