### PR TITLE
Guard missing optional inputs to restore navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -119,7 +119,7 @@ function bind() {
 
   // Drug defaults and automatic calculator
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>
-    el.addEventListener('input', () => {
+    el?.addEventListener('input', () => {
       updateDrugDefaults();
       calcDrugs();
     }),


### PR DESCRIPTION
## Summary
- Avoid errors when def_tnk/def_tpa inputs are absent
- Ensure navigation tabs initialize and function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac954805cc8320a624f484b8636539