### PR TITLE
style: highlight BP correction and meds

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -84,6 +84,25 @@
 .btn.ghost:active {
   background: #0d1319;
 }
+#bpCorrBtn[aria-expanded="true"] {
+  background: var(--accent);
+  color: #fff;
+  border-color: #2d74b8;
+}
+
+#bpCorrBtn[aria-expanded="true"]:hover {
+  background: #2368c5;
+}
+
+#bpCorrBtn[aria-expanded="true"]:active {
+  background: #1a56aa;
+}
+
+.bp-med:active {
+  background: var(--accent);
+  color: #fff;
+  border-color: #2d74b8;
+}
 #d_gks_total {
   margin-left: auto;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Highlight BP correction toggle when expanded
- Give BP medication buttons a primary background while pressed

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afeebfc6dc83209bcfa0e1cd0dee3f