### PR TITLE
Add button-based symptom selection to arrival form

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,6 +519,50 @@
 
             <fieldset>
               <legend>Simptomai</legend>
+              <div class="grid-3 mb-4">
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Veido asimetrija" />
+                  Veido asimetrija</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Rankos silpnumas" />
+                  Rankos silpnumas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Kojos silpnumas" />
+                  Kojos silpnumas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Kalbos sutrikimas" />
+                  Kalbos sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Regos sutrikimas" />
+                  Regos sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Galvos svaigimas" />
+                  Galvos svaigimas</label
+                >
+              </div>
               <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 

--- a/js/arrival.js
+++ b/js/arrival.js
@@ -93,6 +93,28 @@ export function updateArrivalInfo() {
   }
 }
 
+export function initSymptomButtons() {
+  const textarea = $('#arrival_symptoms');
+  if (!textarea) return;
+  const boxes = $$('input[name="arrival_symptom"]');
+  const updateFromBoxes = () => {
+    const values = boxes.filter((i) => i.checked).map((i) => i.value);
+    textarea.value = values.join(', ');
+  };
+  const updateFromText = () => {
+    const values = textarea.value
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+    boxes.forEach((b) => {
+      b.checked = values.includes(b.value);
+    });
+  };
+  boxes.forEach((i) => i.addEventListener('change', updateFromBoxes));
+  textarea.addEventListener('input', updateFromText);
+  updateFromText();
+}
+
 export function initArrival() {
   const updateAll = () => {
     updateArrivalInfo();
@@ -104,6 +126,7 @@ export function initArrival() {
   $$('input[name="lkw_type"]').forEach((r) =>
     r.addEventListener('change', updateAll),
   );
+  initSymptomButtons();
   updateAll();
   clearInterval(timerId);
   timerId = setInterval(updateTimers, 1000);

--- a/js/storage.js
+++ b/js/storage.js
@@ -164,8 +164,12 @@ export function setPayload(p) {
     inputs.t_thrombolysis.value = payload.t_thrombolysis || '';
   if (inputs.lkw_type)
     setRadioValue(inputs.lkw_type, payload.arrival_lkw_type || 'known');
-  if (inputs.arrival_symptoms)
+  if (inputs.arrival_symptoms) {
     inputs.arrival_symptoms.value = payload.arrival_symptoms || '';
+    inputs.arrival_symptoms.dispatchEvent?.(
+      new Event('input', { bubbles: true }),
+    );
+  }
   const contraVals = (payload.arrival_contra || '')
     .split(/;\s*/)
     .filter(Boolean);

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -42,6 +42,50 @@
 
             <fieldset>
               <legend>Simptomai</legend>
+              <div class="grid-3 mb-4">
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Veido asimetrija" />
+                  Veido asimetrija</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Rankos silpnumas" />
+                  Rankos silpnumas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Kojos silpnumas" />
+                  Kojos silpnumas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Kalbos sutrikimas" />
+                  Kalbos sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Regos sutrikimas" />
+                  Regos sutrikimas</label
+                >
+                <label class="pill"
+                  ><input
+                    type="checkbox"
+                    name="arrival_symptom"
+                    value="Galvos svaigimas" />
+                  Galvos svaigimas</label
+                >
+              </div>
               <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 

--- a/test/arrivalSymptoms.test.js
+++ b/test/arrivalSymptoms.test.js
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+
+import { initSymptomButtons } from '../js/arrival.js';
+
+test('symptom buttons sync with textarea both ways', () => {
+  const dom = new JSDOM(`<!DOCTYPE html><body>
+    <textarea id="arrival_symptoms">Rankos silpnumas, Kalbos sutrikimas</textarea>
+    <label><input type="checkbox" name="arrival_symptom" value="Rankos silpnumas"></label>
+    <label><input type="checkbox" name="arrival_symptom" value="Kalbos sutrikimas"></label>
+  </body>`);
+  const { document, Event } = dom.window;
+  global.document = document;
+  initSymptomButtons();
+  const boxes = document.querySelectorAll('input[name="arrival_symptom"]');
+  const textarea = document.getElementById('arrival_symptoms');
+  // initial text should check boxes
+  assert(boxes[0].checked);
+  assert(boxes[1].checked);
+  // uncheck first box -> textarea updates
+  boxes[0].checked = false;
+  boxes[0].dispatchEvent(new Event('change'));
+  assert.equal(textarea.value, 'Kalbos sutrikimas');
+  // edit textarea -> boxes update
+  textarea.value = 'Rankos silpnumas';
+  textarea.dispatchEvent(new Event('input'));
+  assert(boxes[0].checked);
+  assert(!boxes[1].checked);
+});


### PR DESCRIPTION
## Summary
- sync symptom buttons and textarea bidirectionally in arrival form
- fire input events when loading stored symptoms so buttons reflect saved values
- test two-way symptom button synchronization

## Testing
- `npm ci`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad5abaaf848320a020d984c0a8c755