### PR TITLE
Rephrase Lithuanian command symptom text

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,8 +195,8 @@
                   sutrikimas</label
                 >
                 <label class="pill"
-                  ><input id="a_commands" name="a_commands" type="checkbox" />Paliepimų
-                  nevykdo</label
+                  ><input id="a_commands" name="a_commands" type="checkbox" />Nevykdo
+                  paliepimų</label
                 >
                 <label class="pill"
                   ><input id="a_arm" name="a_arm" type="checkbox" />Rankos

--- a/js/summary.js
+++ b/js/summary.js
@@ -49,7 +49,7 @@ export function collectSummaryData(payload) {
     symptoms: [
       payload.a_sym_face && 'Veido paralyžius',
       payload.a_sym_speech && 'Kalbos sutrikimas',
-      payload.a_sym_commands && 'Paliepimų nevykdo',
+      payload.a_sym_commands && 'Nevykdo paliepimų',
       payload.a_sym_arm && 'Rankos silpnumas',
       payload.a_sym_leg && 'Kojos silpnumas',
       payload.a_sym_gaze && 'Žvilgsnis fiksuotas ar nukrypęs',

--- a/templates/sections/activation.njk
+++ b/templates/sections/activation.njk
@@ -61,8 +61,8 @@
                   sutrikimas</label
                 >
                 <label class="pill"
-                  ><input id="a_commands" name="a_commands" type="checkbox" />Paliepimų
-                  nevykdo</label
+                  ><input id="a_commands" name="a_commands" type="checkbox" />Nevykdo
+                  paliepimų</label
                 >
                 <label class="pill"
                   ><input id="a_arm" name="a_arm" type="checkbox" />Rankos


### PR DESCRIPTION
## Summary
- Reword command symptom to "Nevykdo paliepimų" in activation UI and summary.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd51758488320a9d73723b7409cab