### PR TITLE
Add warning and info toast notifications

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -751,6 +751,14 @@ section[data-tab='Intervencijos'] h3 {
   background: var(--red);
   color: #fff;
 }
+.toast.warning {
+  background: var(--yellow);
+  color: var(--bg);
+}
+.toast.info {
+  background: var(--accent);
+  color: var(--bg);
+}
 .toast.hide {
   opacity: 0;
   transform: translateY(10px);

--- a/js/app.js
+++ b/js/app.js
@@ -301,6 +301,7 @@ function bind() {
       refreshPatientSelect(id);
       savePatient(id, newName);
       updateSaveStatus();
+      showToast('Pacientas pervadintas.', { type: 'info' });
     }
   });
 
@@ -311,6 +312,7 @@ function bind() {
       removePatient(id);
       refreshPatientSelect(getActivePatientId());
       updateSaveStatus();
+      showToast('Pacientas ištrintas.', { type: 'warning' });
     }
   });
 

--- a/js/toast.js
+++ b/js/toast.js
@@ -7,8 +7,10 @@ const toast = {
     if (!item) return;
     const { msg, options, container } = item;
     const { type, duration = 3000 } = options;
+    const validTypes = ['success', 'error', 'warning', 'info'];
+    const classType = validTypes.includes(type) ? ` ${type}` : '';
     const el = document.createElement('div');
-    el.className = 'toast' + (type ? ` ${type}` : '');
+    el.className = 'toast' + classType;
     el.setAttribute('role', 'alert');
     el.textContent = msg;
 


### PR DESCRIPTION
## Summary
- Style `.toast.warning` with yellow background and dark text
- Style `.toast.info` using the accent color and dark text
- Enable new toast types and show info on rename, warning on delete

## Testing
- `npm test`
- `node - <<'NODE'
function luminance(r,g,b){const a=[r,g,b].map(v=>{v/=255;return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4);});return 0.2126*a[0]+0.7152*a[1]+0.0722*a[2];}
function contrast(c1,c2){const l1=luminance(...c1),l2=luminance(...c2);const [L1,L2]=l1>l2?[l1,l2]:[l2,l1];return (L1+0.05)/(L2+0.05);}
const bg=[0x0c,0x12,0x18];
const yellow=[0xff,0xcc,0x00];
const accent=[0x4e,0xa0,0xf5];
console.log('warning contrast',contrast(bg,yellow));
console.log('info contrast',contrast(bg,accent));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ac712509ec83209e38935c5abd16bb