### PR TITLE
feat: add custom time picker

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1057,3 +1057,30 @@ details .card {
 .contra-list li {
   margin-bottom: 4px;
 }
+/* Time picker dialog */
+.time-picker-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.5);
+}
+.time-picker-dialog {
+  border: none;
+  padding: 20px;
+  background: var(--card);
+  color: var(--ink);
+  border-radius: 6px;
+}
+.time-picker-dialog .tp-time {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  margin-top: 8px;
+}
+.time-picker-dialog select,
+.time-picker-dialog input {
+  font-size: 1rem;
+}
+.time-picker-dialog .tp-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 12px;
+}

--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
                     <button
                       type="button"
                       class="btn ghost"
-                      data-picker="a_dob"
+                      data-time-picker="a_dob"
                       aria-label="Pasirinkti datą"
                     >
                       📅
@@ -234,7 +234,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="t_door"
+      data-time-picker="t_door"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅
@@ -297,7 +297,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="t_lkw"
+      data-time-picker="t_lkw"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅
@@ -345,7 +345,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="t_sleep_start"
+      data-time-picker="t_sleep_start"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅
@@ -393,7 +393,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="t_sleep_end"
+      data-time-picker="t_sleep_end"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅
@@ -1153,7 +1153,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="t_thrombolysis"
+      data-time-picker="t_thrombolysis"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅
@@ -1210,7 +1210,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="d_time"
+      data-time-picker="d_time"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,6 @@
 import { $, $$, getInputs } from './state.js';
 import { setNow, triggerChange, sleepMidpoint } from './time.js';
+import { openTimePicker } from './timePicker.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { collectSummaryData, summaryTemplate, copySummary } from './summary.js';
 import { showToast } from './toast.js';
@@ -79,10 +80,12 @@ function bind() {
   );
 
   // Date picker buttons
-  $$('button[data-picker]').forEach((b) =>
+  $$('button[data-time-picker]').forEach((b) =>
     b.addEventListener('click', () => {
-      const target = document.getElementById(b.getAttribute('data-picker'));
-      target?.showPicker?.();
+      const target = document.getElementById(
+        b.getAttribute('data-time-picker'),
+      );
+      openTimePicker(target);
     }),
   );
 
@@ -161,16 +164,16 @@ function bind() {
         const entry = document.createElement('div');
         entry.className = 'bp-entry mt-10';
         const id = `bp_time_${Date.now()}`;
-        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
+        entry.innerHTML = `<strong>${med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${now}" /><button class="btn ghost" data-time-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${dose}" /><input type="text" placeholder="Pastabos" /></div>`;
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
         entry
           .querySelector(`[data-now="${id}"]`)
           .addEventListener('click', () => setNow(id));
         entry
-          .querySelector(`[data-picker="${id}"]`)
+          .querySelector(`[data-time-picker="${id}"]`)
           .addEventListener('click', () =>
-            document.getElementById(id)?.showPicker?.(),
+            openTimePicker(document.getElementById(id)),
           );
         entry
           .querySelector(`[data-stepup="${id}"]`)

--- a/js/storage.js
+++ b/js/storage.js
@@ -2,6 +2,7 @@ import * as dom from './state.js';
 import { updateDrugDefaults } from './drugs.js';
 import { updateAge } from './age.js';
 import { setNow } from './time.js';
+import { openTimePicker } from './timePicker.js';
 
 const { state } = dom;
 
@@ -235,7 +236,7 @@ export function setPayload(p) {
         .slice(2, 7)}`;
       entry.innerHTML = `<strong>${m.med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${
         m.time || ''
-      }" /><button class="btn ghost" data-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${
+      }" /><button class="btn ghost" data-time-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${
         m.dose || ''
       }" /><input type="text" placeholder="Pastabos" value="${m.notes || ''}" /></div>`;
       bpContainer.appendChild(entry);
@@ -243,9 +244,9 @@ export function setPayload(p) {
         .querySelector(`[data-now="${id}"]`)
         ?.addEventListener('click', () => setNow(id));
       entry
-        .querySelector(`[data-picker="${id}"]`)
+        .querySelector(`[data-time-picker="${id}"]`)
         ?.addEventListener('click', () =>
-          document.getElementById(id)?.showPicker?.(),
+          openTimePicker(document.getElementById(id)),
         );
       entry
         .querySelector(`[data-stepup="${id}"]`)

--- a/js/timePicker.js
+++ b/js/timePicker.js
@@ -1,0 +1,93 @@
+export function openTimePicker(target) {
+  if (!target) return;
+  if (typeof document === 'undefined' || typeof window === 'undefined') {
+    target.showPicker?.();
+    return;
+  }
+  if (!('HTMLDialogElement' in window)) {
+    target.showPicker?.();
+    return;
+  }
+
+  const dialog = document.createElement('dialog');
+  dialog.className = 'time-picker-dialog';
+
+  const pad = (n) => n.toString().padStart(2, '0');
+  const now = new Date();
+  let datePart = now.toISOString().slice(0, 10);
+  let hour = pad(now.getHours());
+  let minute = pad(now.getMinutes());
+
+  if (target.value) {
+    if (target.type === 'time') {
+      const [h, m] = target.value.split(':');
+      if (h) hour = pad(h);
+      if (m) minute = pad(m);
+    } else {
+      const [d, t] = target.value.split('T');
+      if (d) datePart = d;
+      if (t) {
+        const [h, m] = t.split(':');
+        if (h) hour = pad(h);
+        if (m) minute = pad(m);
+      }
+    }
+  }
+
+  const hourOpts = Array.from({ length: 24 })
+    .map((_, i) => `<option value="${pad(i)}">${pad(i)}</option>`)
+    .join('');
+  const minuteOpts = Array.from({ length: 60 })
+    .map((_, i) => `<option value="${pad(i)}">${pad(i)}</option>`)
+    .join('');
+
+  dialog.innerHTML = `
+    <form method="dialog" class="tp-form">
+      ${
+        target.type === 'time'
+          ? ''
+          : `<input type="date" class="tp-date" value="${datePart}" />`
+      }
+      <div class="tp-time">
+        <select class="tp-hour">${hourOpts}</select>
+        <span>:</span>
+        <select class="tp-minute">${minuteOpts}</select>
+      </div>
+      <div class="tp-actions">
+        <button value="cancel" type="button">Atšaukti</button>
+        <button value="ok" type="submit">Gerai</button>
+      </div>
+    </form>`;
+
+  document.body.appendChild(dialog);
+  const hourSel = dialog.querySelector('.tp-hour');
+  const minuteSel = dialog.querySelector('.tp-minute');
+  hourSel.value = hour;
+  minuteSel.value = minute;
+  const dateInput = dialog.querySelector('.tp-date');
+
+  dialog.addEventListener('close', () => {
+    if (dialog.returnValue === 'ok') {
+      const h = hourSel.value;
+      const m = minuteSel.value;
+      let val = '';
+      if (target.type === 'time') {
+        val = `${h}:${m}`;
+      } else {
+        const d = dateInput?.value || datePart;
+        val = `${d}T${h}:${m}`;
+      }
+      target.value = val;
+      target.dispatchEvent(new Event('input', { bubbles: true }));
+      target.dispatchEvent(new Event('change', { bubbles: true }));
+    }
+    dialog.remove();
+  });
+
+  try {
+    dialog.showModal();
+  } catch (e) {
+    dialog.remove();
+    target.showPicker?.();
+  }
+}

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -15,7 +15,7 @@
     <button
       type="button"
       class="btn ghost"
-      data-picker="{{ id }}"
+      data-time-picker="{{ id }}"
       aria-label="Pasirinkti datą ir laiką"
     >
       📅

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -23,7 +23,7 @@
                     <button
                       type="button"
                       class="btn ghost"
-                      data-picker="a_dob"
+                      data-time-picker="a_dob"
                       aria-label="Pasirinkti datą"
                     >
                       📅


### PR DESCRIPTION
## Summary
- add dialog-based time picker with fallback to native picker
- wire 📅 buttons to custom picker and update templates
- style custom picker and ensure updates trigger change events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac50ca8b28832093b3b52b780fabc4