### PR TITLE
Refactor BP entry rendering to use DOM API

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -17,19 +17,64 @@ export function setupBpEntry() {
         const entry = document.createElement('div');
         entry.className = 'bp-entry mt-10';
         const id = `bp_time_${Date.now()}`;
-        entry.innerHTML = `
-          <strong>${med}</strong>
-          <div class="grid-3 mt-5">
-            <div class="input-group">
-              <input type="time" id="${id}" class="time-input" step="60" value="${now}" />
-              <button class="btn ghost" data-time-picker="${id}" aria-label="Pasirinkti laiką">⌚</button>
-              <button class="btn ghost" data-now="${id}">Dabar</button>
-              <button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button>
-              <button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button>
-            </div>
-            <input type="text" value="${dose}" />
-            <input type="text" placeholder="Pastabos" />
-          </div>`;
+
+        const strong = document.createElement('strong');
+        strong.textContent = med;
+        entry.appendChild(strong);
+
+        const grid = document.createElement('div');
+        grid.className = 'grid-3 mt-5';
+        entry.appendChild(grid);
+
+        const group = document.createElement('div');
+        group.className = 'input-group';
+        grid.appendChild(group);
+
+        const timeInput = document.createElement('input');
+        timeInput.setAttribute('type', 'time');
+        timeInput.id = id;
+        timeInput.className = 'time-input';
+        timeInput.step = '60';
+        timeInput.value = now;
+        group.appendChild(timeInput);
+
+        const timePickerBtn = document.createElement('button');
+        timePickerBtn.className = 'btn ghost';
+        timePickerBtn.setAttribute('data-time-picker', id);
+        timePickerBtn.setAttribute('aria-label', 'Pasirinkti laiką');
+        timePickerBtn.textContent = '⌚';
+        group.appendChild(timePickerBtn);
+
+        const nowBtn = document.createElement('button');
+        nowBtn.className = 'btn ghost';
+        nowBtn.setAttribute('data-now', id);
+        nowBtn.textContent = 'Dabar';
+        group.appendChild(nowBtn);
+
+        const stepDownBtn = document.createElement('button');
+        stepDownBtn.className = 'btn ghost';
+        stepDownBtn.setAttribute('data-stepdown', id);
+        stepDownBtn.setAttribute('aria-label', '−5 min');
+        stepDownBtn.textContent = '−5';
+        group.appendChild(stepDownBtn);
+
+        const stepUpBtn = document.createElement('button');
+        stepUpBtn.className = 'btn ghost';
+        stepUpBtn.setAttribute('data-stepup', id);
+        stepUpBtn.setAttribute('aria-label', '+5 min');
+        stepUpBtn.textContent = '+5';
+        group.appendChild(stepUpBtn);
+
+        const doseInput = document.createElement('input');
+        doseInput.setAttribute('type', 'text');
+        doseInput.value = dose;
+        grid.appendChild(doseInput);
+
+        const notesInput = document.createElement('input');
+        notesInput.setAttribute('type', 'text');
+        notesInput.setAttribute('placeholder', 'Pastabos');
+        grid.appendChild(notesInput);
+
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
       });

--- a/js/storage.js
+++ b/js/storage.js
@@ -261,30 +261,83 @@ export function setPayload(p) {
       const id = `bp_time_${Date.now()}_${Math.random()
         .toString(36)
         .slice(2, 7)}`;
-      entry.innerHTML = `<strong>${m.med}</strong><div class="grid-3 mt-5"><div class="input-group"><input type="time" id="${id}" class="time-input" step="60" value="${
-        m.time || ''
-      }" /><button class="btn ghost" data-time-picker="${id}" aria-label="Pasirinkti laiką">⌚</button><button class="btn ghost" data-now="${id}">Dabar</button><button class="btn ghost" data-stepdown="${id}" aria-label="−5 min">−5</button><button class="btn ghost" data-stepup="${id}" aria-label="+5 min">+5</button></div><input type="text" value="${
-        m.dose || ''
-      }" /><input type="text" placeholder="Pastabos" value="${m.notes || ''}" /></div>`;
+      const strong = document.createElement('strong');
+      strong.textContent = m.med;
+      entry.appendChild(strong);
+
+      const grid = document.createElement('div');
+      grid.className = 'grid-3 mt-5';
+      entry.appendChild(grid);
+
+      const group = document.createElement('div');
+      group.className = 'input-group';
+      grid.appendChild(group);
+
+      const timeInput = document.createElement('input');
+      timeInput.setAttribute('type', 'time');
+      timeInput.id = id;
+      timeInput.className = 'time-input';
+      timeInput.step = '60';
+      if (m.time) timeInput.value = m.time;
+      group.appendChild(timeInput);
+
+      const timePickerBtn = document.createElement('button');
+      timePickerBtn.className = 'btn ghost';
+      timePickerBtn.setAttribute('data-time-picker', id);
+      timePickerBtn.setAttribute('aria-label', 'Pasirinkti laiką');
+      timePickerBtn.textContent = '⌚';
+      group.appendChild(timePickerBtn);
+
+      const nowBtn = document.createElement('button');
+      nowBtn.className = 'btn ghost';
+      nowBtn.setAttribute('data-now', id);
+      nowBtn.textContent = 'Dabar';
+      group.appendChild(nowBtn);
+
+      const stepDownBtn = document.createElement('button');
+      stepDownBtn.className = 'btn ghost';
+      stepDownBtn.setAttribute('data-stepdown', id);
+      stepDownBtn.setAttribute('aria-label', '−5 min');
+      stepDownBtn.textContent = '−5';
+      group.appendChild(stepDownBtn);
+
+      const stepUpBtn = document.createElement('button');
+      stepUpBtn.className = 'btn ghost';
+      stepUpBtn.setAttribute('data-stepup', id);
+      stepUpBtn.setAttribute('aria-label', '+5 min');
+      stepUpBtn.textContent = '+5';
+      group.appendChild(stepUpBtn);
+
+      const doseInput = document.createElement('input');
+      doseInput.setAttribute('type', 'text');
+      doseInput.value = m.dose || '';
+      grid.appendChild(doseInput);
+
+      const notesInput = document.createElement('input');
+      notesInput.setAttribute('type', 'text');
+      notesInput.setAttribute('placeholder', 'Pastabos');
+      notesInput.value = m.notes || '';
+      grid.appendChild(notesInput);
+
       bpContainer.appendChild(entry);
       entry
         .querySelector(`[data-now="${id}"]`)
-        ?.addEventListener('click', () => setNow(id));
+        ?.addEventListener?.('click', () => setNow(id));
       entry
         .querySelector(`[data-time-picker="${id}"]`)
-        ?.addEventListener('click', () =>
+        ?.addEventListener?.('click', () =>
           openTimePicker(document.getElementById(id)),
         );
       entry
         .querySelector(`[data-stepup="${id}"]`)
-        ?.addEventListener('click', () => {
+        ?.addEventListener?.('click', () => {
           const target = document.getElementById(id);
           target?.stepUp(5);
           target?.dispatchEvent(new Event('input'));
         });
       entry
         .querySelector(`[data-stepdown="${id}"]`)
-        ?.addEventListener('click', () => {
+        ?.addEventListener?.('click', () => {
           const target = document.getElementById(id);
           target?.stepDown(5);
           target?.dispatchEvent(new Event('input'));

--- a/test/changeEvents.test.js
+++ b/test/changeEvents.test.js
@@ -20,7 +20,10 @@ function createEl() {
         return this.classes.has(c);
       },
     },
-    querySelector: () => ({ textContent: '' }),
+    querySelector: () => ({ textContent: '', addEventListener: () => {} }),
+    setAttribute(name, value) {
+      (this.attributes || (this.attributes = {}))[name] = value;
+    },
     checked: false,
     appendChild(child) {
       (this.children || (this.children = [])).push(child);

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -18,8 +18,11 @@ export async function setupDom() {
           return this.classes.has(c);
         },
       },
-      querySelector: () => ({ textContent: '' }),
+      querySelector: () => ({ textContent: '', addEventListener: () => {} }),
       addEventListener: () => {},
+      setAttribute(name, value) {
+        (this.attributes || (this.attributes = {}))[name] = value;
+      },
       checked: false,
       appendChild(child) {
         (this.children || (this.children = [])).push(child);


### PR DESCRIPTION
## Summary
- replace BP correction templates with explicit DOM creation
- rebuild saved BP entries using createElement/textContent/attributes
- update test utilities for DOM attribute support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ada1c2368483209ec1c75a71e98b84