### PR TITLE
Validate personal code input

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -17,6 +17,12 @@ function parseLocaleFloat(str) {
   return parseFloat(str.replace(',', '.'));
 }
 
+export function validatePersonalCode(el) {
+  const val = (el.value || '').trim();
+  const ok = !val || /^\d{11}$/.test(val);
+  return setValidity(el, ok, 'Asmens kodas turi būti 11 skaitmenų.');
+}
+
 export function validateGlucose(el) {
   const v = parseLocaleFloat(el.value || '');
   const ok = !el.value || (Number.isFinite(v) && v >= 2.8 && v <= 22);
@@ -49,6 +55,7 @@ export function validateTemp(el) {
 
 export function initActivation() {
   const handlers = [
+    [dom.getAPersonalInput(), validatePersonalCode],
     [dom.getAGlucoseInput(), validateGlucose],
     [dom.getAAksInput(), validateAks],
     [dom.getAHrInput(), validateHr],

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -6,7 +6,12 @@
               <div class="grid-2">
                 <div>
                   <label for="a_personal">Asmens kodas</label>
-                  <input id="a_personal" type="text" />
+                  <input
+                    id="a_personal"
+                    type="text"
+                    inputmode="numeric"
+                    placeholder="11 skaitmenų"
+                  />
                 </div>
                 <div>
                   <label for="a_name">Vardas, Pavardė</label>

--- a/test/activationValidation.test.js
+++ b/test/activationValidation.test.js
@@ -84,3 +84,14 @@ test('validateTemp checks 30-43°C', async () => {
   assert(!el.classList.contains('invalid'));
 });
 
+test('validatePersonalCode requires 11 digits', async () => {
+  const { validatePersonalCode } = await loadModule();
+  const el = createEl();
+  el.value = '123';
+  validatePersonalCode(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '12345678901';
+  validatePersonalCode(el);
+  assert(!el.classList.contains('invalid'));
+});
+


### PR DESCRIPTION
## Summary
- validate Lithuanian personal code with numeric-only input and placeholder
- add personal code validator and register in activation init
- test personal code validation for valid and invalid cases

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac83f3a2c083209b9e920ba7d68a76