### PR TITLE
Flush autosave before unload

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -128,6 +128,7 @@ export function setupAutosave(
 
   window.addEventListener('beforeunload', (e) => {
     if (dirty) {
+      flush(getActivePatientId(), undefined);
       e.preventDefault();
       e.returnValue = '';
     }


### PR DESCRIPTION
## Summary
- flush active patient data when navigating away if autosave is dirty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adafc896ec83209860fb55a3e6c783