### PR TITLE
Sync active patient with form updates

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -17,6 +17,7 @@ import {
   renamePatient,
   getActivePatient,
   getActivePatientId,
+  updateActivePatient,
   getPatients,
 } from './patients.js';
 
@@ -387,12 +388,8 @@ function bind() {
 
   const handleChange = () => {
     dirty = true;
+    updateActivePatient();
     const id = getActivePatientId();
-    if (id) {
-      savePatient(id);
-      updateSaveStatus();
-      dirty = false;
-    }
     if (!$('#summarySec').classList.contains('hidden')) {
       const patient = getActivePatient();
       if (patient) {
@@ -401,6 +398,11 @@ function bind() {
         inputs.summary.value = text;
         patient.summary = text;
       }
+    }
+    if (id) {
+      savePatient(id);
+      updateSaveStatus();
+      dirty = false;
     }
   };
   document.addEventListener('input', handleChange);

--- a/js/patients.js
+++ b/js/patients.js
@@ -64,6 +64,12 @@ export function renamePatient(id, newName) {
   patients[id].name = newName;
 }
 
+export function updateActivePatient() {
+  if (!activeId || !patients[activeId]) return;
+  const { name, summary } = patients[activeId];
+  patients[activeId] = { ...getPayload(), name, summary };
+}
+
 export function getActivePatientId() {
   return activeId;
 }
@@ -81,6 +87,7 @@ export default {
   switchPatient,
   removePatient,
   renamePatient,
+  updateActivePatient,
   getActivePatient,
   getActivePatientId,
   getPatients,


### PR DESCRIPTION
## Summary
- add `updateActivePatient` to sync form payload into the active patient record while preserving name and summary
- call `updateActivePatient` from `handleChange` so summaries and saved data reflect latest inputs
- restore accidentally modified `index.html`

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac76f003e483208114934dda5656fd