### PR TITLE
Allow arrival timer to exit cleanly

### DIFF
--- a/js/arrival.js
+++ b/js/arrival.js
@@ -171,4 +171,5 @@ export function initArrival() {
   updateAll();
   clearInterval(timerId);
   timerId = setInterval(updateTimers, 1000);
+  timerId.unref?.();
 }


### PR DESCRIPTION
## Summary
- prevent arrival timer from keeping process alive by calling `unref()`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b03e857ac88320905b99772721f713