### PR TITLE
Add keyboard toolbar navigation for header actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         </div>
       </div>
     </div>
-    <div class="header-actions">
+    <div class="header-actions" role="toolbar">
       <select id="langSelect" class="btn" title="Kalba" data-i18n-title="language" aria-label="Kalba" data-i18n-aria-label="language">
         <option value="lt">LT</option>
         <option value="en">EN</option>

--- a/js/app.js
+++ b/js/app.js
@@ -8,6 +8,7 @@ import { setupAutosave } from './autosave.js';
 import { savePatient } from './storage.js';
 import { setupIntervals } from './intervals.js';
 import { setupHeaderHeight } from './header.js';
+import { setupToolbarNavigation } from './toolbar.js';
 import { setupTimeButtons } from './timeButtons.js';
 import { setupDrugControls } from './drugControls.js';
 import { setupSummaryHandlers } from './summaryHandlers.js';
@@ -40,6 +41,7 @@ function bind() {
 
   setupIntervals(inputs);
   setupHeaderHeight();
+  setupToolbarNavigation();
   setupTimeButtons();
   setupDrugControls(inputs);
   setupSummaryHandlers(inputs);

--- a/js/toolbar.js
+++ b/js/toolbar.js
@@ -1,0 +1,26 @@
+export function setupToolbarNavigation() {
+  const toolbar = document.querySelector('.header-actions');
+  if (!toolbar) return;
+
+  const getItems = () =>
+    Array.from(toolbar.children)
+      .map((child) =>
+        child.tagName === 'DETAILS' ? child.querySelector('summary') : child,
+      )
+      .filter((el) => el && el.matches('button, select, summary'));
+
+  toolbar.addEventListener('keydown', (e) => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+
+    const items = getItems();
+    const index = items.indexOf(document.activeElement);
+    if (index === -1) return;
+
+    e.preventDefault();
+    const dir = e.key === 'ArrowRight' ? 1 : -1;
+    let nextIndex = index + dir;
+    if (nextIndex < 0) nextIndex = items.length - 1;
+    if (nextIndex >= items.length) nextIndex = 0;
+    items[nextIndex].focus();
+  });
+}

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -9,7 +9,7 @@
         </div>
       </div>
     </div>
-    <div class="header-actions">
+    <div class="header-actions" role="toolbar">
       <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
       <details class="patient-menu">
         <summary>⋮</summary>


### PR DESCRIPTION
## Summary
- mark header actions container as an ARIA toolbar
- add `setupToolbarNavigation` to cycle focus between toolbar controls with arrow keys
- initialize toolbar navigation during app setup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aec4113ba48320b13870ac44b40eb0