### PR TITLE
Handle missing autosave controls gracefully

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -73,7 +73,7 @@ export function setupAutosave(
   const firstId = addPatient();
   refreshPatientSelect(firstId);
 
-  $('#saveBtn').addEventListener('click', () => {
+  $('#saveBtn')?.addEventListener('click', () => {
     const id = getActivePatientId();
     if (!id) return;
     flush(id, undefined, () => {
@@ -84,7 +84,7 @@ export function setupAutosave(
     patientMenu?.removeAttribute('open');
   });
 
-  $('#renamePatientBtn').addEventListener('click', async () => {
+  $('#renamePatientBtn')?.addEventListener('click', async () => {
     const id = getActivePatientId();
     if (!id) return;
     const pats = getPatients();
@@ -100,7 +100,7 @@ export function setupAutosave(
     patientMenu?.removeAttribute('open');
   });
 
-  $('#deletePatientBtn').addEventListener('click', async () => {
+  $('#deletePatientBtn')?.addEventListener('click', async () => {
     const id = getActivePatientId();
     if (!id) return;
     if (await confirmModal(t('delete_patient_confirm'))) {
@@ -112,7 +112,7 @@ export function setupAutosave(
     patientMenu?.removeAttribute('open');
   });
 
-  $('#newPatientBtn').addEventListener('click', () => {
+  $('#newPatientBtn')?.addEventListener('click', () => {
     const id = addPatient();
     refreshPatientSelect(id);
     updateSaveStatus();


### PR DESCRIPTION
## Summary
- Safely bind autosave-related buttons using optional chaining so setup works even when controls are absent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af5be4e2a083208027855b21d4d9b0