### PR TITLE
Add aria-label for patient actions menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       </select>
       <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
       <details class="patient-menu">
-        <summary>⋮</summary>
+        <summary aria-label="Paciento veiksmai" data-i18n-aria-label="patient_actions">⋮</summary>
         <div class="menu">
           
 <button id="renamePatientBtn" title="Pervardyti pacientą" class="btn" >✏️ <span class="btn-label">Pervardyti</span></button>

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,5 +15,6 @@
   "patient_deleted": "Patient deleted.",
   "just_now": "just now",
   "minutes_ago": "{mins} min ago",
-  "saved": "saved"
+  "saved": "saved",
+  "patient_actions": "Patient actions"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -15,5 +15,6 @@
   "patient_deleted": "Pacientas ištrintas.",
   "just_now": "ką tik",
   "minutes_ago": "prieš {mins} min.",
-  "saved": "išsaugota"
+  "saved": "išsaugota",
+  "patient_actions": "Paciento veiksmai"
 }


### PR DESCRIPTION
## Summary
- improve accessibility of patient menu by adding aria label with translation support
- add `patient_actions` localization key in English and Lithuanian

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec16afcb48320aa753876669ab568