### PR TITLE
Add status-based arrival info box styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -763,6 +763,21 @@ section[data-tab='Intervencijos'] h3 {
   border-radius: 6px;
 }
 
+.info-box.success {
+  border-color: var(--green);
+  color: var(--green);
+}
+
+.info-box.warning {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.info-box.error {
+  border-color: var(--red);
+  color: var(--red);
+}
+
 .info-box:empty {
   display: none;
 }

--- a/js/arrival.js
+++ b/js/arrival.js
@@ -37,28 +37,41 @@ function updateTimers() {
 
 export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
   if (lkwType === 'unknown') {
-    return 'Pacientui reperfuzinis gydymas neindikuotinas.';
+    return {
+      message: 'Pacientui reperfuzinis gydymas neindikuotinas.',
+      type: 'error',
+    };
   }
-  if (!lkwValue) return '';
+  if (!lkwValue) return { message: '', type: '' };
   let diff;
   if (lkwType === 'sleep' && !doorValue) {
     diff = (Date.now() - new Date(lkwValue).getTime()) / 36e5;
   } else if (doorValue) {
     diff = (new Date(doorValue) - new Date(lkwValue)) / 36e5;
   } else {
-    return '';
+    return { message: '', type: '' };
   }
-  if (!isFinite(diff) || diff < 0) return '';
+  if (!isFinite(diff) || diff < 0) return { message: '', type: '' };
   if (diff <= 4.5) {
-    return 'Indikuotina trombolizė / trombektomija.';
+    return {
+      message: 'Indikuotina trombolizė / trombektomija.',
+      type: 'success',
+    };
   }
   if (diff < 9) {
-    return 'Reikalinga KT perfuzija.';
+    return { message: 'Reikalinga KT perfuzija.', type: 'warning' };
   }
   if (diff <= 24) {
-    return 'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.';
+    return {
+      message:
+        'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
+      type: 'warning',
+    };
   }
-  return 'Reperfuzinis gydymas neindikuotinas.';
+  return {
+    message: 'Reperfuzinis gydymas neindikuotinas.',
+    type: 'error',
+  };
 }
 
 export function updateArrivalInfo() {
@@ -67,11 +80,17 @@ export function updateArrivalInfo() {
   const lkwType = $$('input[name="lkw_type"]').find((r) => r.checked)?.value;
   const lkwValue = $('#t_lkw')?.value;
   const doorValue = $('#t_door')?.value;
-  infoEl.textContent = computeArrivalMessage({
+  const { message, type } = computeArrivalMessage({
     lkwType,
     lkwValue,
     doorValue,
   });
+  infoEl.textContent = '';
+  infoEl.classList.remove('success', 'warning', 'error');
+  if (message) {
+    infoEl.textContent = message;
+    if (type) infoEl.classList.add(type);
+  }
 }
 
 export function initArrival() {

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -3,100 +3,121 @@ import assert from 'node:assert/strict';
 import { computeArrivalMessage, timeSince } from '../js/arrival.js';
 
 test('unknown last known well', () => {
-  const msg = computeArrivalMessage({ lkwType: 'unknown' });
-  assert.equal(msg, 'Pacientui reperfuzinis gydymas neindikuotinas.');
+  const res = computeArrivalMessage({ lkwType: 'unknown' });
+  assert.deepEqual(res, {
+    message: 'Pacientui reperfuzinis gydymas neindikuotinas.',
+    type: 'error',
+  });
 });
 
 test('within 4.5 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T07:00',
     doorValue: '2024-01-01T10:00',
   });
-  assert.equal(msg, 'Indikuotina trombolizė / trombektomija.');
+  assert.deepEqual(res, {
+    message: 'Indikuotina trombolizė / trombektomija.',
+    type: 'success',
+  });
 });
 
 test('exactly 4.5 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T07:00',
     doorValue: '2024-01-01T11:30',
   });
-  assert.equal(msg, 'Indikuotina trombolizė / trombektomija.');
+  assert.deepEqual(res, {
+    message: 'Indikuotina trombolizė / trombektomija.',
+    type: 'success',
+  });
 });
 
 test('between 4.5 and 9 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T06:00',
     doorValue: '2024-01-01T12:00',
   });
-  assert.equal(msg, 'Reikalinga KT perfuzija.');
+  assert.deepEqual(res, {
+    message: 'Reikalinga KT perfuzija.',
+    type: 'warning',
+  });
 });
 
 test('exactly 9 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T07:00',
     doorValue: '2024-01-01T16:00',
   });
-  assert.equal(
-    msg,
-    'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
-  );
+  assert.deepEqual(res, {
+    message:
+      'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
+    type: 'warning',
+  });
 });
 
 test('over 9 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T00:00',
     doorValue: '2024-01-01T10:00',
   });
-  assert.equal(
-    msg,
-    'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
-  );
+  assert.deepEqual(res, {
+    message:
+      'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
+    type: 'warning',
+  });
 });
 
 test('over 24 hours', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T00:00',
     doorValue: '2024-01-02T01:00',
   });
-  assert.equal(msg, 'Reperfuzinis gydymas neindikuotinas.');
+  assert.deepEqual(res, {
+    message: 'Reperfuzinis gydymas neindikuotinas.',
+    type: 'error',
+  });
 });
 
 test('negative diff returns empty message', () => {
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T10:00',
     doorValue: '2024-01-01T09:00',
   });
-  assert.equal(msg, '');
+  assert.deepEqual(res, { message: '', type: '' });
 });
 
 test('sleep midpoint without door time uses current time', () => {
   const eightHoursAgo = new Date(Date.now() - 8 * 36e5).toISOString();
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'sleep',
     lkwValue: eightHoursAgo,
     doorValue: '',
   });
-  assert.equal(msg, 'Reikalinga KT perfuzija.');
+  assert.deepEqual(res, {
+    message: 'Reikalinga KT perfuzija.',
+    type: 'warning',
+  });
 });
 
 test('sleep midpoint older than 9h requires different message', () => {
   const tenHoursAgo = new Date(Date.now() - 10 * 36e5).toISOString();
-  const msg = computeArrivalMessage({
+  const res = computeArrivalMessage({
     lkwType: 'sleep',
     lkwValue: tenHoursAgo,
     doorValue: '',
   });
-  assert.equal(
-    msg,
-    'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
-  );
+  assert.deepEqual(res, {
+    message:
+      'Trombolizė kontraindikuotina, bet gali būti taikoma trombektomija.',
+    type: 'warning',
+  });
 });
 
 test('timeSince formats difference', () => {


### PR DESCRIPTION
## Summary
- style info boxes for success, warning, and error states using CSS variables
- have computeArrivalMessage return a message type and updateArrivalInfo apply matching classes
- adjust tests for new arrival message structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6fcef9008320ab4f7768d875bf1a