### PR TITLE
chore(ci): run tests and lint on node lts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 jobs:
   build:
@@ -14,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: lts/*
       - run: npm ci
       - run: npm test
-      - run: npm run format -- --check
+      - run: npm run lint


### PR DESCRIPTION
## Summary
- use Node.js LTS in CI workflow
- run npm test and npm run lint on pushes and pull requests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ade161f67883208df5709c3248e089