### PR TITLE
fix: guard summary handlers against missing elements

### DIFF
--- a/js/summaryHandlers.js
+++ b/js/summaryHandlers.js
@@ -7,7 +7,7 @@ import {
 import { getActivePatient } from './patients.js';
 
 export function setupSummaryHandlers(inputs) {
-  document.getElementById('summary').addEventListener('focus', () => {
+  document.getElementById('summary')?.addEventListener('focus', () => {
     const patient = getActivePatient();
     if (!patient) return;
     const data = collectSummaryData(patient);
@@ -15,14 +15,14 @@ export function setupSummaryHandlers(inputs) {
     inputs.summary.value = text;
     patient.summary = text;
   });
-  document.getElementById('copySummaryBtn').addEventListener('click', () => {
+  document.getElementById('copySummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
     if (!patient) return;
     const data = collectSummaryData(patient);
     const text = copySummary(data);
     patient.summary = text;
   });
-  document.getElementById('exportSummaryBtn').addEventListener('click', () => {
+  document.getElementById('exportSummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
     if (!patient) return;
     const data = collectSummaryData(patient);


### PR DESCRIPTION
## Summary
- avoid null access when summary elements are absent by guarding `addEventListener`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05a9ac42083209315870c9c4a9095