### PR TITLE
refactor: use shared dom helpers

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -1,5 +1,4 @@
-const $ = (sel) => document.querySelector(sel);
-const $$ = (sel) => Array.from(document.querySelectorAll(sel));
+import { $, $$ } from './state.js';
 
 const pad = (n) => String(n).padStart(2, '0');
 

--- a/js/state.js
+++ b/js/state.js
@@ -115,4 +115,6 @@ export function getInputs() {
   };
 }
 
-state.autosave = getAutosaveInput()?.value || 'on';
+if (typeof document !== 'undefined') {
+  state.autosave = getAutosaveInput()?.value || 'on';
+}


### PR DESCRIPTION
## Summary
- reuse shared $ and $$ DOM helpers in arrival module
- guard state autosave initialization from running when document is unavailable

## Testing
- `npm test`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68adab1ae1b88320af84ed90ef037ff9