### PR TITLE
Show toast when LKW under 4.5 hours

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -83,4 +83,13 @@ export function initActivation() {
       }
     });
   });
+
+  const lkwInputs = dom.getALkwInputs();
+  lkwInputs.forEach((el) => {
+    el.addEventListener('change', () => {
+      if (el.value === '<4.5') {
+        showToast('Aktyvuokite insulto komandą', { type: 'info' });
+      }
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Notify users to activate stroke team when last-known-well is under 4.5 hours.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68adebe4a5f48320a3153c3595e7280f