### PR TITLE
Refine activation summary with GMP details

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -94,6 +94,33 @@ export function summaryTemplate({
   if (patient.inr) lines.push(`- INR: ${patient.inr}`);
   lines.push(`- NIHSS pradinis: ${patient.nih0 ?? '—'}`);
 
+  if (
+    activation.lkw ||
+    activation.drugs.length ||
+    activation.params.glucose ||
+    activation.params.aks ||
+    activation.params.hr ||
+    activation.params.spo2 ||
+    activation.params.temp
+  ) {
+    lines.push('AKTYVACIJA:');
+    if (activation.lkw)
+      lines.push(`- Preliminarus susirgimo laikas: ${activation.lkw}`);
+    if (activation.drugs.length)
+      lines.push(`- Vartojami vaistai: ${activation.drugs.join(', ')}`);
+    const paramParts = [];
+    if (activation.params.glucose)
+      paramParts.push(`Gliukozė: ${activation.params.glucose}`);
+    if (activation.params.aks) paramParts.push(`AKS: ${activation.params.aks}`);
+    if (activation.params.hr) paramParts.push(`ŠSD: ${activation.params.hr}`);
+    if (activation.params.spo2)
+      paramParts.push(`SpO₂: ${activation.params.spo2}`);
+    if (activation.params.temp)
+      paramParts.push(`Temp: ${activation.params.temp}`);
+    if (paramParts.length)
+      lines.push(`- GMP parametrai: ${paramParts.join(', ')}`);
+  }
+
   lines.push('LAIKAI:');
   if (times.gmp) lines.push(`- GMP iškvietimas: ${times.gmp}`);
   lines.push(`- LKW: ${times.lkw ?? '—'}`);
@@ -122,30 +149,6 @@ export function summaryTemplate({
         }`.trim(),
       ),
     );
-  }
-
-  if (
-    activation.lkw ||
-    activation.drugs.length ||
-    activation.params.glucose ||
-    activation.params.aks ||
-    activation.params.hr ||
-    activation.params.spo2 ||
-    activation.params.temp
-  ) {
-    lines.push('AKTYVACIJOS KRITERIJAI:');
-    if (activation.lkw) lines.push(`- ${activation.lkw}`);
-    if (activation.drugs.length) lines.push(`- ${activation.drugs.join(', ')}`);
-    const paramParts = [];
-    if (activation.params.glucose)
-      paramParts.push(`Gliukozė: ${activation.params.glucose}`);
-    if (activation.params.aks) paramParts.push(`AKS: ${activation.params.aks}`);
-    if (activation.params.hr) paramParts.push(`ŠSD: ${activation.params.hr}`);
-    if (activation.params.spo2)
-      paramParts.push(`SpO₂: ${activation.params.spo2}`);
-    if (activation.params.temp)
-      paramParts.push(`Temp: ${activation.params.temp}`);
-    if (paramParts.length) lines.push(`- ${paramParts.join(', ')}`);
   }
 
   if (activation.symptoms.length || arrivalSymptoms) {

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -114,10 +114,16 @@ test('summaryTemplate generates summary text correctly', async () => {
   assert(
     summary.includes('AKS KOREKCIJA:\n- Kaptoprilis 10:00 25 mg (požymai)'),
   );
-  assert(summary.includes('AKTYVACIJOS KRITERIJAI:\n- <4.5'));
-  assert(summary.includes('- Varfarinas'));
   assert(
-    summary.includes('- Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37'),
+    summary.includes(
+      'AKTYVACIJA:\n- Preliminarus susirgimo laikas: <4.5',
+    ),
+  );
+  assert(summary.includes('- Vartojami vaistai: Varfarinas'));
+  assert(
+    summary.includes(
+      '- GMP parametrai: Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37',
+    ),
   );
   assert(summary.includes('SIMPTOMAI:\n- Veido paralyžius, Kalbos sutrikimas'));
   assert(summary.includes('- Dešinės rankos silpnumas'));


### PR DESCRIPTION
## Summary
- Rename activation section to "AKTYVACIJA" and move it below patient data
- Include preliminary onset time, listed medications, and GMP parameters in summary output
- Adjust summary template tests for new activation section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad7bd686648320a83e094861eada4d