### PR TITLE
Use textContent for toast close button

### DIFF
--- a/js/toast.js
+++ b/js/toast.js
@@ -19,7 +19,7 @@ const toast = {
     closeBtn.className = 'toast-close';
     closeBtn.setAttribute('aria-label', 'Close');
     closeBtn.setAttribute('tabindex', '0');
-    closeBtn.innerHTML = '&times;';
+    closeBtn.textContent = '×';
     el.appendChild(closeBtn);
 
     const hide = () => {

--- a/test/toast.test.js
+++ b/test/toast.test.js
@@ -28,6 +28,8 @@ test(
 
     const firstToast = container.querySelector('.toast');
     const closeBtn = firstToast.querySelector('.toast-close');
+    assert.equal(closeBtn.getAttribute('aria-label'), 'Close');
+    assert.equal(closeBtn.textContent, '×');
     closeBtn.dispatchEvent(new window.Event('click', { bubbles: true }));
     firstToast.dispatchEvent(new window.Event('transitionend'));
     await new Promise((r) => setTimeout(r, 0));


### PR DESCRIPTION
## Summary
- replace innerHTML for toast dismiss button with textContent
- test close button label and symbol

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aea7ffc64883208549a52af18c6bbc