### PR TITLE
refactor print window helper and test exportSummaryPDF

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -189,13 +189,19 @@ export function copySummary(data) {
   return inputs.summary.value;
 }
 
-export function exportSummaryPDF(data) {
-  const text = summaryTemplate(data);
-  const printWindow = window.open('', '', 'width=800,height=600');
+export function openPrintWindow(win) {
+  const printWindow = win.open('', '', 'width=800,height=600');
   if (!printWindow) {
     showToast('Nepavyko atidaryti spausdinimo lango', { type: 'error' });
-    return;
+    return null;
   }
+  return printWindow;
+}
+
+export function exportSummaryPDF(data, win = window) {
+  const text = summaryTemplate(data);
+  const printWindow = openPrintWindow(win);
+  if (!printWindow) return;
   const esc = (s) =>
     s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   printWindow.document.write(`

--- a/test/exportSummaryPDF.test.js
+++ b/test/exportSummaryPDF.test.js
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+function createData() {
+  return {
+    patient: {
+      personal: null,
+      name: 'Jonas <Doe>',
+      dob: null,
+      age: null,
+      weight: null,
+      bp: null,
+      inr: null,
+      nih0: null,
+    },
+    times: {
+      lkw: null,
+      door: null,
+      decision: null,
+      thrombolysis: null,
+      gmp: null,
+    },
+    drugs: {
+      type: '',
+      conc: null,
+      totalDose: null,
+      totalVol: null,
+      bolus: null,
+      infusion: null,
+    },
+    decision: null,
+    bpMeds: [],
+    activation: {
+      lkw: null,
+      drugs: [],
+      params: {
+        glucose: null,
+        aks: null,
+        hr: null,
+        spo2: null,
+        temp: null,
+      },
+      symptoms: [],
+    },
+    arrivalSymptoms: null,
+    arrivalContra: null,
+    arrivalMtContra: null,
+  };
+}
+
+test('exportSummaryPDF writes escaped summary to new window', async () => {
+  const data = createData();
+  const { exportSummaryPDF, summaryTemplate } = await import(
+    '../js/summary.js'
+  );
+  let html = '';
+  const stubPrintWindow = {
+    document: {
+      write: (content) => {
+        html += content;
+      },
+      close: () => {},
+    },
+    focus: () => {},
+    print: () => {},
+  };
+  const stubWindow = {
+    open: () => stubPrintWindow,
+  };
+  exportSummaryPDF(data, stubWindow);
+  const escaped = summaryTemplate(data)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+  assert.ok(html.includes('<title>Santrauka</title>'));
+  assert.ok(html.includes(`<pre>${escaped}</pre>`));
+});
+
+test('exportSummaryPDF shows error when window cannot be opened', async () => {
+  const data = createData();
+  const { exportSummaryPDF } = await import('../js/summary.js');
+  const { toast } = await import('../js/toast.js');
+  let message;
+  let options;
+  toast.showToast = (msg, opts) => {
+    message = msg;
+    options = opts;
+  };
+  const stubWindow = {
+    open: () => null,
+  };
+  exportSummaryPDF(data, stubWindow);
+  assert.equal(message, 'Nepavyko atidaryti spausdinimo lango');
+  assert.deepEqual(options, { type: 'error' });
+});


### PR DESCRIPTION
## Summary
- refactor `exportSummaryPDF` to use new `openPrintWindow` helper
- cover exportSummaryPDF with tests for HTML output and window-open failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeb9ec9050832085a92a5fb8746fa6