### PR TITLE
Refactor date parsing with helper and add tests

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -9,6 +9,11 @@ export function triggerChange(el) {
   el.dispatchEvent(new Event('change', { bubbles: true }));
 }
 
+export function parseValidDate(value) {
+  const date = new Date(value);
+  return isNaN(date.getTime()) ? null : date;
+}
+
 export function setNow(id) {
   const el = document.getElementById(id);
   if (!el) return;
@@ -23,9 +28,9 @@ export function setNow(id) {
 
 export function sleepMidpoint(start, end) {
   if (!start || !end) return '';
-  const s = new Date(start);
-  let e = new Date(end);
-  if (isNaN(s) || isNaN(e)) return '';
+  const s = parseValidDate(start);
+  let e = parseValidDate(end);
+  if (!s || !e) return '';
   if (e < s) e = new Date(e.getTime() + 864e5);
   const mid = new Date((s.getTime() + e.getTime()) / 2);
   return toLocalInputValue(mid);
@@ -33,9 +38,9 @@ export function sleepMidpoint(start, end) {
 
 export function diffMinutes(start, end) {
   if (!start || !end) return NaN;
-  const s = new Date(start);
-  let e = new Date(end);
-  if (isNaN(s) || isNaN(e)) return NaN;
+  const s = parseValidDate(start);
+  let e = parseValidDate(end);
+  if (!s || !e) return NaN;
   if (e < s) e = new Date(e.getTime() + 864e5);
   return Math.round((e.getTime() - s.getTime()) / 60000);
 }

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -44,3 +44,18 @@ test('diffMinutes returns minutes between times', async () => {
   const { diffMinutes } = await import('../js/time.js');
   assert.equal(diffMinutes('2024-01-01T23:00', '2024-01-02T01:00'), 120);
 });
+
+test('parseValidDate returns null for invalid input', async () => {
+  const { parseValidDate } = await import('../js/time.js');
+  assert.equal(parseValidDate('not-a-date'), null);
+});
+
+test('sleepMidpoint returns empty string for invalid dates', async () => {
+  const { sleepMidpoint } = await import('../js/time.js');
+  assert.equal(sleepMidpoint('bad', 'dates'), '');
+});
+
+test('diffMinutes returns NaN for invalid dates', async () => {
+  const { diffMinutes } = await import('../js/time.js');
+  assert.ok(Number.isNaN(diffMinutes('bad', 'dates')));
+});


### PR DESCRIPTION
## Summary
- add `parseValidDate` utility to centralize date parsing
- reuse helper in `sleepMidpoint` and `diffMinutes`
- test invalid dates and cross-midnight ranges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5ab249c88320ae0063ea697f10b6