### PR TITLE
Use random IDs for patients

### DIFF
--- a/js/patients.js
+++ b/js/patients.js
@@ -7,13 +7,13 @@ import { getInputs } from './state.js';
 
 const patients = {};
 let activeId = null;
-let counter = 1;
 
 function generateId() {
-  return `p${counter++}`;
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
 }
 
-export function addPatient() {
+export function addPatient(id, data = {}) {
   const inputs = getInputs();
   if (activeId)
     patients[activeId] = {
@@ -21,13 +21,17 @@ export function addPatient() {
       summary: inputs.summary?.value || '',
       name: patients[activeId].name,
     };
-  const id = generateId();
-  const name = `Pacientas ${Object.keys(patients).length + 1}`;
-  patients[id] = { summary: '', name };
-  activeId = id;
-  setPayload({});
-  if (inputs.summary) inputs.summary.value = '';
-  return id;
+  const newId = id || generateId();
+  const {
+    summary = '',
+    name = `Pacientas ${Object.keys(patients).length + 1}`,
+    ...payload
+  } = data || {};
+  patients[newId] = { ...payload, summary, name };
+  activeId = newId;
+  setPayload(payload);
+  if (inputs.summary) inputs.summary.value = summary;
+  return newId;
 }
 
 export function switchPatient(id) {

--- a/test/patients.test.js
+++ b/test/patients.test.js
@@ -67,3 +67,18 @@ test(
     assert.strictEqual(remaining[id2].p_nihss0, '2');
   },
 );
+
+test('addPatient keeps provided ID and data', () => {
+  localStorageStub.store = {};
+  resetInputs();
+
+  const existingId = 'existing-id';
+  const data = { p_nihss0: '5', summary: 's', name: 'Existing' };
+  const id = addPatient(existingId, data);
+
+  assert.strictEqual(id, existingId);
+  const patients = getPatientStore();
+  assert.strictEqual(patients[existingId].p_nihss0, '5');
+  assert.strictEqual(patients[existingId].summary, 's');
+  assert.strictEqual(patients[existingId].name, 'Existing');
+});


### PR DESCRIPTION
## Summary
- generate unique patient IDs with `crypto.randomUUID` fallback
- load existing patients with provided IDs and data
- test retaining existing IDs when adding patient

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad854684088320b7119abb7c34cad1