### PR TITLE
Delegate autosave events to appForm container

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 </header>
 
   <div class="wrap layout-main">
-    
+
 <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
 
     <nav id="mainNav">
@@ -69,6 +69,7 @@
   >
 </nav>
 
+    <div id="appForm">
     <main class="px-0">
               <section id="activation" class="card">
           <h2>Komandos aktyvacija</h2>
@@ -1479,6 +1480,7 @@
         </div>
 
     </main>
+    </div>
   </div>
 
     <script type="module" src="js/app.js"></script>

--- a/js/autosave.js
+++ b/js/autosave.js
@@ -41,6 +41,7 @@ export function setupAutosave(
   };
 
   const saveStatus = document.getElementById('saveStatus');
+  const appForm = document.getElementById('appForm');
   const updateSaveStatus = () => {
     if (!saveStatus) return;
     const id = getActivePatientId();
@@ -130,8 +131,8 @@ export function setupAutosave(
       });
     }
   };
-  document.addEventListener('input', handleChange);
-  document.addEventListener('change', handleChange);
+  appForm?.addEventListener('input', handleChange);
+  appForm?.addEventListener('change', handleChange);
 
   window.addEventListener('beforeunload', (e) => {
     if (dirty) {

--- a/test/autosave.test.js
+++ b/test/autosave.test.js
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+test('autosave triggers on form input', { concurrency: false }, async () => {
+  const { setupAutosave } = await import('../js/autosave.js');
+  const { getInputs } = await import('../js/state.js');
+
+  const inputs = getInputs();
+  let called = false;
+  setupAutosave(inputs, {
+    scheduleSave(id, data, cb) {
+      called = true;
+      cb?.();
+    },
+    flushSave() {},
+  });
+
+  const field = document.getElementById('a_name');
+  field.value = 'Test';
+  field.dispatchEvent(new Event('input', { bubbles: true }));
+
+  assert.ok(called);
+});


### PR DESCRIPTION
## Summary
- wrap main content in `#appForm` container
- scope autosave event listeners to `#appForm`
- add unit test confirming autosave triggers on form input

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aeb6d5a48c8320911909e5fcfe29c2