### PR TITLE
Add ARIA roles to navigation tabs

### DIFF
--- a/templates/partials/nav.njk
+++ b/templates/partials/nav.njk
@@ -1,20 +1,50 @@
-<nav id="mainNav">
-  <a href="#activation" data-section="activation" class="tab active"
+<nav id="mainNav" role="tablist">
+  <a
+    id="activation-tab"
+    href="#activation"
+    data-section="activation"
+    class="tab active"
+    role="tab"
     ><span class="tab-icon">🚨</span>Aktyvacija</a
   >
-  <a href="#arrival" data-section="arrival" class="tab"
+  <a
+    id="arrival-tab"
+    href="#arrival"
+    data-section="arrival"
+    class="tab"
+    role="tab"
     ><span class="tab-icon">🚑</span>Paciento atvykimas</a
   >
-  <a href="#nihss" data-section="nihss" class="tab"
+  <a
+    id="nihss-tab"
+    href="#nihss"
+    data-section="nihss"
+    class="tab"
+    role="tab"
     ><span class="tab-icon">🧮</span>NIHSS</a
   >
-  <a href="#thrombolysis" data-section="thrombolysis" class="tab"
+  <a
+    id="thrombolysis-tab"
+    href="#thrombolysis"
+    data-section="thrombolysis"
+    class="tab"
+    role="tab"
     ><span class="tab-icon">🩸</span>Pasiruošimas trombolizei</a
   >
-  <a href="#decision" data-section="decision" class="tab"
+  <a
+    id="decision-tab"
+    href="#decision"
+    data-section="decision"
+    class="tab"
+    role="tab"
     ><span class="tab-icon">☑️</span>Sprendimas</a
   >
-  <a href="#summarySec" data-section="summarySec" class="tab"
+  <a
+    id="summarySec-tab"
+    href="#summarySec"
+    data-section="summarySec"
+    class="tab"
+    role="tab"
     ><span class="tab-icon">📄</span>Santrauka</a
   >
 </nav>

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -1,4 +1,9 @@
-        <section id="activation" class="card">
+        <section
+          id="activation"
+          class="card"
+          role="tabpanel"
+          aria-labelledby="activation-tab"
+        >
           <h2>Komandos aktyvacija</h2>
           <form>
             <fieldset>

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -1,5 +1,10 @@
         <!-- Paciento atvykimas -->
-        <section id="arrival" class="card hidden">
+        <section
+          id="arrival"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="arrival-tab"
+        >
           <h2>Paciento atvykimas</h2>
           <div class="arrival-timer">Nuo atvykimo: <span id="door_timer"></span></div>
           <div class="arrival-timer">Nuo simptomų pradžios: <span id="onset_timer"></span></div>

--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -1,5 +1,10 @@
         <!-- Sprendimas -->
-        <section id="decision" class="card hidden">
+        <section
+          id="decision"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="decision-tab"
+        >
           <h2>Sprendimas</h2>
           <form>
             <fieldset>

--- a/templates/sections/nihss.njk
+++ b/templates/sections/nihss.njk
@@ -1,5 +1,10 @@
         <!-- NIHSS -->
-        <section id="nihss" class="card hidden">
+        <section
+          id="nihss"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="nihss-tab"
+        >
           <h2>NIHSS</h2>
           <form>
             <fieldset class="nihss-layout">

--- a/templates/sections/summary.njk
+++ b/templates/sections/summary.njk
@@ -1,5 +1,10 @@
         <!-- Santrauka HIS sistemai -->
-        <section id="summarySec" class="card full-span hidden">
+        <section
+          id="summarySec"
+          class="card full-span hidden"
+          role="tabpanel"
+          aria-labelledby="summarySec-tab"
+        >
           <h2>Santrauka (kopijavimui į HIS)</h2>
           <textarea
             id="summary"

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -1,5 +1,10 @@
         <!-- Pasiruošimas trombolizei -->
-        <section id="thrombolysis" class="card hidden">
+        <section
+          id="thrombolysis"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="thrombolysis-tab"
+        >
           <h2>Pasiruošimas trombolizei</h2>
           <form>
             <div class="grid-3">


### PR DESCRIPTION
## Summary
- Add WAI-ARIA roles to navigation: `role="tablist"` for the nav and `role="tab"` with unique IDs for each link
- Mark each main content section as `role="tabpanel"` and connect it to its tab via `aria-labelledby`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade00dc5d083208acd51d7391ff6f4