### PR TITLE
Use crypto.randomUUID for modal title IDs

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -7,7 +7,8 @@ export function showModal({ title = '', message = '', input, buttons = [] }) {
     dialog.className = 'modal';
     dialog.setAttribute('role', 'dialog');
     dialog.setAttribute('aria-modal', 'true');
-    const titleId = `modal-title-${Date.now()}`;
+    const idPart = globalThis.crypto?.randomUUID?.() ?? Date.now();
+    const titleId = `modal-title-${idPart}`;
     dialog.setAttribute('aria-labelledby', titleId);
 
     const h2 = document.createElement('h2');


### PR DESCRIPTION
## Summary
- Generate modal `titleId` with `crypto.randomUUID`, falling back to `Date.now` when `randomUUID` is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd3054cb08320856a027650027978