### PR TITLE
Remove language switch functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,6 @@
     </div>
     <div class="header-actions" role="toolbar">
       <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
-      <select id="langSelect" class="btn" title="Kalba" data-i18n-title="language" aria-label="Kalba" data-i18n-aria-label="language">
-        <option value="lt">LT</option>
-        <option value="en">EN</option>
-      </select>
       <details id="patientMenu" class="patient-menu">
         <summary class="btn" aria-label="Pacientai" data-i18n-aria-label="patients">👥
           <span id="patientMenuLabel" class="btn-label">Pacientas</span>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -33,17 +33,7 @@ async function setLanguage(lang) {
 }
 
 export async function initI18n() {
-  const lang = localStorage.getItem('lang') || DEFAULT_LANG;
-  await setLanguage(lang);
-  const selector = document.getElementById('langSelect');
-  if (selector) {
-    selector.value = lang;
-    selector.addEventListener('change', async () => {
-      const newLang = selector.value;
-      localStorage.setItem('lang', newLang);
-      await setLanguage(newLang);
-    });
-  }
+  await setLanguage(DEFAULT_LANG);
 }
 
 export { t };


### PR DESCRIPTION
## Summary
- Remove language dropdown from header
- Load default language only and drop client language switching

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aed78c6c288320934769c58d7aef59