### PR TITLE
feat: handle unknown anticoagulant selection

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -1,4 +1,5 @@
 import * as dom from './state.js';
+import { showToast } from './toast.js';
 
 function setValidity(el, valid, message) {
   if (!el) return valid;
@@ -59,5 +60,31 @@ export function initActivation() {
     const cb = () => fn(el);
     el.addEventListener('input', cb);
     fn(el);
+  });
+
+  const unknown = dom.getAUnknownInput();
+  const drugs = dom.getADrugsInputs().filter((el) => el.id !== 'a_unknown');
+
+  unknown?.addEventListener('change', () => {
+    if (!unknown.checked) return;
+    let cleared = false;
+    drugs.forEach((el) => {
+      if (el.checked) {
+        el.checked = false;
+        cleared = true;
+      }
+    });
+    if (cleared) {
+      showToast('Pašalinti kiti vaistai.', { type: 'info' });
+    }
+  });
+
+  drugs.forEach((el) => {
+    el.addEventListener('change', () => {
+      if (el.checked && unknown?.checked) {
+        unknown.checked = false;
+        showToast('„Nežinoma“ nužymėta.', { type: 'info' });
+      }
+    });
   });
 }

--- a/js/state.js
+++ b/js/state.js
@@ -50,6 +50,7 @@ export const getARivaroxabanInput = () => $('#a_rivaroxaban');
 export const getADabigatranInput = () => $('#a_dabigatran');
 export const getAEdoxabanInput = () => $('#a_edoxaban');
 export const getAUnknownInput = () => $('#a_unknown');
+export const getADrugsInputs = () => $$('#a_drugs input[type="checkbox"]');
 export const getALkwInputs = () => $$('input[name="a_lkw"]');
 export const getAGlucoseInput = () => $('#a_glucose');
 export const getAAksInput = () => $('#a_aks');
@@ -101,6 +102,7 @@ export function getInputs() {
     a_rivaroxaban: getARivaroxabanInput(),
     a_dabigatran: getADabigatranInput(),
     a_edoxaban: getAEdoxabanInput(),
+    a_drugs: getADrugsInputs(),
     a_unknown: getAUnknownInput(),
     a_lkw: getALkwInputs(),
     a_glucose: getAGlucoseInput(),

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -67,7 +67,7 @@
 
             <fieldset>
               <legend>Vartojami vaistai</legend>
-              <div class="grid-2">
+              <div id="a_drugs" class="grid-2">
                 <label class="pill"
                   ><input id="a_warfarin" type="checkbox" />Varfarinas</label
                 >


### PR DESCRIPTION
## Summary
- ensure anticoagulant checkboxes are wrapped in a dedicated container
- expose grouped anticoagulant getters
- auto-clear conflicting drug selections and show a toast when corrected

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac82206a108320a855bae99fccfbac