### PR TITLE
Add button style variants for patient actions

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -48,6 +48,30 @@
 .btn.warn:active {
   background: #e5a545;
 }
+.btn.success {
+  background: var(--green);
+  color: #fff;
+  border-color: #00973d;
+}
+.btn.success:hover {
+  background: #00b248;
+}
+
+.btn.success:active {
+  background: #00913c;
+}
+.btn.danger {
+  background: var(--red);
+  color: #fff;
+  border-color: #a52623;
+}
+.btn.danger:hover {
+  background: #d32f2f;
+}
+
+.btn.danger:active {
+  background: #b71c1c;
+}
 .btn.ghost {
   background: rgba(0, 0, 0, 0);
   color: var(--muted);

--- a/index.html
+++ b/index.html
@@ -28,16 +28,16 @@
         <div class="menu">
           <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
           
-<button id="newPatientBtn" title="Naujas pacientas" class="btn" >🆕 <span class="btn-label">Naujas</span></button>
+<button id="newPatientBtn" title="Naujas pacientas" class="btn primary" >🆕 <span class="btn-label">Naujas</span></button>
 
           
 <button id="renamePatientBtn" title="Pervardyti pacientą" class="btn" >✏️ <span class="btn-label">Pervardyti</span></button>
 
           
-<button id="deletePatientBtn" title="Ištrinti pacientą" class="btn" >🗑️ <span class="btn-label">Trinti</span></button>
+<button id="deletePatientBtn" title="Ištrinti pacientą" class="btn warn" >🗑️ <span class="btn-label">Trinti</span></button>
 
           
-<button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn" >💾 <span class="btn-label">Išsaugoti</span></button>
+<button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn primary" >💾 <span class="btn-label">Išsaugoti</span></button>
 
         </div>
       </details>


### PR DESCRIPTION
## Summary
- Highlight important actions by styling new patient and save buttons as `primary`
- Mark patient deletion button with `warn` style
- Provide new `btn.success` and `btn.danger` variants for future use

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afebbd73708320b6d310f059d6da0d