### PR TITLE
Consolidate patient controls into compact dropdown

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -117,6 +117,28 @@ header {
   flex: 0 1 auto;
   min-width: auto;
 }
+.header-actions .patient-menu {
+  position: relative;
+}
+.header-actions .patient-menu > summary.btn {
+  min-width: 0;
+  padding: 8px;
+}
+.header-actions .patient-menu .menu {
+  position: absolute;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px;
+  margin-top: 4px;
+}
+.header-actions .patient-menu .btn {
+  width: 100%;
+}
 #saveStatus {
   width: 100%;
   color: var(--muted);

--- a/index.html
+++ b/index.html
@@ -26,23 +26,47 @@
         <option value="lt">LT</option>
         <option value="en">EN</option>
       </select>
-      <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-      <details class="patient-menu">
-        <summary aria-label="Paciento veiksmai" data-i18n-aria-label="patient_actions">⋮</summary>
+      <details id="patientMenu" class="patient-menu">
+        <summary class="btn" aria-label="Pacientai" data-i18n-aria-label="patients">👥
+          <span id="patientMenuLabel" class="btn-label">Pacientas</span>
+        </summary>
         <div class="menu">
-          
-<button id="renamePatientBtn" title="Pervardyti pacientą" class="btn" >✏️ <span class="btn-label">Pervardyti</span></button>
-
-          
-<button id="deletePatientBtn" title="Ištrinti pacientą" class="btn" >🗑️ <span class="btn-label">Trinti</span></button>
-
+          <select
+            id="patientSelect"
+            title="Pacientai"
+            aria-label="Pacientai"
+            class="btn"
+          ></select>
+          <button
+            id="newPatientBtn"
+            title="Naujas pacientas"
+            class="btn"
+          >
+            🆕 <span class="btn-label">Naujas</span>
+          </button>
+          <button
+            id="renamePatientBtn"
+            title="Pervardyti pacientą"
+            class="btn"
+          >
+            ✏️ <span class="btn-label">Pervardyti</span>
+          </button>
+          <button
+            id="deletePatientBtn"
+            title="Ištrinti pacientą"
+            class="btn"
+          >
+            🗑️ <span class="btn-label">Trinti</span>
+          </button>
+          <button
+            id="saveBtn"
+            title="Išsaugoti vietoje (naršyklėje)"
+            class="btn"
+          >
+            💾 <span class="btn-label">Išsaugoti</span>
+          </button>
         </div>
       </details>
-      
-<button id="newPatientBtn" title="Naujas pacientas" class="btn" >🆕 <span class="btn-label">Naujas</span></button>
-
-      
-<button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn" >💾 <span class="btn-label">Išsaugoti</span></button>
 
     </div>
   </div>

--- a/js/autosave.js
+++ b/js/autosave.js
@@ -27,6 +27,8 @@ export function setupAutosave(
 ) {
   let dirty = false;
   const patientSelect = $('#patientSelect');
+  const patientMenu = $('#patientMenu');
+  const patientMenuLabel = $('#patientMenuLabel');
 
   const refreshPatientSelect = (selectedId) => {
     if (!patientSelect) return;
@@ -39,6 +41,9 @@ export function setupAutosave(
       patientSelect.appendChild(opt);
     });
     if (selectedId) patientSelect.value = selectedId;
+    const current = pats[selectedId || patientSelect.value];
+    if (patientMenuLabel)
+      patientMenuLabel.textContent = current?.name || 'Pacientas';
   };
 
   const saveStatus = document.getElementById('saveStatus');
@@ -62,6 +67,7 @@ export function setupAutosave(
     switchPatient(patientSelect.value);
     refreshPatientSelect(patientSelect.value);
     updateSaveStatus();
+    patientMenu?.removeAttribute('open');
   });
 
   const firstId = addPatient();
@@ -75,6 +81,7 @@ export function setupAutosave(
       updateSaveStatus();
       dirty = false;
     });
+    patientMenu?.removeAttribute('open');
   });
 
   $('#renamePatientBtn').addEventListener('click', async () => {
@@ -90,6 +97,7 @@ export function setupAutosave(
         showToast(t('patient_renamed'), { type: 'info' });
       });
     }
+    patientMenu?.removeAttribute('open');
   });
 
   $('#deletePatientBtn').addEventListener('click', async () => {
@@ -101,12 +109,14 @@ export function setupAutosave(
       updateSaveStatus();
       showToast(t('patient_deleted'), { type: 'warning' });
     }
+    patientMenu?.removeAttribute('open');
   });
 
   $('#newPatientBtn').addEventListener('click', () => {
     const id = addPatient();
     refreshPatientSelect(id);
     updateSaveStatus();
+    patientMenu?.removeAttribute('open');
   });
 
   const handleChange = () => {

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -10,16 +10,18 @@
       </div>
     </div>
     <div class="header-actions" role="toolbar">
-      <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-      <details class="patient-menu">
-        <summary>⋮</summary>
+      <details id="patientMenu" class="patient-menu">
+        <summary class="btn" aria-label="Pacientai" data-i18n-aria-label="patients">👥
+          <span id="patientMenuLabel" class="btn-label">Pacientas</span>
+        </summary>
         <div class="menu">
+          <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
+          {{ actionButton('newPatientBtn', 'Naujas pacientas', '🆕', 'Naujas') }}
           {{ actionButton('renamePatientBtn', 'Pervardyti pacientą', '✏️', 'Pervardyti') }}
           {{ actionButton('deletePatientBtn', 'Ištrinti pacientą', '🗑️', 'Trinti') }}
+          {{ actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', '💾', 'Išsaugoti') }}
         </div>
       </details>
-      {{ actionButton('newPatientBtn', 'Naujas pacientas', '🆕', 'Naujas') }}
-      {{ actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', '💾', 'Išsaugoti') }}
     </div>
   </div>
   <div id="saveStatus" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- Group patient selection and actions into a single dropdown menu
- Style dropdown in header for reduced footprint
- Update autosave logic to refresh dropdown label and close menu on actions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aecf47ab288320bc8bac99b570eb70