### PR TITLE
Improve BP medication list accessibility

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -9,7 +9,9 @@ export function setupBpEntry() {
   if (bpCorrBtn && bpMedList && bpEntries) {
     bpCorrBtn.addEventListener('click', (e) => {
       e.preventDefault();
-      bpMedList.classList.toggle('hidden');
+      const isHidden = bpMedList.classList.toggle('hidden');
+      bpMedList.hidden = isHidden;
+      bpCorrBtn.setAttribute('aria-expanded', (!isHidden).toString());
     });
     bpMedList.querySelectorAll('.bp-med').forEach((btn) => {
       btn.addEventListener('click', () => {
@@ -19,6 +21,8 @@ export function setupBpEntry() {
         const entry = createBpEntry(med, dose, now);
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
+        bpMedList.hidden = true;
+        bpCorrBtn.setAttribute('aria-expanded', 'false');
       });
     });
   }

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -39,10 +39,16 @@
               </div>
             </div>
             <div class="mt-10">
-              <button type="button" id="bpCorrBtn" class="btn">
+              <button
+                type="button"
+                id="bpCorrBtn"
+                class="btn"
+                aria-controls="bpMedList"
+                aria-expanded="false"
+              >
                 AKS korekcija
               </button>
-              <div id="bpMedList" class="hidden mt-10">
+              <div id="bpMedList" class="hidden mt-10" hidden>
                 <button
                   type="button"
                   class="btn bp-med"


### PR DESCRIPTION
## Summary
- add aria-controls/expanded to BP correction button
- toggle aria-expanded and hidden state in `setupBpEntry`
- mark the BP medication list as hidden for screen readers

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af050a84108320acad3f968fa9e433