### PR TITLE
Use triggerChange for time-button updates

### DIFF
--- a/js/bpEntries.js
+++ b/js/bpEntries.js
@@ -1,4 +1,4 @@
-import { setNow } from './time.js';
+import { setNow, triggerChange } from './time.js';
 import { openTimePicker } from './timePicker.js';
 import { setupBpEntry, setupBpInput } from './bp.js';
 
@@ -14,11 +14,11 @@ export function handleBpEntriesClick(event) {
   } else if (target.matches('button[data-stepup]')) {
     const input = document.getElementById(target.dataset.stepup);
     input?.stepUp(5);
-    input?.dispatchEvent(new Event('input'));
+    if (input) triggerChange(input);
   } else if (target.matches('button[data-stepdown]')) {
     const input = document.getElementById(target.dataset.stepdown);
     input?.stepDown(5);
-    input?.dispatchEvent(new Event('input'));
+    if (input) triggerChange(input);
   } else if (target.matches('button[data-remove-bp]')) {
     const entry = document.getElementById(target.dataset.removeBp);
     entry?.remove();

--- a/js/timeButtons.js
+++ b/js/timeButtons.js
@@ -1,6 +1,6 @@
 import { $$ } from './state.js';
 import { openTimePicker } from './timePicker.js';
-import { setNow } from './time.js';
+import { setNow, triggerChange } from './time.js';
 
 export function setupTimeButtons() {
   $$('button[data-now]').forEach((b) =>
@@ -20,7 +20,7 @@ export function setupTimeButtons() {
     b.addEventListener('click', () => {
       const target = document.getElementById(b.getAttribute('data-stepup'));
       target?.stepUp(5);
-      target?.dispatchEvent(new Event('input'));
+      if (target) triggerChange(target);
     }),
   );
 
@@ -28,7 +28,7 @@ export function setupTimeButtons() {
     b.addEventListener('click', () => {
       const target = document.getElementById(b.getAttribute('data-stepdown'));
       target?.stepDown(5);
-      target?.dispatchEvent(new Event('input'));
+      if (target) triggerChange(target);
     }),
   );
 
@@ -37,7 +37,7 @@ export function setupTimeButtons() {
       const target = document.getElementById(b.dataset.set);
       if (target) {
         target.value = b.dataset.val ?? '';
-        target.dispatchEvent(new Event('input'));
+        triggerChange(target);
       }
     }),
   );


### PR DESCRIPTION
## Summary
- Import `triggerChange` in button handlers and use it to fire both input and change events after step adjustments or value setting.
- Apply the same `triggerChange` pattern to blood pressure entry controls.

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af5cd54cec8320acc47db67eda42cf