### PR TITLE
Add basic localization and language selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,10 @@
       </div>
     </div>
     <div class="header-actions">
+      <select id="langSelect" class="btn" title="Kalba" data-i18n-title="language" aria-label="Kalba" data-i18n-aria-label="language">
+        <option value="lt">LT</option>
+        <option value="en">EN</option>
+      </select>
       <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
       <details class="patient-menu">
         <summary>⋮</summary>
@@ -90,14 +94,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="a_gmp_time"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="a_gmp_time"
+      data-now="a_gmp_time" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -129,7 +133,7 @@
                   <label for="a_personal">Asmens kodas</label>
                   <div class="input-group">
                     <input id="a_personal" type="text" />
-                    <button id="copyPersonalBtn" type="button" class="btn ghost">
+                    <button id="copyPersonalBtn" type="button" class="btn ghost" data-i18n="copy">
                       Kopijuoti
                     </button>
                   </div>
@@ -322,14 +326,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="t_door"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="t_door"
+      data-now="t_door" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -385,14 +389,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="t_lkw"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="t_lkw"
+      data-now="t_lkw" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -433,14 +437,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="t_sleep_start"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="t_sleep_start"
+      data-now="t_sleep_start" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -481,14 +485,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="t_sleep_end"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="t_sleep_end"
+      data-now="t_sleep_end" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -1305,14 +1309,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="t_thrombolysis"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="t_thrombolysis"
+      data-now="t_thrombolysis" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -1366,14 +1370,14 @@
       type="button"
       class="btn ghost"
       data-time-picker="d_time"
-      aria-label="Pasirinkti datą ir laiką"
+      aria-label="Pasirinkti datą ir laiką" data-i18n-aria-label="select_date_time"
     >
       📅
     </button>
     <button
       type="button"
       class="btn ghost"
-      data-now="d_time"
+      data-now="d_time" data-i18n="now" data-i18n-aria-label="now"
       aria-label="Dabar"
     >
       Dabar
@@ -1445,14 +1449,14 @@
           ></textarea>
           <div class="sticky-actions">
             
-<button id="copySummaryBtn" title="Kopijuoti santrauką" class="btn" >📋 <span class="btn-label">Kopijuoti</span></button>
-<button id="exportSummaryBtn" title="Eksportuoti santrauką" class="btn" >🖨️ <span class="btn-label">PDF</span></button>
+<button id="copySummaryBtn" title="Kopijuoti santrauką" data-i18n-title="copy_summary" class="btn" >📋 <span class="btn-label" data-i18n="copy">Kopijuoti</span></button>
+<button id="exportSummaryBtn" title="Eksportuoti santrauką" data-i18n-title="export_summary" class="btn" >🖨️ <span class="btn-label" data-i18n="export_pdf">PDF</span></button>
 
           </div>
         </section>
 
-              <details class="settings">
-          <summary><span class="pill">⚙️ Nustatymai</span></summary>
+<details class="settings">
+          <summary><span class="pill">⚙️ <span data-i18n="settings">Nustatymai</span></span></summary>
             <div class="card">
               <div class="grid-3">
                 <div>

--- a/js/app.js
+++ b/js/app.js
@@ -17,6 +17,7 @@ import { setupBpHandlers } from './bpEntries.js';
 import { setupPillState } from './pill.js';
 import { setupLkw } from './lkw.js';
 import { initNIHSS } from './nihss.js';
+import { initI18n } from './i18n.js';
 
 const SAVE_DEBOUNCE_MS = 500;
 let saveTimer;
@@ -63,4 +64,7 @@ function bind() {
   activateFromHash();
 }
 
-document.addEventListener('DOMContentLoaded', bind);
+document.addEventListener('DOMContentLoaded', async () => {
+  await initI18n();
+  bind();
+});

--- a/js/autosave.js
+++ b/js/autosave.js
@@ -2,6 +2,7 @@ import { $ } from './state.js';
 import { collectSummaryData, summaryTemplate } from './summary.js';
 import { showToast } from './toast.js';
 import { confirmModal, promptModal } from './modal.js';
+import { t } from './i18n.js';
 import {
   addPatient,
   switchPatient,
@@ -15,9 +16,9 @@ import {
 import { getPatients as getSavedPatients } from './storage.js';
 
 const SAVE_STATUS_TEXT = {
-  justNow: 'ką tik',
-  minutesAgo: (mins) => `prieš ${mins} min.`,
-  saved: 'išsaugota',
+  justNow: () => t('just_now'),
+  minutesAgo: (mins) => t('minutes_ago', { mins }),
+  saved: () => t('saved'),
 };
 
 export function setupAutosave(
@@ -53,8 +54,8 @@ export function setupAutosave(
     const diff = Date.now() - new Date(rec.lastUpdated).getTime();
     const mins = Math.floor(diff / 60000);
     const ago =
-      mins < 1 ? SAVE_STATUS_TEXT.justNow : SAVE_STATUS_TEXT.minutesAgo(mins);
-    saveStatus.textContent = `${rec.name} ${SAVE_STATUS_TEXT.saved} ${ago}`;
+      mins < 1 ? SAVE_STATUS_TEXT.justNow() : SAVE_STATUS_TEXT.minutesAgo(mins);
+    saveStatus.textContent = `${rec.name} ${SAVE_STATUS_TEXT.saved()} ${ago}`;
   };
 
   patientSelect?.addEventListener('change', () => {
@@ -70,7 +71,7 @@ export function setupAutosave(
     const id = getActivePatientId();
     if (!id) return;
     flush(id, undefined, () => {
-      showToast('Išsaugota naršyklėje.', { type: 'success' });
+      showToast(t('saved_locally'), { type: 'success' });
       updateSaveStatus();
       dirty = false;
     });
@@ -80,16 +81,13 @@ export function setupAutosave(
     const id = getActivePatientId();
     if (!id) return;
     const pats = getPatients();
-    const newName = await promptModal(
-      'Naujas pavadinimas',
-      pats[id]?.name || '',
-    );
+    const newName = await promptModal(t('rename_prompt'), pats[id]?.name || '');
     if (newName) {
       renamePatient(id, newName);
       refreshPatientSelect(id);
       flush(id, newName, () => {
         updateSaveStatus();
-        showToast('Pacientas pervadintas.', { type: 'info' });
+        showToast(t('patient_renamed'), { type: 'info' });
       });
     }
   });
@@ -97,11 +95,11 @@ export function setupAutosave(
   $('#deletePatientBtn').addEventListener('click', async () => {
     const id = getActivePatientId();
     if (!id) return;
-    if (await confirmModal('Ištrinti pacientą?')) {
+    if (await confirmModal(t('delete_patient_confirm'))) {
       removePatient(id);
       refreshPatientSelect(getActivePatientId());
       updateSaveStatus();
-      showToast('Pacientas ištrintas.', { type: 'warning' });
+      showToast(t('patient_deleted'), { type: 'warning' });
     }
   });
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -1,0 +1,49 @@
+const DEFAULT_LANG = 'lt';
+let translations = {};
+
+function t(key, vars = {}) {
+  let str = translations[key] || key;
+  for (const [k, v] of Object.entries(vars)) {
+    str = str.replace(new RegExp(`{${k}}`, 'g'), v);
+  }
+  return str;
+}
+
+async function loadLang(lang) {
+  const res = await fetch(`locales/${lang}.json`);
+  translations = await res.json();
+  document.documentElement.lang = lang;
+}
+
+function applyTranslations() {
+  document.querySelectorAll('[data-i18n]').forEach((el) => {
+    el.textContent = t(el.dataset.i18n);
+  });
+  document.querySelectorAll('[data-i18n-title]').forEach((el) => {
+    el.setAttribute('title', t(el.dataset.i18nTitle));
+  });
+  document.querySelectorAll('[data-i18n-aria-label]').forEach((el) => {
+    el.setAttribute('aria-label', t(el.dataset.i18nAriaLabel));
+  });
+}
+
+async function setLanguage(lang) {
+  await loadLang(lang);
+  applyTranslations();
+}
+
+export async function initI18n() {
+  const lang = localStorage.getItem('lang') || DEFAULT_LANG;
+  await setLanguage(lang);
+  const selector = document.getElementById('langSelect');
+  if (selector) {
+    selector.value = lang;
+    selector.addEventListener('change', async () => {
+      const newLang = selector.value;
+      localStorage.setItem('lang', newLang);
+      await setLanguage(newLang);
+    });
+  }
+}
+
+export { t };

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,0 +1,19 @@
+{
+  "LKW": "Last known well – the time when the patient was last known without stroke symptoms. The app uses this to compute intervals like LKW to thrombolysis for treatment decisions.",
+  "settings": "Settings",
+  "copy": "Copy",
+  "export_pdf": "PDF",
+  "select_date_time": "Select date and time",
+  "now": "Now",
+  "language": "Language",
+  "copy_summary": "Copy summary",
+  "export_summary": "Export summary",
+  "saved_locally": "Saved locally.",
+  "rename_prompt": "New name",
+  "patient_renamed": "Patient renamed.",
+  "delete_patient_confirm": "Delete patient?",
+  "patient_deleted": "Patient deleted.",
+  "just_now": "just now",
+  "minutes_ago": "{mins} min ago",
+  "saved": "saved"
+}

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -1,3 +1,19 @@
 {
-  "LKW": "Paskutinį kartą matytas sveikas – laikas, kai pacientas paskutinį kartą buvo be insulto simptomų. Programėlė šį laiką naudoja apskaičiuodama intervalus, tokius kaip nuo LKW iki trombolizės, sprendimams dėl gydymo."
+  "LKW": "Paskutinį kartą matytas sveikas – laikas, kai pacientas paskutinį kartą buvo be insulto simptomų. Programėlė šį laiką naudoja apskaičiuodama intervalus, tokius kaip nuo LKW iki trombolizės, sprendimams dėl gydymo.",
+  "settings": "Nustatymai",
+  "copy": "Kopijuoti",
+  "export_pdf": "PDF",
+  "select_date_time": "Pasirinkti datą ir laiką",
+  "now": "Dabar",
+  "language": "Kalba",
+  "copy_summary": "Kopijuoti santrauką",
+  "export_summary": "Eksportuoti santrauką",
+  "saved_locally": "Išsaugota naršyklėje.",
+  "rename_prompt": "Naujas pavadinimas",
+  "patient_renamed": "Pacientas pervadintas.",
+  "delete_patient_confirm": "Ištrinti pacientą?",
+  "patient_deleted": "Pacientas ištrintas.",
+  "just_now": "ką tik",
+  "minutes_ago": "prieš {mins} min.",
+  "saved": "išsaugota"
 }


### PR DESCRIPTION
## Summary
- add English locale and runtime i18n loader
- translate autosave messages and various UI labels
- add language selector with localStorage persistence

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aebcd3e498832089a2c730d94f7431