### PR TITLE
Show arrival and symptom onset timers in Paciento atvykimas

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,8 @@
               <!-- Paciento atvykimas -->
         <section id="arrival" class="card hidden">
           <h2>Paciento atvykimas</h2>
-          <div id="onset_timer" class="arrival-timer"></div>
+          <div class="arrival-timer">Nuo atvykimo: <span id="door_timer"></span></div>
+          <div class="arrival-timer">Nuo simptomų pradžios: <span id="onset_timer"></span></div>
           <form>
             <fieldset>
               <legend>Atvykimo laikas</legend>

--- a/js/arrival.js
+++ b/js/arrival.js
@@ -15,16 +15,24 @@ export function timeSince(onset) {
 }
 
 let timerId;
-function updateOnsetTimer() {
-  const timerEl = $('#onset_timer');
-  if (!timerEl) return;
+function updateTimers() {
+  const onsetEl = $('#onset_timer');
+  const doorEl = $('#door_timer');
   const lkwType = $$('input[name="lkw_type"]').find((r) => r.checked)?.value;
   const lkwValue = $('#t_lkw')?.value;
-  if (!lkwValue || lkwType === 'unknown') {
-    timerEl.textContent = '';
-    return;
+  const doorValue = $('#t_door')?.value;
+
+  if (doorEl) {
+    doorEl.textContent = doorValue ? timeSince(doorValue) : '';
   }
-  timerEl.textContent = timeSince(lkwValue);
+
+  if (onsetEl) {
+    if (!lkwValue || lkwType === 'unknown') {
+      onsetEl.textContent = '';
+    } else {
+      onsetEl.textContent = timeSince(lkwValue);
+    }
+  }
 }
 
 export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
@@ -69,7 +77,7 @@ export function updateArrivalInfo() {
 export function initArrival() {
   const updateAll = () => {
     updateArrivalInfo();
-    updateOnsetTimer();
+    updateTimers();
   };
   ['#t_lkw', '#t_door'].forEach((id) =>
     $(id)?.addEventListener('input', updateAll),
@@ -79,5 +87,5 @@ export function initArrival() {
   );
   updateAll();
   clearInterval(timerId);
-  timerId = setInterval(updateOnsetTimer, 1000);
+  timerId = setInterval(updateTimers, 1000);
 }

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -1,7 +1,8 @@
         <!-- Paciento atvykimas -->
         <section id="arrival" class="card hidden">
           <h2>Paciento atvykimas</h2>
-          <div id="onset_timer" class="arrival-timer"></div>
+          <div class="arrival-timer">Nuo atvykimo: <span id="door_timer"></span></div>
+          <div class="arrival-timer">Nuo simptomų pradžios: <span id="onset_timer"></span></div>
           <form>
             <fieldset>
               <legend>Atvykimo laikas</legend>


### PR DESCRIPTION
## Summary
- Display separate timers for time since arrival and since symptom onset in the Paciento atvykimas section
- Update timer logic to refresh both values every second

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac50a20e0083208f494c89dcfe3844