### PR TITLE
Add onset timer to patient arrival page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -781,6 +781,9 @@ section[data-tab='Intervencijos'] h3 {
   font-family: monospace;
   pointer-events: none;
   cursor: default;
+  font-size: 2rem;
+  text-align: center;
+  margin-top: 8px;
 }
 .grid-2,
 .grid-3 {

--- a/index.html
+++ b/index.html
@@ -217,6 +217,7 @@
               <!-- Paciento atvykimas -->
         <section id="arrival" class="card hidden">
           <h2>Paciento atvykimas</h2>
+          <div id="onset_timer" class="arrival-timer"></div>
           <form>
             <fieldset>
               <legend>Atvykimo laikas</legend>

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -1,6 +1,7 @@
         <!-- Paciento atvykimas -->
         <section id="arrival" class="card hidden">
           <h2>Paciento atvykimas</h2>
+          <div id="onset_timer" class="arrival-timer"></div>
           <form>
             <fieldset>
               <legend>Atvykimo laikas</legend>

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { computeArrivalMessage } from '../js/arrival.js';
+import { computeArrivalMessage, timeSince } from '../js/arrival.js';
 
 test('unknown last known well', () => {
   const msg = computeArrivalMessage({ lkwType: 'unknown' });
@@ -97,4 +97,13 @@ test('sleep midpoint older than 9h requires different message', () => {
     msg,
     'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
   );
+});
+
+test('timeSince formats difference', () => {
+  const fakeNow = new Date('2024-01-01T10:00:00').getTime();
+  const origNow = Date.now;
+  Date.now = () => fakeNow;
+  const res = timeSince('2024-01-01T07:05:04');
+  Date.now = origNow;
+  assert.equal(res, '02:54:56');
 });


### PR DESCRIPTION
## Summary
- add clock element to arrival section displaying elapsed time since symptom onset
- style arrival timer for clear visibility
- compute and update timer with tests for formatting

## Testing
- `npm test`
- `npm run build`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68ac45d9f06483208559a13049d17077