### PR TITLE
Avoid duplicating symptoms in summary

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -153,9 +153,11 @@ export function summaryTemplate({
 
   if (activation.symptoms.length || arrivalSymptoms) {
     lines.push('SIMPTOMAI:');
-    if (activation.symptoms.length)
+    if (arrivalSymptoms) {
+      lines.push(`- ${arrivalSymptoms}`);
+    } else if (activation.symptoms.length) {
       lines.push(`- ${activation.symptoms.join(', ')}`);
-    if (arrivalSymptoms) lines.push(`- ${arrivalSymptoms}`);
+    }
   }
 
   if (arrivalContra) {

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -64,8 +64,8 @@ test('summaryTemplate generates summary text correctly', async () => {
       '- GMP parametrai: Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37',
     ),
   );
-  assert(summary.includes('SIMPTOMAI:\n- Veido paralyžius, Kalbos sutrikimas'));
-  assert(summary.includes('- Dešinės rankos silpnumas'));
+  assert(summary.includes('SIMPTOMAI:\n- Dešinės rankos silpnumas'));
+  assert(!summary.includes('Veido paralyžius'));
   assert(
     summary.includes('SPRENDIMAS:\n- Taikoma IVT, indikacijų MTE nenustatyta'),
   );


### PR DESCRIPTION
## Summary
- show only arrival symptoms in the summary when present
- adjust summary tests for updated symptom behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aea654708c8320a403217e142ed42d