### PR TITLE
Add GMP notification time field to activation form

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,54 @@
           <h2>Komandos aktyvacija</h2>
           <form>
             <fieldset>
+              <legend>GMP pranešimo laikas</legend>
+              
+<div class="row">
+  <div class="input-group">
+    <input
+      id="a_gmp_time"
+      class="time-input"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+    <button
+      type="button"
+      class="btn ghost"
+      data-time-picker="a_gmp_time"
+      aria-label="Pasirinkti datą ir laiką"
+    >
+      📅
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-now="a_gmp_time"
+      aria-label="Dabar"
+    >
+      Dabar
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepdown="a_gmp_time"
+      aria-label="−5 min"
+    >
+      −5
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepup="a_gmp_time"
+      aria-label="+5 min"
+    >
+      +5
+    </button>
+  </div>
+</div>
+
+            </fieldset>
+            <fieldset>
               <legend>Paciento duomenys</legend>
               <div class="grid-2">
                 <div>
@@ -195,23 +243,56 @@
               <div class="grid-2">
                 <div>
                   <label for="a_glucose">Gliukozė</label>
-                  <input id="a_glucose" type="text" />
+                  <input
+                    id="a_glucose"
+                    type="number"
+                    step="0.1"
+                    min="2.8"
+                    max="22"
+                    placeholder="mmol/l"
+                  />
                 </div>
                 <div>
                   <label for="a_aks">AKS</label>
-                  <input id="a_aks" type="text" />
+                  <input
+                    id="a_aks"
+                    type="text"
+                    inputmode="numeric"
+                    placeholder="120/80"
+                  />
                 </div>
                 <div>
                   <label for="a_hr">ŠSD</label>
-                  <input id="a_hr" type="text" />
+                  <input
+                    id="a_hr"
+                    type="number"
+                    step="1"
+                    min="30"
+                    max="250"
+                    placeholder="bpm"
+                  />
                 </div>
                 <div>
                   <label for="a_spo2">SpO₂</label>
-                  <input id="a_spo2" type="text" />
+                  <input
+                    id="a_spo2"
+                    type="number"
+                    step="1"
+                    min="50"
+                    max="100"
+                    placeholder="%"
+                  />
                 </div>
                 <div>
                   <label for="a_temp">Temperatūra</label>
-                  <input id="a_temp" type="text" />
+                  <input
+                    id="a_temp"
+                    type="number"
+                    step="0.1"
+                    min="30"
+                    max="43"
+                    placeholder="°C"
+                  />
                 </div>
               </div>
             </fieldset>

--- a/js/state.js
+++ b/js/state.js
@@ -38,6 +38,7 @@ export const getAPersonalInput = () => $('#a_personal');
 export const getANameInput = () => $('#a_name');
 export const getADobInput = () => $('#a_dob');
 export const getAAgeInput = () => $('#a_age');
+export const getAGmpTimeInput = () => $('#a_gmp_time');
 export const getASymFaceInputs = () => $$('input[name="a_face"]');
 export const getASymSpeechInputs = () => $$('input[name="a_speech"]');
 export const getASymCommandsInputs = () => $$('input[name="a_commands"]');
@@ -91,6 +92,7 @@ export function getInputs() {
     a_name: getANameInput(),
     a_dob: getADobInput(),
     a_age: getAAgeInput(),
+    a_gmp_time: getAGmpTimeInput(),
     a_sym_face: getASymFaceInputs(),
     a_sym_speech: getASymSpeechInputs(),
     a_sym_commands: getASymCommandsInputs(),

--- a/js/storage.js
+++ b/js/storage.js
@@ -132,6 +132,7 @@ export function getPayload() {
     a_hr: inputs.a_hr?.value || '',
     a_spo2: inputs.a_spo2?.value || '',
     a_temp: inputs.a_temp?.value || '',
+    a_gmp_time: inputs.a_gmp_time?.value || '',
     bp_meds,
   };
 }
@@ -225,6 +226,7 @@ export function setPayload(p) {
   if (inputs.a_hr) inputs.a_hr.value = payload.a_hr || '';
   if (inputs.a_spo2) inputs.a_spo2.value = payload.a_spo2 || '';
   if (inputs.a_temp) inputs.a_temp.value = payload.a_temp || '';
+  if (inputs.a_gmp_time) inputs.a_gmp_time.value = payload.a_gmp_time || '';
   const bpContainer = document.getElementById('bpEntries');
   if (bpContainer) {
     bpContainer.innerHTML = '';

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -2,6 +2,10 @@
           <h2>Komandos aktyvacija</h2>
           <form>
             <fieldset>
+              <legend>GMP pranešimo laikas</legend>
+              {{ timeInput('a_gmp_time') }}
+            </fieldset>
+            <fieldset>
               <legend>Paciento duomenys</legend>
               <div class="grid-2">
                 <div>


### PR DESCRIPTION
## Summary
- add GMP notification time input with a quick "Dabar" button on activation page
- include new time field in DOM helpers and storage so it persists

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac870941448320ad9de28751d395de