### PR TITLE
Add section transition fade effect for navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -891,6 +891,15 @@ section[data-tab='Intervencijos'] h3 {
   font-size: 0.875rem;
   color: var(--muted);
 }
+.section-transition {
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.2s ease;
+}
+.section-transition.active {
+  opacity: 1;
+  visibility: visible;
+}
 .hidden {
   display: none;
 }

--- a/js/app.js
+++ b/js/app.js
@@ -334,11 +334,27 @@ function bind() {
   // Navigation
   const tabs = $$('nav .tab');
   const sections = $$('main > section');
+  sections.forEach((s) => s.classList.add('section-transition'));
   const navToggle = $('#navToggle');
   const showSection = (id) => {
     sections.forEach((s) => {
+      const wasActive = s.classList.contains('active');
       const active = s.id === id;
-      s.classList.toggle('hidden', !active);
+      if (!active && wasActive) {
+        s.style.visibility = 'visible';
+        s.style.pointerEvents = 'none';
+        s.addEventListener(
+          'transitionend',
+          () => {
+            if (!s.classList.contains('active')) {
+              s.style.visibility = '';
+              s.style.pointerEvents = '';
+            }
+          },
+          { once: true },
+        );
+      }
+      s.classList.toggle('active', active);
       s.setAttribute('tabindex', active ? '0' : '-1');
       s.setAttribute('aria-hidden', active ? 'false' : 'true');
     });
@@ -404,7 +420,7 @@ function bind() {
     dirty = true;
     updateActivePatient();
     const id = getActivePatientId();
-    if (!$('#summarySec').classList.contains('hidden')) {
+    if ($('#summarySec').classList.contains('active')) {
       const patient = getActivePatient();
       if (patient) {
         const data = collectSummaryData(patient);


### PR DESCRIPTION
## Summary
- add `.section-transition` and `.section-transition.active` classes to handle fade transitions
- switch navigation to toggle `.active` and manage visibility/pointer-events on transition end
- update summary section check to rely on `.active`

## Testing
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac917b55d0832098491a0fd855114f