### PR TITLE
Animate tab navigation transitions

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -888,6 +888,27 @@ section[data-tab='Intervencijos'] h3 {
 .hidden {
   display: none;
 }
+
+@keyframes tabFade {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+main > section.tab-animate {
+  animation: tabFade 0.3s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  main > section.tab-animate {
+    animation: none;
+  }
+}
 .detail {
   overflow: hidden;
   max-height: 200px;

--- a/js/app.js
+++ b/js/app.js
@@ -341,6 +341,14 @@ function bind() {
       s.classList.toggle('hidden', !active);
       s.setAttribute('tabindex', active ? '0' : '-1');
       s.setAttribute('aria-hidden', active ? 'false' : 'true');
+      if (active) {
+        s.classList.add('tab-animate');
+        s.addEventListener(
+          'animationend',
+          () => s.classList.remove('tab-animate'),
+          { once: true },
+        );
+      }
     });
     tabs.forEach((t) => {
       const selected = t.dataset.section === id;


### PR DESCRIPTION
## Summary
- animate switching sections with a fade and slide effect
- respect user preference for reduced motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac94bcc83c8320a36ff2e48ba500b1