### PR TITLE
chore: expand format script and run prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prettier": "^3.2.5"
   },
   "scripts": {
-    "format": "prettier --write js/*.js",
+    "format": "prettier --write \"js/**/*.js\" \"test/**/*.js\"",
     "test": "node --test",
     "build": "node build.js",
     "prepare": "husky install",

--- a/test/age.test.js
+++ b/test/age.test.js
@@ -22,7 +22,10 @@ test('calcAge and updateAge compute and display age correctly', async () => {
   assert.strictEqual(calcAge('2000-01-01'), '24');
   updateAge();
   assert.strictEqual(inputs.a_age.value, '24');
-  assert.strictEqual(document.getElementById('a_age_display').textContent, '24 m.');
+  assert.strictEqual(
+    document.getElementById('a_age_display').textContent,
+    '24 m.',
+  );
 
   inputs.a_dob.value = '';
   updateAge();

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -6,9 +6,13 @@ test('copySummary builds data object and copies formatted text', async () => {
   const { getInputs } = await import('../js/state.js');
   const inputs = getInputs();
   const { getPayload } = await import('../js/storage.js');
-  const { collectSummaryData, summaryTemplate, copySummary } = await import('../js/summary.js');
+  const { collectSummaryData, summaryTemplate, copySummary } = await import(
+    '../js/summary.js'
+  );
 
-  document.querySelector('input[name="d_decision"][value="Taikoma IVT, indikacijų MTE nenustatyta"]').checked = true;
+  document.querySelector(
+    'input[name="d_decision"][value="Taikoma IVT, indikacijų MTE nenustatyta"]',
+  ).checked = true;
   document.querySelector('input[name="a_lkw"][value="<4.5"]').checked = true;
   document.querySelector('input[name="a_face"]').checked = true;
   document.querySelector('input[name="a_speech"]').checked = true;

--- a/test/jsdomSetup.js
+++ b/test/jsdomSetup.js
@@ -15,7 +15,11 @@ function applyDom() {
   Object.defineProperty(global, 'navigator', {
     value: {
       ...dom.window.navigator,
-      clipboard: { writeText: async (txt) => { global.__copied = txt; } },
+      clipboard: {
+        writeText: async (txt) => {
+          global.__copied = txt;
+        },
+      },
     },
     configurable: true,
   });

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -73,7 +73,10 @@ test(
 
     assert.ok(global.__copied.includes('PACIENTAS'));
     assert.ok(global.__copied.includes('NIHSS pradinis: 5'));
-    assert.strictEqual(document.getElementById('summary').value, global.__copied);
+    assert.strictEqual(
+      document.getElementById('summary').value,
+      global.__copied,
+    );
   },
 );
 

--- a/test/modal.test.js
+++ b/test/modal.test.js
@@ -5,119 +5,130 @@ import { showModal, confirmModal, promptModal } from '../js/modal.js';
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
 
-test('showModal traps focus and cleans up on Escape', { concurrency: false }, async () => {
-  const outside = document.createElement('button');
-  document.body.appendChild(outside);
-  outside.focus();
+test(
+  'showModal traps focus and cleans up on Escape',
+  { concurrency: false },
+  async () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
 
-  const promise = showModal({
-    title: 'test',
-    buttons: [
-      { label: 'A', value: 'a', autofocus: true },
-      { label: 'B', value: 'b' },
-    ],
-  });
+    const promise = showModal({
+      title: 'test',
+      buttons: [
+        { label: 'A', value: 'a', autofocus: true },
+        { label: 'B', value: 'b' },
+      ],
+    });
 
-  await tick();
-  const overlay = document.querySelector('.modal-overlay');
-  const [btnA, btnB] = overlay.querySelectorAll('button');
-  assert.strictEqual(document.activeElement, btnA);
+    await tick();
+    const overlay = document.querySelector('.modal-overlay');
+    const [btnA, btnB] = overlay.querySelectorAll('button');
+    assert.strictEqual(document.activeElement, btnA);
 
-  btnB.focus();
-  btnB.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, btnA);
+    btnB.focus();
+    btnB.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, btnA);
 
-  btnA.focus();
-  btnA.dispatchEvent(
-    new window.KeyboardEvent('keydown', {
-      key: 'Tab',
-      shiftKey: true,
-      bubbles: true,
-    }),
-  );
-  assert.strictEqual(document.activeElement, btnB);
+    btnA.focus();
+    btnA.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    assert.strictEqual(document.activeElement, btnB);
 
-  btnB.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-  );
-  const res = await promise;
-  assert.strictEqual(res, null);
-  assert.strictEqual(document.querySelector('.modal-overlay'), null);
-  assert.strictEqual(document.activeElement, outside);
-});
+    btnB.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    const res = await promise;
+    assert.strictEqual(res, null);
+    assert.strictEqual(document.querySelector('.modal-overlay'), null);
+    assert.strictEqual(document.activeElement, outside);
+  },
+);
 
-test('confirmModal traps focus and resolves null on Escape', { concurrency: false }, async () => {
-  const outside = document.createElement('button');
-  document.body.appendChild(outside);
-  outside.focus();
+test(
+  'confirmModal traps focus and resolves null on Escape',
+  { concurrency: false },
+  async () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
 
-  const promise = confirmModal('Confirm?');
-  await tick();
-  const overlay = document.querySelector('.modal-overlay');
-  const [okBtn, cancelBtn] = overlay.querySelectorAll('button');
-  assert.strictEqual(document.activeElement, okBtn);
+    const promise = confirmModal('Confirm?');
+    await tick();
+    const overlay = document.querySelector('.modal-overlay');
+    const [okBtn, cancelBtn] = overlay.querySelectorAll('button');
+    assert.strictEqual(document.activeElement, okBtn);
 
-  cancelBtn.focus();
-  cancelBtn.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, okBtn);
+    cancelBtn.focus();
+    cancelBtn.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, okBtn);
 
-  okBtn.focus();
-  okBtn.dispatchEvent(
-    new window.KeyboardEvent('keydown', {
-      key: 'Tab',
-      shiftKey: true,
-      bubbles: true,
-    }),
-  );
-  assert.strictEqual(document.activeElement, cancelBtn);
+    okBtn.focus();
+    okBtn.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    assert.strictEqual(document.activeElement, cancelBtn);
 
-  cancelBtn.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-  );
-  const res = await promise;
-  assert.strictEqual(res, null);
-  assert.strictEqual(document.querySelector('.modal-overlay'), null);
-  assert.strictEqual(document.activeElement, outside);
-});
+    cancelBtn.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    const res = await promise;
+    assert.strictEqual(res, null);
+    assert.strictEqual(document.querySelector('.modal-overlay'), null);
+    assert.strictEqual(document.activeElement, outside);
+  },
+);
 
-test('promptModal traps focus across fields and resolves null on Escape', { concurrency: false }, async () => {
-  const outside = document.createElement('button');
-  document.body.appendChild(outside);
-  outside.focus();
+test(
+  'promptModal traps focus across fields and resolves null on Escape',
+  { concurrency: false },
+  async () => {
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
 
-  const promise = promptModal('Prompt', 'x');
-  await tick();
-  const overlay = document.querySelector('.modal-overlay');
-  const input = overlay.querySelector('input');
-  const [okBtn, cancelBtn] = overlay.querySelectorAll('button');
-  assert.strictEqual(document.activeElement, okBtn);
+    const promise = promptModal('Prompt', 'x');
+    await tick();
+    const overlay = document.querySelector('.modal-overlay');
+    const input = overlay.querySelector('input');
+    const [okBtn, cancelBtn] = overlay.querySelectorAll('button');
+    assert.strictEqual(document.activeElement, okBtn);
 
-  cancelBtn.focus();
-  cancelBtn.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, input);
+    cancelBtn.focus();
+    cancelBtn.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Tab', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, input);
 
-  input.focus();
-  input.dispatchEvent(
-    new window.KeyboardEvent('keydown', {
-      key: 'Tab',
-      shiftKey: true,
-      bubbles: true,
-    }),
-  );
-  assert.strictEqual(document.activeElement, cancelBtn);
+    input.focus();
+    input.dispatchEvent(
+      new window.KeyboardEvent('keydown', {
+        key: 'Tab',
+        shiftKey: true,
+        bubbles: true,
+      }),
+    );
+    assert.strictEqual(document.activeElement, cancelBtn);
 
-  cancelBtn.dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
-  );
-  const res = await promise;
-  assert.strictEqual(res, null);
-  assert.strictEqual(document.querySelector('.modal-overlay'), null);
-  assert.strictEqual(document.activeElement, outside);
-});
-
+    cancelBtn.dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'Escape', bubbles: true }),
+    );
+    const res = await promise;
+    assert.strictEqual(res, null);
+    assert.strictEqual(document.querySelector('.modal-overlay'), null);
+    assert.strictEqual(document.activeElement, outside);
+  },
+);

--- a/test/navigation.test.js
+++ b/test/navigation.test.js
@@ -3,11 +3,14 @@ import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 import { setupNavigation } from '../js/navigation.js';
 
-test('arrow key navigation updates focus, sections and hash', { concurrency: false }, () => {
-  // reset url
-  window.history.replaceState(null, '', 'http://localhost/');
+test(
+  'arrow key navigation updates focus, sections and hash',
+  { concurrency: false },
+  () => {
+    // reset url
+    window.history.replaceState(null, '', 'http://localhost/');
 
-  document.body.innerHTML = `
+    document.body.innerHTML = `
     <button id="navToggle"></button>
     <nav>
       <a href="#sec1" class="tab" data-section="sec1">One</a>
@@ -21,53 +24,54 @@ test('arrow key navigation updates focus, sections and hash', { concurrency: fal
     </main>
   `;
 
-  const inputs = { summary: { value: '' }, d_time: { value: '' } };
-  global.location = window.location;
-  global.history = window.history;
-  const { activateFromHash } = setupNavigation(inputs);
-  activateFromHash();
+    const inputs = { summary: { value: '' }, d_time: { value: '' } };
+    global.location = window.location;
+    global.history = window.history;
+    const { activateFromHash } = setupNavigation(inputs);
+    activateFromHash();
 
-  const tabs = document.querySelectorAll('nav .tab');
-  const sections = document.querySelectorAll('main > section');
+    const tabs = document.querySelectorAll('nav .tab');
+    const sections = document.querySelectorAll('main > section');
 
-  // Initial state: first section visible
-  assert.ok(!sections[0].classList.contains('hidden'));
-  assert.ok(sections[1].classList.contains('hidden'));
+    // Initial state: first section visible
+    assert.ok(!sections[0].classList.contains('hidden'));
+    assert.ok(sections[1].classList.contains('hidden'));
 
-  // Move to next tab with ArrowRight
-  tabs[0].focus();
-  tabs[0].dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, tabs[1]);
-  assert.ok(sections[0].classList.contains('hidden'));
-  assert.ok(!sections[1].classList.contains('hidden'));
-  assert.strictEqual(window.location.hash, '#sec2');
+    // Move to next tab with ArrowRight
+    tabs[0].focus();
+    tabs[0].dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, tabs[1]);
+    assert.ok(sections[0].classList.contains('hidden'));
+    assert.ok(!sections[1].classList.contains('hidden'));
+    assert.strictEqual(window.location.hash, '#sec2');
 
-  // Move back with ArrowLeft
-  tabs[1].dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, tabs[0]);
-  assert.ok(!sections[0].classList.contains('hidden'));
-  assert.ok(sections[1].classList.contains('hidden'));
-  assert.strictEqual(window.location.hash, '#sec1');
+    // Move back with ArrowLeft
+    tabs[1].dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, tabs[0]);
+    assert.ok(!sections[0].classList.contains('hidden'));
+    assert.ok(sections[1].classList.contains('hidden'));
+    assert.strictEqual(window.location.hash, '#sec1');
 
-  // Wrap around: ArrowLeft from first goes to last
-  tabs[0].dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, tabs[2]);
-  assert.ok(sections[0].classList.contains('hidden'));
-  assert.ok(!sections[2].classList.contains('hidden'));
-  assert.strictEqual(window.location.hash, '#sec3');
+    // Wrap around: ArrowLeft from first goes to last
+    tabs[0].dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, tabs[2]);
+    assert.ok(sections[0].classList.contains('hidden'));
+    assert.ok(!sections[2].classList.contains('hidden'));
+    assert.strictEqual(window.location.hash, '#sec3');
 
-  // Wrap around forward: ArrowRight from last goes to first
-  tabs[2].dispatchEvent(
-    new window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
-  );
-  assert.strictEqual(document.activeElement, tabs[0]);
-  assert.ok(!sections[0].classList.contains('hidden'));
-  assert.ok(sections[2].classList.contains('hidden'));
-  assert.strictEqual(window.location.hash, '#sec1');
-});
+    // Wrap around forward: ArrowRight from last goes to first
+    tabs[2].dispatchEvent(
+      new window.KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }),
+    );
+    assert.strictEqual(document.activeElement, tabs[0]);
+    assert.ok(!sections[0].classList.contains('hidden'));
+    assert.ok(sections[2].classList.contains('hidden'));
+    assert.strictEqual(window.location.hash, '#sec1');
+  },
+);

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -6,9 +6,13 @@ test('summaryTemplate generates summary text correctly', async () => {
   const { getInputs } = await import('../js/state.js');
   const inputs = getInputs();
   const { getPayload } = await import('../js/storage.js');
-  const { collectSummaryData, summaryTemplate } = await import('../js/summary.js');
+  const { collectSummaryData, summaryTemplate } = await import(
+    '../js/summary.js'
+  );
 
-  document.querySelector('input[name="d_decision"][value="Taikoma IVT, indikacijų MTE nenustatyta"]').checked = true;
+  document.querySelector(
+    'input[name="d_decision"][value="Taikoma IVT, indikacijų MTE nenustatyta"]',
+  ).checked = true;
   document.querySelector('input[name="a_lkw"][value="<4.5"]').checked = true;
   document.querySelector('input[name="a_face"]').checked = true;
   document.querySelector('input[name="a_speech"]').checked = true;
@@ -48,11 +52,21 @@ test('summaryTemplate generates summary text correctly', async () => {
   assert(summary.includes('VAISTAI:\n- Tipas: Tenekteplazė'));
   assert(summary.includes('- Koncentracija: 5 mg/ml'));
   assert(summary.includes('- Bendra dozė: 20 mg (4 ml)'));
-  assert(summary.includes('AKS KOREKCIJA:\n- Kaptoprilis 10:00 25 mg (požymai)'));
-  assert(summary.includes('AKTYVACIJA:\n- Preliminarus susirgimo laikas: <4.5'));
+  assert(
+    summary.includes('AKS KOREKCIJA:\n- Kaptoprilis 10:00 25 mg (požymai)'),
+  );
+  assert(
+    summary.includes('AKTYVACIJA:\n- Preliminarus susirgimo laikas: <4.5'),
+  );
   assert(summary.includes('- Vartojami vaistai: Varfarinas'));
-  assert(summary.includes('- GMP parametrai: Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37'));
+  assert(
+    summary.includes(
+      '- GMP parametrai: Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37',
+    ),
+  );
   assert(summary.includes('SIMPTOMAI:\n- Veido paralyžius, Kalbos sutrikimas'));
   assert(summary.includes('- Dešinės rankos silpnumas'));
-  assert(summary.includes('SPRENDIMAS:\n- Taikoma IVT, indikacijų MTE nenustatyta'));
+  assert(
+    summary.includes('SPRENDIMAS:\n- Taikoma IVT, indikacijų MTE nenustatyta'),
+  );
 });

--- a/test/toast.test.js
+++ b/test/toast.test.js
@@ -14,24 +14,28 @@ beforeEach(() => {
   container.innerHTML = '';
 });
 
-test('queues messages and shows next on close', { concurrency: false }, async () => {
-  showToast('first', { duration: 10000 });
-  showToast('second', { duration: 10000 });
+test(
+  'queues messages and shows next on close',
+  { concurrency: false },
+  async () => {
+    showToast('first', { duration: 10000 });
+    showToast('second', { duration: 10000 });
 
-  const container = document.getElementById('toastContainer');
-  assert.equal(container.querySelectorAll('.toast').length, 1);
-  assert.match(container.querySelector('.toast').textContent, /first/);
-  assert.equal(toast.queue.length, 1);
+    const container = document.getElementById('toastContainer');
+    assert.equal(container.querySelectorAll('.toast').length, 1);
+    assert.match(container.querySelector('.toast').textContent, /first/);
+    assert.equal(toast.queue.length, 1);
 
-  const firstToast = container.querySelector('.toast');
-  const closeBtn = firstToast.querySelector('.toast-close');
-  closeBtn.dispatchEvent(new window.Event('click', { bubbles: true }));
-  firstToast.dispatchEvent(new window.Event('transitionend'));
-  await new Promise((r) => setTimeout(r, 0));
+    const firstToast = container.querySelector('.toast');
+    const closeBtn = firstToast.querySelector('.toast-close');
+    closeBtn.dispatchEvent(new window.Event('click', { bubbles: true }));
+    firstToast.dispatchEvent(new window.Event('transitionend'));
+    await new Promise((r) => setTimeout(r, 0));
 
-  assert.equal(container.querySelectorAll('.toast').length, 1);
-  assert.match(container.querySelector('.toast').textContent, /second/);
-});
+    assert.equal(container.querySelectorAll('.toast').length, 1);
+    assert.match(container.querySelector('.toast').textContent, /second/);
+  },
+);
 
 test('shows queued toast after timeout', { concurrency: false }, async () => {
   showToast('first', { duration: 10 });
@@ -49,4 +53,3 @@ test('shows queued toast after timeout', { concurrency: false }, async () => {
   assert.equal(container.querySelectorAll('.toast').length, 1);
   assert.match(container.querySelector('.toast').textContent, /second/);
 });
-


### PR DESCRIPTION
## Summary
- expand `format` script to format JS and test directories
- run Prettier to normalize existing test files

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae9e03af9c8320aa6d5feacb1f2c4b