### PR TITLE
Delegate BP entry button handlers to container

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -162,6 +162,27 @@ function bind() {
   // BP correction helpers
   setupBpEntry();
 
+  const bpEntries = document.getElementById('bpEntries');
+  bpEntries?.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+
+    if (target.matches('button[data-now]')) {
+      setNow(target.dataset.now);
+    } else if (target.matches('button[data-time-picker]')) {
+      const input = document.getElementById(target.dataset.timePicker);
+      if (input) openTimePicker(input);
+    } else if (target.matches('button[data-stepup]')) {
+      const input = document.getElementById(target.dataset.stepup);
+      input?.stepUp(5);
+      input?.dispatchEvent(new Event('input'));
+    } else if (target.matches('button[data-stepdown]')) {
+      const input = document.getElementById(target.dataset.stepdown);
+      input?.stepDown(5);
+      input?.dispatchEvent(new Event('input'));
+    }
+  });
+
   // Pill checked state
   document.querySelectorAll('.pill input').forEach((input) => {
     const pill = input.closest('.pill');

--- a/js/bp.js
+++ b/js/bp.js
@@ -1,5 +1,4 @@
-import { setNow } from './time.js';
-import { openTimePicker } from './timePicker.js';
+// Event handlers for created entries are delegated in app.js
 
 export function setupBpEntry() {
   const bpCorrBtn = document.getElementById('bpCorrBtn');
@@ -33,28 +32,6 @@ export function setupBpEntry() {
           </div>`;
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
-        entry
-          .querySelector(`[data-now="${id}"]`)
-          .addEventListener('click', () => setNow(id));
-        entry
-          .querySelector(`[data-time-picker="${id}"]`)
-          .addEventListener('click', () =>
-            openTimePicker(document.getElementById(id)),
-          );
-        entry
-          .querySelector(`[data-stepup="${id}"]`)
-          .addEventListener('click', () => {
-            const target = document.getElementById(id);
-            target?.stepUp(5);
-            target?.dispatchEvent(new Event('input'));
-          });
-        entry
-          .querySelector(`[data-stepdown="${id}"]`)
-          .addEventListener('click', () => {
-            const target = document.getElementById(id);
-            target?.stepDown(5);
-            target?.dispatchEvent(new Event('input'));
-          });
       });
     });
   }


### PR DESCRIPTION
## Summary
- Handle BP entry time-control buttons with a single delegated listener on `#bpEntries`
- Remove per-entry event listener setup when creating new BP entries

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68ad8ce2f20483208a640344eb839ba4