### PR TITLE
Add error handling to build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -3,5 +3,10 @@ import nunjucks from 'nunjucks';
 
 nunjucks.configure('templates', { autoescape: false });
 
-const html = nunjucks.render('index.njk');
-fs.writeFileSync('index.html', html);
+try {
+  const html = nunjucks.render('index.njk');
+  await fs.promises.writeFile('index.html', html);
+} catch (error) {
+  console.error('Failed to build index.html:', error);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- use async fs.promises.writeFile and try/catch in build.js
- log and exit with failure when template rendering or writing fails

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad8a5fe0dc8320b672ab45a4865a8d