### PR TITLE
Handle schema version mismatch in storage

### DIFF
--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -86,9 +86,26 @@ test('getPatients migrates unversioned data', () => {
     }),
   };
   const patients = getPatients();
-  assert.strictEqual(patients.old.data.version, 0);
+  assert.strictEqual(patients.old.data.version, 1);
   assert.strictEqual(patients.old.data.data.p_nihss0, '1');
   assert.strictEqual(patients.old.patientId, 'old');
   assert.ok(patients.old.created);
   assert.ok(patients.old.lastUpdated);
+});
+
+test('getPatients discards unknown schema versions', () => {
+  localStorageStub.store = {
+    insultoKomandaPatients_v1: JSON.stringify({
+      future: { name: 'Future', data: { version: 999, data: {} } },
+    }),
+  };
+  let warned = false;
+  const origWarn = console.warn;
+  console.warn = () => {
+    warned = true;
+  };
+  const patients = getPatients();
+  console.warn = origWarn;
+  assert.ok(!('future' in patients));
+  assert.ok(warned);
 });


### PR DESCRIPTION
## Summary
- migrate patient records to current schema or drop unknown versions
- bump patient record version when saving after schema updates
- test migration and discarding of incompatible schemas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8b67956c83209f795d9ad76b0ffb