### PR TITLE
feat: add summary PDF export

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -612,7 +612,8 @@ select.invalid {
 @media print {
   header,
   nav,
-  .toolbar {
+  .toolbar,
+  .sticky-actions {
     display: none !important;
   }
   body {

--- a/index.html
+++ b/index.html
@@ -1441,6 +1441,7 @@
           <div class="sticky-actions">
             
 <button id="copySummaryBtn" title="Kopijuoti santrauką" class="btn" >📋 <span class="btn-label">Kopijuoti</span></button>
+<button id="exportSummaryBtn" title="Eksportuoti santrauką" class="btn" >🖨️ <span class="btn-label">PDF</span></button>
 
           </div>
         </section>

--- a/js/app.js
+++ b/js/app.js
@@ -2,7 +2,12 @@ import { $, $$, getInputs } from './state.js';
 import { setNow, triggerChange, sleepMidpoint } from './time.js';
 import { openTimePicker } from './timePicker.js';
 import { updateDrugDefaults, calcDrugs } from './drugs.js';
-import { collectSummaryData, summaryTemplate, copySummary } from './summary.js';
+import {
+  collectSummaryData,
+  summaryTemplate,
+  copySummary,
+  exportSummaryPDF,
+} from './summary.js';
 import { showToast } from './toast.js';
 import { updateAge } from './age.js';
 import { initArrival } from './arrival.js';
@@ -142,6 +147,15 @@ function bind() {
     const data = collectSummaryData(patient);
     const text = copySummary(data);
     patient.summary = text;
+  });
+  $('#exportSummaryBtn').addEventListener('click', () => {
+    const patient = getActivePatient();
+    if (!patient) return;
+    const data = collectSummaryData(patient);
+    const text = summaryTemplate(data);
+    inputs.summary.value = text;
+    patient.summary = text;
+    exportSummaryPDF(data);
   });
 
   // Copy personal code

--- a/js/summary.js
+++ b/js/summary.js
@@ -186,3 +186,29 @@ export function copySummary(data) {
   }
   return inputs.summary.value;
 }
+
+export function exportSummaryPDF(data) {
+  const text = summaryTemplate(data);
+  const printWindow = window.open('', '', 'width=800,height=600');
+  if (!printWindow) {
+    showToast('Nepavyko atidaryti spausdinimo lango', { type: 'error' });
+    return;
+  }
+  const esc = (s) =>
+    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  printWindow.document.write(`
+    <html>
+      <head>
+        <title>Santrauka</title>
+        <style>
+          body { font-family: monospace; white-space: pre-wrap; padding: 16px; }
+          pre { margin: 0; }
+        </style>
+      </head>
+      <body><pre>${esc(text)}</pre></body>
+    </html>
+  `);
+  printWindow.document.close();
+  printWindow.focus();
+  printWindow.print();
+}


### PR DESCRIPTION
## Summary
- add exportSummaryPDF to generate printable summary view
- add PDF export button and wire up click handler
- hide interactive controls when printing for clean layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adbbc5ef808320b02e74d2dbbfc180