### PR TITLE
Handle invalid hashes in navigation

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -37,8 +37,13 @@ export function setupNavigation(inputs) {
   };
 
   const activateFromHash = () => {
-    const id = location.hash.slice(1) || tabs[0]?.dataset.section;
-    if (id) showSection(id);
+    const hash = location.hash.slice(1);
+    const first = tabs[0]?.dataset.section;
+    const id = tabs.some((t) => t.dataset.section === hash) ? hash : first;
+    if (id) {
+      if (hash !== id) history.replaceState(null, '', `#${id}`);
+      showSection(id);
+    }
   };
 
   if (navToggle) {

--- a/test/navigation.test.js
+++ b/test/navigation.test.js
@@ -75,3 +75,29 @@ test(
     assert.strictEqual(window.location.hash, '#sec1');
   },
 );
+
+test('falls back to first section when hash is invalid', () => {
+  window.history.replaceState(null, '', 'http://localhost/#missing');
+  document.body.innerHTML = `
+    <button id="navToggle" class="btn"></button>
+    <nav>
+      <a href="#sec1" class="tab" data-section="sec1">One</a>
+      <a href="#sec2" class="tab" data-section="sec2">Two</a>
+    </nav>
+    <main>
+      <section id="sec1"></section>
+      <section id="sec2" class="hidden"></section>
+    </main>
+  `;
+
+  const inputs = { summary: { value: '' }, d_time: { value: '' } };
+  global.location = window.location;
+  global.history = window.history;
+  const { activateFromHash } = setupNavigation(inputs);
+  activateFromHash();
+
+  const sections = document.querySelectorAll('main > section');
+  assert.ok(!sections[0].classList.contains('hidden'));
+  assert.ok(sections[1].classList.contains('hidden'));
+  assert.strictEqual(window.location.hash, '#sec1');
+});


### PR DESCRIPTION
## Summary
- Ensure navigation falls back to first tab when URL hash is unknown
- Replace hash with valid section and hide invalid sections
- Test navigation fallback behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b01b9bc5008320a8ec7d43fec29e52