### PR TITLE
feat: add INR quick-set button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,7 +1033,17 @@
               </div>
               <div>
                 <label for="p_inr">INR</label>
-                <input id="p_inr" type="number" step="0.1" />
+                <div class="input-group">
+                  <input id="p_inr" type="number" step="0.1" />
+                  <button
+                    type="button"
+                    class="btn ghost"
+                    data-set="p_inr"
+                    data-val="1"
+                  >
+                    1,0
+                  </button>
+                </div>
               </div>
             </div>
             <div class="mt-10">

--- a/js/app.js
+++ b/js/app.js
@@ -105,6 +105,17 @@ function bind() {
     }),
   );
 
+  // Fast value buttons
+  $$('button[data-set]').forEach((b) =>
+    b.addEventListener('click', () => {
+      const target = document.getElementById(b.dataset.set);
+      if (target) {
+        target.value = b.dataset.val ?? '';
+        target.dispatchEvent(new Event('input'));
+      }
+    }),
+  );
+
   // Drug defaults and automatic calculator
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>
     el.addEventListener('input', () => {

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -20,7 +20,17 @@
               </div>
               <div>
                 <label for="p_inr">INR</label>
-                <input id="p_inr" type="number" step="0.1" />
+                <div class="input-group">
+                  <input id="p_inr" type="number" step="0.1" />
+                  <button
+                    type="button"
+                    class="btn ghost"
+                    data-set="p_inr"
+                    data-val="1"
+                  >
+                    1,0
+                  </button>
+                </div>
               </div>
             </div>
             <div class="mt-10">


### PR DESCRIPTION
## Summary
- add fast button to populate INR with 1.0
- support generic fast value buttons via data-set / data-val

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac56b89f208320aff86aa94864d55f