### PR TITLE
refactor: centralize DOM input accessors

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -1,4 +1,4 @@
-import * as dom from './state.js';
+import { dom } from './state.js';
 import { showToast } from './toast.js';
 
 function setValidity(el, valid, message) {

--- a/js/age.js
+++ b/js/age.js
@@ -1,4 +1,4 @@
-import * as dom from './state.js';
+import { dom } from './state.js';
 
 export function calcAge(dob) {
   if (!dob) return '';

--- a/js/drugs.js
+++ b/js/drugs.js
@@ -1,4 +1,4 @@
-import * as dom from './state.js';
+import { dom } from './state.js';
 import { computeDose } from './computeDose.js';
 
 export function updateDrugDefaults() {

--- a/js/state.js
+++ b/js/state.js
@@ -6,115 +6,101 @@ export const state = {
   autosave: 'on',
 };
 
-// Individual DOM accessors
-export const getWeightInput = () => $('#p_weight');
-export const getBpInput = () => $('#p_bp');
-export const getInrInput = () => $('#p_inr');
-export const getNih0Input = () => $('#p_nihss0');
-export const getLkwInput = () => $('#t_lkw');
-export const getDoorInput = () => $('#t_door');
-export const getDTimeInput = () => $('#d_time');
-export const getDDecisionInputs = () => $$('input[name="d_decision"]');
-export const getLkwTypeInputs = () => $$('input[name="lkw_type"]');
-export const getSleepStartInput = () => $('#t_sleep_start');
-export const getSleepEndInput = () => $('#t_sleep_end');
-export const getArrivalSymptomsInput = () => $('#arrival_symptoms');
-export const getArrivalContraInputs = () => $$('input[name="arrival_contra"]');
-export const getArrivalMtContraInputs = () =>
-  $$('input[name="arrival_mt_contra"]');
-export const getDrugTypeInput = () => $('#drug_type');
-export const getDrugConcInput = () => $('#drug_conc');
-export const getDoseTotalInput = () => $('#dose_total');
-export const getDoseVolInput = () => $('#dose_volume');
-export const getTpaBolusInput = () => $('#tpa_bolus');
-export const getTpaInfInput = () => $('#tpa_infusion');
-export const getDefTnkInput = () => $('#def_tnk');
-export const getDefTpaInput = () => $('#def_tpa');
-export const getThrombolysisStartInput = () => $('#t_thrombolysis');
-export const getAutosaveInput = () => $('#autosave');
-export const getSummaryInput = () => $('#summary');
-export const getPatientSelect = () => $('#patientSelect');
-export const getAPersonalInput = () => $('#a_personal');
-export const getANameInput = () => $('#a_name');
-export const getADobInput = () => $('#a_dob');
-export const getAAgeInput = () => $('#a_age');
-export const getAGmpTimeInput = () => $('#a_gmp_time');
-export const getASymFaceInputs = () => $$('input[name="a_face"]');
-export const getASymSpeechInputs = () => $$('input[name="a_speech"]');
-export const getASymCommandsInputs = () => $$('input[name="a_commands"]');
-export const getASymArmInputs = () => $$('input[name="a_arm"]');
-export const getASymLegInputs = () => $$('input[name="a_leg"]');
-export const getASymGazeInputs = () => $$('input[name="a_gaze"]');
-export const getAWarfarinInput = () => $('#a_warfarin');
-export const getAApixabanInput = () => $('#a_apixaban');
-export const getARivaroxabanInput = () => $('#a_rivaroxaban');
-export const getADabigatranInput = () => $('#a_dabigatran');
-export const getAEdoxabanInput = () => $('#a_edoxaban');
-export const getAUnknownInput = () => $('#a_unknown');
-export const getADrugsInputs = () => $$('#a_drugs input[type="checkbox"]');
-export const getALkwInputs = () => $$('input[name="a_lkw"]');
-export const getAGlucoseInput = () => $('#a_glucose');
-export const getAAksInput = () => $('#a_aks');
-export const getAHrInput = () => $('#a_hr');
-export const getASpo2Input = () => $('#a_spo2');
-export const getATempInput = () => $('#a_temp');
+/**
+ * @typedef {HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement} InputEl
+ * @typedef {InputEl[]} InputElList
+ */
 
-// Convenience aggregator for tests
+/**
+ * Map of known input selectors. `true` means all matching elements are returned.
+ * @type {Record<string, [string, boolean?]>}
+ */
+const selectorMap = {
+  weight: ['#p_weight'],
+  bp: ['#p_bp'],
+  inr: ['#p_inr'],
+  nih0: ['#p_nihss0'],
+  lkw: ['#t_lkw'],
+  door: ['#t_door'],
+  d_time: ['#d_time'],
+  d_decision: ['input[name="d_decision"]', true],
+  lkw_type: ['input[name="lkw_type"]', true],
+  sleep_start: ['#t_sleep_start'],
+  sleep_end: ['#t_sleep_end'],
+  arrival_symptoms: ['#arrival_symptoms'],
+  arrival_contra: ['input[name="arrival_contra"]', true],
+  arrival_mt_contra: ['input[name="arrival_mt_contra"]', true],
+  drugType: ['#drug_type'],
+  drugConc: ['#drug_conc'],
+  doseTotal: ['#dose_total'],
+  doseVol: ['#dose_volume'],
+  tpaBolus: ['#tpa_bolus'],
+  tpaInf: ['#tpa_infusion'],
+  def_tnk: ['#def_tnk'],
+  def_tpa: ['#def_tpa'],
+  t_thrombolysis: ['#t_thrombolysis'],
+  autosave: ['#autosave'],
+  summary: ['#summary'],
+  patientSelect: ['#patientSelect'],
+  a_personal: ['#a_personal'],
+  a_name: ['#a_name'],
+  a_dob: ['#a_dob'],
+  a_age: ['#a_age'],
+  a_gmp_time: ['#a_gmp_time'],
+  a_sym_face: ['input[name="a_face"]', true],
+  a_sym_speech: ['input[name="a_speech"]', true],
+  a_sym_commands: ['input[name="a_commands"]', true],
+  a_sym_arm: ['input[name="a_arm"]', true],
+  a_sym_leg: ['input[name="a_leg"]', true],
+  a_sym_gaze: ['input[name="a_gaze"]', true],
+  a_warfarin: ['#a_warfarin'],
+  a_apixaban: ['#a_apixaban'],
+  a_rivaroxaban: ['#a_rivaroxaban'],
+  a_dabigatran: ['#a_dabigatran'],
+  a_edoxaban: ['#a_edoxaban'],
+  a_unknown: ['#a_unknown'],
+  a_drugs: ['#a_drugs input[type="checkbox"]', true],
+  a_lkw: ['input[name="a_lkw"]', true],
+  a_glucose: ['#a_glucose'],
+  a_aks: ['#a_aks'],
+  a_hr: ['#a_hr'],
+  a_spo2: ['#a_spo2'],
+  a_temp: ['#a_temp'],
+};
+
+function toPascal(key) {
+  return key.replace(/(^|_)([a-z])/g, (_, __, c) => c.toUpperCase());
+}
+
+/**
+ * Generated DOM accessor functions.
+ * @type {Record<string, () => InputEl | InputElList>}
+ */
+export const dom = Object.fromEntries(
+  Object.entries(selectorMap).map(([key, [sel, all]]) => {
+    const fnName = `get${toPascal(key)}${all ? 'Inputs' : 'Input'}`;
+    /** @returns {InputEl | InputElList} */
+    const fn = () => (all ? $$ : $)(sel);
+    return [fnName, fn];
+  }),
+);
+
+/**
+ * Convenience aggregator for tests and other consumers.
+ * @returns {Record<keyof typeof selectorMap, InputEl | InputElList>}
+ */
 export function getInputs() {
-  return {
-    weight: getWeightInput(),
-    bp: getBpInput(),
-    inr: getInrInput(),
-    nih0: getNih0Input(),
-    lkw: getLkwInput(),
-    sleep_start: getSleepStartInput(),
-    sleep_end: getSleepEndInput(),
-    door: getDoorInput(),
-    d_time: getDTimeInput(),
-    d_decision: getDDecisionInputs(),
-    lkw_type: getLkwTypeInputs(),
-    arrival_symptoms: getArrivalSymptomsInput(),
-    arrival_contra: getArrivalContraInputs(),
-    arrival_mt_contra: getArrivalMtContraInputs(),
-    drugType: getDrugTypeInput(),
-    drugConc: getDrugConcInput(),
-    doseTotal: getDoseTotalInput(),
-    doseVol: getDoseVolInput(),
-    tpaBolus: getTpaBolusInput(),
-    tpaInf: getTpaInfInput(),
-    def_tnk: getDefTnkInput(),
-    def_tpa: getDefTpaInput(),
-    t_thrombolysis: getThrombolysisStartInput(),
-    autosave: getAutosaveInput(),
-    summary: getSummaryInput(),
-    patientSelect: getPatientSelect(),
-    a_personal: getAPersonalInput(),
-    a_name: getANameInput(),
-    a_dob: getADobInput(),
-    a_age: getAAgeInput(),
-    a_gmp_time: getAGmpTimeInput(),
-    a_sym_face: getASymFaceInputs(),
-    a_sym_speech: getASymSpeechInputs(),
-    a_sym_commands: getASymCommandsInputs(),
-    a_sym_arm: getASymArmInputs(),
-    a_sym_leg: getASymLegInputs(),
-    a_sym_gaze: getASymGazeInputs(),
-    a_warfarin: getAWarfarinInput(),
-    a_apixaban: getAApixabanInput(),
-    a_rivaroxaban: getARivaroxabanInput(),
-    a_dabigatran: getADabigatranInput(),
-    a_edoxaban: getAEdoxabanInput(),
-    a_drugs: getADrugsInputs(),
-    a_unknown: getAUnknownInput(),
-    a_lkw: getALkwInputs(),
-    a_glucose: getAGlucoseInput(),
-    a_aks: getAAksInput(),
-    a_hr: getAHrInput(),
-    a_spo2: getASpo2Input(),
-    a_temp: getATempInput(),
-  };
+  /** @type {Record<string, InputEl | InputElList>} */
+  const inputs = {};
+  for (const [key, [, all]] of Object.entries(selectorMap)) {
+    const fnName = `get${toPascal(key)}${all ? 'Inputs' : 'Input'}`;
+    inputs[key] = dom[fnName]();
+  }
+  return /** @type {Record<keyof typeof selectorMap, InputEl | InputElList>} */ (
+    inputs
+  );
 }
 
 if (typeof document !== 'undefined') {
-  state.autosave = getAutosaveInput()?.value || 'on';
+  state.autosave = dom.getAutosaveInput()?.value || 'on';
 }

--- a/js/storage.js
+++ b/js/storage.js
@@ -1,10 +1,8 @@
-import * as dom from './state.js';
+import { state, getInputs } from './state.js';
 import { updateDrugDefaults } from './drugs.js';
 import { updateAge } from './age.js';
 import { setNow } from './time.js';
 import { openTimePicker } from './timePicker.js';
-
-const { state } = dom;
 
 const LS_KEY = 'insultoKomandaPatients_v1';
 // Current version of the payload schema stored in localStorage
@@ -86,7 +84,7 @@ function setRadioValue(nodes, value) {
 }
 
 export function getPayload() {
-  const inputs = dom.getInputs();
+  const inputs = getInputs();
   const bp_meds = Array.from(
     document.querySelectorAll('#bpEntries .bp-entry'),
   ).map((entry) => {
@@ -161,7 +159,7 @@ export function getPayload() {
 export function setPayload(p) {
   if (!p) return;
   const payload = p.version !== undefined ? p.data : p;
-  const inputs = dom.getInputs();
+  const inputs = getInputs();
   if (inputs.weight) inputs.weight.value = payload.p_weight || '';
   if (inputs.bp) inputs.bp.value = payload.p_bp || '';
   if (inputs.inr) inputs.inr.value = payload.p_inr || '';
@@ -352,7 +350,7 @@ export function setPayload(p) {
 }
 
 export function savePatient(id, name) {
-  const inputs = dom.getInputs();
+  const inputs = getInputs();
   const patients = getPatients();
   const patientId = id || Date.now().toString();
   const now = new Date().toISOString();

--- a/js/summary.js
+++ b/js/summary.js
@@ -1,4 +1,4 @@
-import * as dom from './state.js';
+import { getInputs } from './state.js';
 import { showToast } from './toast.js';
 
 export function collectSummaryData(payload) {
@@ -173,7 +173,7 @@ export function summaryTemplate({
 }
 
 export function copySummary(data) {
-  const inputs = dom.getInputs();
+  const inputs = getInputs();
   if (inputs.summary) inputs.summary.value = summaryTemplate(data);
   if (window.isSecureContext && navigator.clipboard) {
     navigator.clipboard.writeText(inputs.summary.value).catch((err) => {


### PR DESCRIPTION
## Summary
- generate DOM accessors from a selector map instead of exporting many functions
- add JSDoc types for form elements to improve editor hints
- update modules to consume new `dom` accessors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae984fa8b08320870a1301df9fbe64