### PR TITLE
refactor: reuse pad function

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -1,6 +1,5 @@
 import { $, $$ } from './state.js';
-
-const pad = (n) => String(n).padStart(2, '0');
+import { pad } from './time.js';
 
 export function timeSince(onset) {
   const start = new Date(onset).getTime();

--- a/js/time.js
+++ b/js/time.js
@@ -1,4 +1,4 @@
-const pad = (n) => String(n).padStart(2, '0');
+export const pad = (n) => String(n).padStart(2, '0');
 
 export function toLocalInputValue(d) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;


### PR DESCRIPTION
## Summary
- export `pad` from `time.js` for reuse
- use shared `pad` in `arrival.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adac19f66c8320a78270c5c6b3c809