### PR TITLE
feat: improve toast accessibility and localization

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="css/style.css" />
   </head>
   <body>
-    
-  <div id="toastContainer" class="toast-container"></div>
+
+  <div id="toastContainer" class="toast-container" role="status" aria-live="polite"></div>
   <header>
   <div class="wrap">
     <div class="brand">

--- a/js/toast.js
+++ b/js/toast.js
@@ -1,3 +1,5 @@
+import { t } from './i18n.js';
+
 const toast = {
   queue: [],
   showing: false,
@@ -17,13 +19,15 @@ const toast = {
     const closeBtn = document.createElement('button');
     closeBtn.type = 'button';
     closeBtn.className = 'btn toast-close';
-    closeBtn.setAttribute('aria-label', 'Close');
+    closeBtn.setAttribute('data-i18n-aria-label', 'close');
+    closeBtn.setAttribute('aria-label', t('close'));
     closeBtn.setAttribute('tabindex', '0');
     closeBtn.textContent = '×';
     el.appendChild(closeBtn);
 
     const hide = () => {
       el.classList.add('hide');
+      document.removeEventListener('keydown', onKey);
       el.addEventListener(
         'transitionend',
         () => {
@@ -35,11 +39,19 @@ const toast = {
       );
     };
 
+    const onKey = (e) => {
+      if (e.key === 'Escape') {
+        clearTimeout(timer);
+        hide();
+      }
+    };
+
     const timer = setTimeout(hide, duration);
     closeBtn.addEventListener('click', () => {
       clearTimeout(timer);
       hide();
     });
+    document.addEventListener('keydown', onKey);
 
     container.appendChild(el);
     this.showing = true;

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,5 +16,6 @@
   "just_now": "just now",
   "minutes_ago": "{mins} min ago",
   "saved": "saved",
-  "patient_actions": "Patient actions"
+  "patient_actions": "Patient actions",
+  "close": "Close"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -16,5 +16,6 @@
   "just_now": "ką tik",
   "minutes_ago": "prieš {mins} min.",
   "saved": "išsaugota",
-  "patient_actions": "Paciento veiksmai"
+  "patient_actions": "Paciento veiksmai",
+  "close": "Uždaryti"
 }

--- a/test/toast.test.js
+++ b/test/toast.test.js
@@ -2,6 +2,7 @@ import { test, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 import { toast, showToast } from '../js/toast.js';
+import { t } from '../js/i18n.js';
 
 const originalShowToast = toast.showToast;
 
@@ -28,7 +29,7 @@ test(
 
     const firstToast = container.querySelector('.toast');
     const closeBtn = firstToast.querySelector('.toast-close');
-    assert.equal(closeBtn.getAttribute('aria-label'), 'Close');
+    assert.equal(closeBtn.getAttribute('aria-label'), t('close'));
     assert.equal(closeBtn.textContent, '×');
     closeBtn.dispatchEvent(new window.Event('click', { bubbles: true }));
     firstToast.dispatchEvent(new window.Event('transitionend'));
@@ -54,4 +55,19 @@ test('shows queued toast after timeout', { concurrency: false }, async () => {
 
   assert.equal(container.querySelectorAll('.toast').length, 1);
   assert.match(container.querySelector('.toast').textContent, /second/);
+});
+
+test('dismisses toast with Escape key', { concurrency: false }, async () => {
+  showToast('to dismiss', { duration: 10000 });
+
+  const container = document.getElementById('toastContainer');
+  const firstToast = container.querySelector('.toast');
+
+  document.dispatchEvent(
+    new window.KeyboardEvent('keydown', { key: 'Escape' }),
+  );
+  firstToast.dispatchEvent(new window.Event('transitionend'));
+  await new Promise((r) => setTimeout(r, 0));
+
+  assert.equal(container.querySelectorAll('.toast').length, 0);
 });


### PR DESCRIPTION
## Summary
- add ARIA status region for toast container
- localize toast close button text and translations
- allow Escape key to dismiss toasts and cover with tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af56106b208320b9763317c29e35bf