### PR TITLE
Handle negative arrival time diff

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -49,7 +49,10 @@ export function computeArrivalMessage({ lkwType, lkwValue, doorValue }) {
   } else {
     return { message: '', type: '' };
   }
-  if (!isFinite(diff) || diff < 0) return { message: '', type: '' };
+  if (!isFinite(diff)) return { message: '', type: '' };
+  if (diff < 0) {
+    return { message: 'Nenuoseklus laiko įrašas.', type: 'error' };
+  }
   if (diff <= 4.5) {
     return {
       message: 'Indikuotina trombolizė / trombektomija.',

--- a/test/arrival.test.js
+++ b/test/arrival.test.js
@@ -84,13 +84,16 @@ test('over 24 hours', () => {
   });
 });
 
-test('negative diff returns empty message', () => {
+test('negative diff returns error message', () => {
   const res = computeArrivalMessage({
     lkwType: 'known',
     lkwValue: '2024-01-01T10:00',
     doorValue: '2024-01-01T09:00',
   });
-  assert.deepEqual(res, { message: '', type: '' });
+  assert.deepEqual(res, {
+    message: 'Nenuoseklus laiko įrašas.',
+    type: 'error',
+  });
 });
 
 test('sleep midpoint without door time uses current time', () => {


### PR DESCRIPTION
## Summary
- show error message for inconsistent arrival times
- test negative arrival diff

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adae841d688320a7de6c902278d3d9