### PR TITLE
feat: close patient menu on outside click

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -30,6 +30,16 @@ export function setupAutosave(
   const patientMenu = $('#patientMenu');
   const patientMenuLabel = $('#patientMenuLabel');
 
+  const onDocumentClick = (e) => {
+    if (
+      patientMenu?.hasAttribute('open') &&
+      !patientMenu.contains(/** @type {Node} */ (e.target))
+    ) {
+      patientMenu.removeAttribute('open');
+    }
+  };
+  document.addEventListener('click', onDocumentClick);
+
   const refreshPatientSelect = (selectedId) => {
     if (!patientSelect) return;
     patientSelect.innerHTML = '';
@@ -150,5 +160,8 @@ export function setupAutosave(
     }
   });
 
-  return { updateSaveStatus };
+  return {
+    updateSaveStatus,
+    cleanup: () => document.removeEventListener('click', onDocumentClick),
+  };
 }


### PR DESCRIPTION
## Summary
- close patient menu when clicking outside of it
- expose cleanup to remove click handler

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b004dd53e48320bfabd42029e17d3e