### PR TITLE
Add autoprefixer and parallelize build

### DIFF
--- a/build.js
+++ b/build.js
@@ -2,6 +2,7 @@ import fs from 'fs/promises';
 import nunjucks from 'nunjucks';
 import postcss from 'postcss';
 import cssnano from 'cssnano';
+import autoprefixer from 'autoprefixer';
 
 nunjucks.configure('templates', { autoescape: false });
 
@@ -13,13 +14,12 @@ async function buildHtml() {
 async function buildCss() {
   const files = ['css/layout.css', 'css/components.css', 'css/forms.css'];
   const contents = await Promise.all(files.map(f => fs.readFile(f, 'utf8')));
-  const result = await postcss([cssnano]).process(contents.join('\n'), { from: undefined });
+  const result = await postcss([autoprefixer, cssnano]).process(contents.join('\n'), { from: undefined });
   await fs.writeFile('css/style.css', result.css);
 }
 
 try {
-  await buildHtml();
-  await buildCss();
+  await Promise.all([buildHtml(), buildCss()]);
 } catch (error) {
   console.error('Build failed:', error);
   process.exit(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "nunjucks": "^3.2.4"
       },
       "devDependencies": {
+        "autoprefixer": "^10.4.21",
         "axe-core": "^4.8.3",
         "cssnano": "^7.1.1",
         "eslint": "^9.34.0",
@@ -18,6 +19,9 @@
         "jsdom": "^24.0.0",
         "postcss": "^8.5.6",
         "prettier": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -461,6 +465,44 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.4.21",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
+      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.24.4",
+        "caniuse-lite": "^1.0.30001702",
+        "fraction.js": "^4.3.7",
+        "normalize-range": "^0.1.2",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
     },
     "node_modules/axe-core": {
       "version": "4.10.3",
@@ -1361,6 +1403,20 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fraction.js": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -1893,6 +1949,16 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-range": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "autoprefixer": "^10.4.21",
     "axe-core": "^4.8.3",
     "cssnano": "^7.1.1",
     "eslint": "^9.34.0",


### PR DESCRIPTION
## Summary
- install autoprefixer as a dev dependency
- process styles with autoprefixer and cssnano
- run HTML and CSS builds in parallel

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aeb49e5a988320a7b515ee6c591b85