### PR TITLE
Highlight BP correction toggle and medication buttons

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -84,6 +84,23 @@
 .btn.ghost:active {
   background: var(--ghost-active-bg);
 }
+#bpCorrBtn[aria-expanded="true"] {
+  background: var(--accent);
+  color: #fff;
+  border-color: #2d74b8;
+}
+#bpCorrBtn[aria-expanded="true"]:hover {
+  background: #2368c5;
+}
+#bpCorrBtn[aria-expanded="true"]:active {
+  background: #1a56aa;
+}
+.bp-med:active,
+.bp-med.selected {
+  background: var(--accent);
+  color: #fff;
+  border-color: #2d74b8;
+}
 #d_gks_total {
   margin-left: auto;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- Style BP correction toggle to show a primary background while expanded
- Give medication buttons a primary background when pressed or marked selected

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b05d9c84608320a77077941c0bff4e