### PR TITLE
Warn once per invalid interval

### DIFF
--- a/js/intervals.js
+++ b/js/intervals.js
@@ -9,6 +9,8 @@ const INTERVAL_LIMITS = {
 export function setupIntervals(inputs) {
   const lkwIntervalBox = document.getElementById('lkwThrombolysisInterval');
   const doorIntervalBox = document.getElementById('doorThrombolysisInterval');
+  let lkwToastShown = false;
+  let doorToastShown = false;
   const updateIntervals = () => {
     const thrombo = inputs.t_thrombolysis?.value;
     const lkw = inputs.lkw?.value;
@@ -20,16 +22,22 @@ export function setupIntervals(inputs) {
         lkwIntervalBox.textContent = `Paskutinį kartą matytas sveikas → trombolizė: ${diff} min`;
         const over = diff > INTERVAL_LIMITS.lkwThrombolysis;
         lkwIntervalBox.classList.toggle('error', over);
-        if (over)
-          showToast(
-            'Viršytas Paskutinį kartą matytas sveikas→trombolizės intervalas',
-            {
-              type: 'warning',
-            },
-          );
+        if (over) {
+          if (!lkwToastShown)
+            showToast(
+              'Viršytas Paskutinį kartą matytas sveikas→trombolizės intervalas',
+              {
+                type: 'warning',
+              },
+            );
+          lkwToastShown = true;
+        } else {
+          lkwToastShown = false;
+        }
       } else {
         lkwIntervalBox.textContent = '';
         lkwIntervalBox.classList.remove('error');
+        lkwToastShown = false;
       }
     }
 
@@ -39,13 +47,19 @@ export function setupIntervals(inputs) {
         doorIntervalBox.textContent = `Durys → trombolizė: ${diff} min`;
         const over = diff > INTERVAL_LIMITS.doorThrombolysis;
         doorIntervalBox.classList.toggle('error', over);
-        if (over)
-          showToast('Viršytas durų→trombolizės intervalas', {
-            type: 'warning',
-          });
+        if (over) {
+          if (!doorToastShown)
+            showToast('Viršytas durų→trombolizės intervalas', {
+              type: 'warning',
+            });
+          doorToastShown = true;
+        } else {
+          doorToastShown = false;
+        }
       } else {
         doorIntervalBox.textContent = '';
         doorIntervalBox.classList.remove('error');
+        doorToastShown = false;
       }
     }
   };


### PR DESCRIPTION
## Summary
- Avoid repeating warning toasts when intervals remain invalid
- Reset toast flags when intervals return to valid values

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeabc0625083208e28f35b65077550