### PR TITLE
Make thrombolysis start button standout

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -58,7 +58,7 @@
 }
 
 .btn.success:active {
-  background: #00913c;
+  background: #00c853;
 }
 .btn.danger {
   background: var(--red);

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -161,7 +161,7 @@
               >
             </div>
             <div class="section-actions mt-10">
-              <button type="button" id="startThrombolysis" class="btn">
+              <button type="button" id="startThrombolysis" class="btn success">
                 Pradėta trombolizė
               </button>
             </div>


### PR DESCRIPTION
## Summary
- highlight "Pradėta trombolizė" button with success styling for clearer activation
- brighten active success button state for more visible feedback

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0647d3ae48320a615df7441e780e5