### PR TITLE
feat: warn SPS doctor for 4.5-24h cases

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -85,11 +85,34 @@ export function initActivation() {
   });
 
   const lkwInputs = dom.getALkwInputs();
+  const spsInput = lkwInputs.find((el) => el.value === '4.5-24');
+  let spsBadge;
+  if (spsInput) {
+    const label = spsInput.closest('label');
+    if (label) {
+      spsBadge = document.createElement('span');
+      spsBadge.className = 'badge';
+      spsBadge.textContent = 'SPS';
+      spsBadge.style.display = 'none';
+      label.appendChild(spsBadge);
+    }
+  }
+
+  const updateLkwBadge = () => {
+    if (spsBadge && spsInput) {
+      spsBadge.style.display = spsInput.checked ? 'inline-block' : 'none';
+    }
+  };
+
   lkwInputs.forEach((el) => {
     el.addEventListener('change', () => {
       if (el.value === '<4.5') {
         showToast('Aktyvuokite insulto komandą', { type: 'info' });
+      } else if (el.value === '4.5-24') {
+        showToast('Informuokite SPS gydytoją', { type: 'warning' });
       }
+      updateLkwBadge();
     });
   });
+  updateLkwBadge();
 }


### PR DESCRIPTION
## Summary
- warn SPS doctor when LKW is between 4.5-24 hours
- show badge next to the 4.5-24 hour option

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aded396ac883208525578c0425f203