### PR TITLE
feat: add anticoagulant brand names

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,25 +217,25 @@
               <legend>Vartojami vaistai</legend>
               <div id="a_drugs" class="grid-2">
                 <label class="pill"
-                  ><input id="a_warfarin" type="checkbox" />Varfarinas</label
+                  ><input id="a_warfarin" type="checkbox" />Varfarinas (Warfarin, Orfarin)</label
                 >
                 <label class="pill"
-                  ><input id="a_apixaban" type="checkbox" />Apiksabanas</label
+                  ><input id="a_apixaban" type="checkbox" />Apiksabanas (Eliquis)</label
                 >
                 <label class="pill"
                   ><input
                     id="a_rivaroxaban"
                     type="checkbox"
-                  />Rivaroksabanas</label
+                  />Rivaroksabanas (Xarelto)</label
                 >
                 <label class="pill"
                   ><input
                     id="a_dabigatran"
                     type="checkbox"
-                  />Dabigatranas</label
+                  />Dabigatranas (Pradaxa)</label
                 >
                 <label class="pill"
-                  ><input id="a_edoxaban" type="checkbox" />Edoksabanas</label
+                  ><input id="a_edoxaban" type="checkbox" />Edoksabanas (Lixiana)</label
                 >
                 <label class="pill"
                   ><input id="a_unknown" type="checkbox" />Nežinoma</label

--- a/js/summary.js
+++ b/js/summary.js
@@ -32,11 +32,11 @@ export function collectSummaryData(payload) {
   const activation = {
     lkw: get(payload.a_lkw),
     drugs: [
-      payload.a_drug_warfarin && 'Varfarinas',
-      payload.a_drug_apixaban && 'Apiksabanas',
-      payload.a_drug_rivaroxaban && 'Rivaroksabanas',
-      payload.a_drug_dabigatran && 'Dabigatranas',
-      payload.a_drug_edoxaban && 'Edoksabanas',
+      payload.a_drug_warfarin && 'Varfarinas (Warfarin, Orfarin)',
+      payload.a_drug_apixaban && 'Apiksabanas (Eliquis)',
+      payload.a_drug_rivaroxaban && 'Rivaroksabanas (Xarelto)',
+      payload.a_drug_dabigatran && 'Dabigatranas (Pradaxa)',
+      payload.a_drug_edoxaban && 'Edoksabanas (Lixiana)',
       payload.a_drug_unknown && 'Nežinoma',
     ].filter(Boolean),
     params: {

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -83,25 +83,25 @@
               <legend>Vartojami vaistai</legend>
               <div id="a_drugs" class="grid-2">
                 <label class="pill"
-                  ><input id="a_warfarin" type="checkbox" />Varfarinas</label
+                  ><input id="a_warfarin" type="checkbox" />Varfarinas (Warfarin, Orfarin)</label
                 >
                 <label class="pill"
-                  ><input id="a_apixaban" type="checkbox" />Apiksabanas</label
+                  ><input id="a_apixaban" type="checkbox" />Apiksabanas (Eliquis)</label
                 >
                 <label class="pill"
                   ><input
                     id="a_rivaroxaban"
                     type="checkbox"
-                  />Rivaroksabanas</label
+                  />Rivaroksabanas (Xarelto)</label
                 >
                 <label class="pill"
                   ><input
                     id="a_dabigatran"
                     type="checkbox"
-                  />Dabigatranas</label
+                  />Dabigatranas (Pradaxa)</label
                 >
                 <label class="pill"
-                  ><input id="a_edoxaban" type="checkbox" />Edoksabanas</label
+                  ><input id="a_edoxaban" type="checkbox" />Edoksabanas (Lixiana)</label
                 >
                 <label class="pill"
                   ><input id="a_unknown" type="checkbox" />Nežinoma</label

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -74,7 +74,7 @@ test('copySummary builds data object and copies formatted text', async () => {
     ],
     activation: {
       lkw: '<4.5',
-      drugs: ['Varfarinas'],
+      drugs: ['Varfarinas (Warfarin, Orfarin)'],
       params: {
         glucose: '5',
         aks: '140/90',

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -58,7 +58,9 @@ test('summaryTemplate generates summary text correctly', async () => {
   assert(
     summary.includes('AKTYVACIJA:\n- Preliminarus susirgimo laikas: <4.5'),
   );
-  assert(summary.includes('- Vartojami vaistai: Varfarinas'));
+  assert(
+    summary.includes('- Vartojami vaistai: Varfarinas (Warfarin, Orfarin)'),
+  );
   assert(
     summary.includes(
       '- GMP parametrai: Gliukozė: 5, AKS: 140/90, ŠSD: 80, SpO₂: 98, Temp: 37',


### PR DESCRIPTION
## Summary
- display brand names alongside anticoagulant options
- include brand names in generated patient summaries
- adjust tests for updated drug labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef7eb6be083209b1b43f4e3241e7a