### PR TITLE
Animate mobile navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -223,7 +223,7 @@ nav .tab:focus-visible {
     margin-bottom: 12px;
   }
   nav {
-    display: none;
+    display: block;
     position: fixed;
     top: var(--header-height);
     left: 0;
@@ -233,9 +233,15 @@ nav .tab:focus-visible {
     z-index: 1000;
     max-height: calc(100vh - var(--header-height));
     overflow-y: auto;
+    opacity: 0;
+    transform: translateY(-100%);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
   }
   body.nav-open nav {
-    display: block;
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
   }
 }
 section.card {


### PR DESCRIPTION
## Summary
- Animate the mobile nav drawer with opacity and translateY transitions
- Reveal nav via `body.nav-open` with pointer events enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9099ba0883208685287913b8bd5c