### PR TITLE
Use numeric inputs for activation parameters

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -13,12 +13,8 @@ function setValidity(el, valid, message) {
   return valid;
 }
 
-function parseLocaleFloat(str) {
-  return parseFloat(str.replace(',', '.'));
-}
-
 export function validateGlucose(el) {
-  const v = parseLocaleFloat(el.value || '');
+  const v = parseFloat(el.value);
   const ok = !el.value || (Number.isFinite(v) && v >= 2.8 && v <= 22);
   return setValidity(el, ok, 'Gliukozė turi būti 2.8–22 mmol/l.');
 }
@@ -42,7 +38,7 @@ export function validateSpo2(el) {
 }
 
 export function validateTemp(el) {
-  const v = parseLocaleFloat(el.value || '');
+  const v = parseFloat(el.value);
   const ok = !el.value || (Number.isFinite(v) && v >= 30 && v <= 43);
   return setValidity(el, ok, 'Temperatūra turi būti 30–43 °C.');
 }

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -123,23 +123,56 @@
               <div class="grid-2">
                 <div>
                   <label for="a_glucose">Gliukozė</label>
-                  <input id="a_glucose" type="text" />
+                  <input
+                    id="a_glucose"
+                    type="number"
+                    step="0.1"
+                    min="2.8"
+                    max="22"
+                    placeholder="mmol/l"
+                  />
                 </div>
                 <div>
                   <label for="a_aks">AKS</label>
-                  <input id="a_aks" type="text" />
+                  <input
+                    id="a_aks"
+                    type="text"
+                    inputmode="numeric"
+                    placeholder="120/80"
+                  />
                 </div>
                 <div>
                   <label for="a_hr">ŠSD</label>
-                  <input id="a_hr" type="text" />
+                  <input
+                    id="a_hr"
+                    type="number"
+                    step="1"
+                    min="30"
+                    max="250"
+                    placeholder="bpm"
+                  />
                 </div>
                 <div>
                   <label for="a_spo2">SpO₂</label>
-                  <input id="a_spo2" type="text" />
+                  <input
+                    id="a_spo2"
+                    type="number"
+                    step="1"
+                    min="50"
+                    max="100"
+                    placeholder="%"
+                  />
                 </div>
                 <div>
                   <label for="a_temp">Temperatūra</label>
-                  <input id="a_temp" type="text" />
+                  <input
+                    id="a_temp"
+                    type="number"
+                    step="0.1"
+                    min="30"
+                    max="43"
+                    placeholder="°C"
+                  />
                 </div>
               </div>
             </fieldset>

--- a/test/activationValidation.test.js
+++ b/test/activationValidation.test.js
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
 
 function createEl() {
   return {
@@ -35,6 +36,9 @@ test('validateGlucose enforces 2.8-22 range', async () => {
   el.value = '1';
   validateGlucose(el);
   assert(el.classList.contains('invalid'));
+  el.value = '25';
+  validateGlucose(el);
+  assert(el.classList.contains('invalid'));
   el.value = '5';
   validateGlucose(el);
   assert(!el.classList.contains('invalid'));
@@ -57,6 +61,9 @@ test('validateHr checks 30-250 bpm', async () => {
   el.value = '10';
   validateHr(el);
   assert(el.classList.contains('invalid'));
+  el.value = '260';
+  validateHr(el);
+  assert(el.classList.contains('invalid'));
   el.value = '70';
   validateHr(el);
   assert(!el.classList.contains('invalid'));
@@ -66,6 +73,9 @@ test('validateSpo2 checks 50-100%', async () => {
   const { validateSpo2 } = await loadModule();
   const el = createEl();
   el.value = '30';
+  validateSpo2(el);
+  assert(el.classList.contains('invalid'));
+  el.value = '101';
   validateSpo2(el);
   assert(el.classList.contains('invalid'));
   el.value = '98';
@@ -79,8 +89,54 @@ test('validateTemp checks 30-43°C', async () => {
   el.value = '25';
   validateTemp(el);
   assert(el.classList.contains('invalid'));
+  el.value = '45';
+  validateTemp(el);
+  assert(el.classList.contains('invalid'));
   el.value = '37';
   validateTemp(el);
   assert(!el.classList.contains('invalid'));
+});
+
+test('activation parameter inputs have numeric attributes', async () => {
+  const html = await fs.readFile('templates/sections/activation.njk', 'utf8');
+  function getInput(id) {
+    const regex = new RegExp(`<input[^>]*id="${id}"[^>]*>`, 'm');
+    const match = html.match(regex);
+    assert.ok(match, `Input ${id} not found`);
+    return match[0];
+  }
+
+  let input = getInput('a_glucose');
+  assert.match(input, /type="number"/);
+  assert.match(input, /step="0.1"/);
+  assert.match(input, /min="2.8"/);
+  assert.match(input, /max="22"/);
+  assert.match(input, /placeholder="mmol\/l"/);
+
+  input = getInput('a_hr');
+  assert.match(input, /type="number"/);
+  assert.match(input, /step="1"/);
+  assert.match(input, /min="30"/);
+  assert.match(input, /max="250"/);
+  assert.match(input, /placeholder="bpm"/);
+
+  input = getInput('a_spo2');
+  assert.match(input, /type="number"/);
+  assert.match(input, /step="1"/);
+  assert.match(input, /min="50"/);
+  assert.match(input, /max="100"/);
+  assert.match(input, /placeholder="%"/);
+
+  input = getInput('a_temp');
+  assert.match(input, /type="number"/);
+  assert.match(input, /step="0.1"/);
+  assert.match(input, /min="30"/);
+  assert.match(input, /max="43"/);
+  assert.match(input, /placeholder="°C"/);
+
+  input = getInput('a_aks');
+  assert.match(input, /type="text"/);
+  assert.match(input, /inputmode="numeric"/);
+  assert.match(input, /placeholder="120\/80"/);
 });
 


### PR DESCRIPTION
## Summary
- Convert glucose, HR, SpO₂, and temperature fields to numeric inputs with range limits and unit placeholders
- Keep AKS as text with numeric inputmode and placeholder
- Parse numeric values directly in activation validation and extend tests for ranges/attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac859b96b48320ad3ee04203c8a7e2