### PR TITLE
Initialize app when DOM parsing completes

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -76,8 +76,11 @@ async function init() {
   }
 }
 
-if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', init);
-} else {
+if (
+  document.readyState === 'complete' ||
+  document.readyState === 'interactive'
+) {
   init();
+} else {
+  document.addEventListener('DOMContentLoaded', init);
 }


### PR DESCRIPTION
## Summary
- ensure `init()` runs immediately when the document is `interactive` or `complete`
- otherwise, attach a `DOMContentLoaded` listener to trigger initialization once parsing finishes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b04c1ee5ec8320bf8a5e9399859ad0