### PR TITLE
feat: select symptom side on arrival

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,6 +563,16 @@
                   Galvos svaigimas</label
                 >
               </div>
+              <div class="grid-2 mb-4">
+                <label class="pill"
+                  ><input type="radio" name="arrival_symptom_side" value="left" />
+                  Kairė pusė</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="arrival_symptom_side" value="right" />
+                  Dešinė pusė</label
+                >
+              </div>
               <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 

--- a/js/arrival.js
+++ b/js/arrival.js
@@ -97,20 +97,55 @@ export function initSymptomButtons() {
   const textarea = $('#arrival_symptoms');
   if (!textarea) return;
   const boxes = $$('input[name="arrival_symptom"]');
+  const sideRadios = $$('input[name="arrival_symptom_side"]');
+  const sideSymptoms = [
+    'Veido asimetrija',
+    'Rankos silpnumas',
+    'Kojos silpnumas',
+  ];
+  const sideLabels = { left: 'Kairės', right: 'Dešinės' };
+  const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1);
+
   const updateFromBoxes = () => {
-    const values = boxes.filter((i) => i.checked).map((i) => i.value);
+    const side = sideRadios.find((r) => r.checked)?.value;
+    const values = boxes
+      .filter((i) => i.checked)
+      .map((i) => i.value)
+      .map((v) =>
+        side && sideSymptoms.includes(v)
+          ? `${sideLabels[side]} ${v.toLowerCase()}`
+          : v,
+      );
     textarea.value = values.join(', ');
   };
   const updateFromText = () => {
+    const leftPrefix = `${sideLabels.left} `;
+    const rightPrefix = `${sideLabels.right} `;
+    let detectedSide;
     const values = textarea.value
       .split(',')
       .map((v) => v.trim())
-      .filter(Boolean);
+      .filter(Boolean)
+      .map((v) => {
+        if (v.toLowerCase().startsWith(leftPrefix.toLowerCase())) {
+          detectedSide = 'left';
+          return capitalize(v.slice(leftPrefix.length).trim());
+        }
+        if (v.toLowerCase().startsWith(rightPrefix.toLowerCase())) {
+          detectedSide = 'right';
+          return capitalize(v.slice(rightPrefix.length).trim());
+        }
+        return capitalize(v);
+      });
     boxes.forEach((b) => {
       b.checked = values.includes(b.value);
     });
+    sideRadios.forEach((r) => {
+      r.checked = r.value === detectedSide;
+    });
   };
   boxes.forEach((i) => i.addEventListener('change', updateFromBoxes));
+  sideRadios.forEach((r) => r.addEventListener('change', updateFromBoxes));
   textarea.addEventListener('input', updateFromText);
   updateFromText();
 }

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -86,6 +86,16 @@
                   Galvos svaigimas</label
                 >
               </div>
+              <div class="grid-2 mb-4">
+                <label class="pill"
+                  ><input type="radio" name="arrival_symptom_side" value="left" />
+                  Kairė pusė</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="arrival_symptom_side" value="right" />
+                  Dešinė pusė</label
+                >
+              </div>
               <textarea id="arrival_symptoms" rows="3" aria-label="Simptomai"></textarea>
             </fieldset>
 

--- a/test/arrivalSymptoms.test.js
+++ b/test/arrivalSymptoms.test.js
@@ -6,25 +6,30 @@ import { initSymptomButtons } from '../js/arrival.js';
 
 test('symptom buttons sync with textarea both ways', () => {
   const dom = new JSDOM(`<!DOCTYPE html><body>
-    <textarea id="arrival_symptoms">Rankos silpnumas, Kalbos sutrikimas</textarea>
+    <textarea id="arrival_symptoms">Dešinės rankos silpnumas, Kalbos sutrikimas</textarea>
     <label><input type="checkbox" name="arrival_symptom" value="Rankos silpnumas"></label>
     <label><input type="checkbox" name="arrival_symptom" value="Kalbos sutrikimas"></label>
+    <label><input type="radio" name="arrival_symptom_side" value="left"></label>
+    <label><input type="radio" name="arrival_symptom_side" value="right"></label>
   </body>`);
   const { document, Event } = dom.window;
   global.document = document;
   initSymptomButtons();
   const boxes = document.querySelectorAll('input[name="arrival_symptom"]');
   const textarea = document.getElementById('arrival_symptoms');
-  // initial text should check boxes
+  const sides = document.querySelectorAll('input[name="arrival_symptom_side"]');
+  // initial text should check boxes and side
   assert(boxes[0].checked);
   assert(boxes[1].checked);
+  assert(sides[1].checked);
   // uncheck first box -> textarea updates
   boxes[0].checked = false;
   boxes[0].dispatchEvent(new Event('change'));
   assert.equal(textarea.value, 'Kalbos sutrikimas');
-  // edit textarea -> boxes update
-  textarea.value = 'Rankos silpnumas';
+  // edit textarea -> boxes and side update
+  textarea.value = 'Kairės rankos silpnumas';
   textarea.dispatchEvent(new Event('input'));
   assert(boxes[0].checked);
   assert(!boxes[1].checked);
+  assert(sides[0].checked);
 });


### PR DESCRIPTION
## Summary
- allow choosing left or right side for arrival symptoms
- sync side selection with textarea and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad6371117083209142a34f6d9f19ab