### PR TITLE
refactor: centralize boolean field handling

### DIFF
--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -1,4 +1,5 @@
 import { state } from '../state.js';
+import { booleanField } from './helpers.js';
 
 export function getRadioValue(nodes) {
   return nodes.find((n) => n.checked)?.value || '';
@@ -149,60 +150,12 @@ export const FIELD_DEFS = [
     set: setBooleanGroup,
     default: false,
   },
-  {
-    key: 'a_drug_warfarin',
-    selector: 'a_warfarin',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
-  {
-    key: 'a_drug_apixaban',
-    selector: 'a_apixaban',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
-  {
-    key: 'a_drug_rivaroxaban',
-    selector: 'a_rivaroxaban',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
-  {
-    key: 'a_drug_dabigatran',
-    selector: 'a_dabigatran',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
-  {
-    key: 'a_drug_edoxaban',
-    selector: 'a_edoxaban',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
-  {
-    key: 'a_drug_unknown',
-    selector: 'a_unknown',
-    get: (el) => el?.checked || false,
-    set: (el, value) => {
-      if (el) el.checked = !!value;
-    },
-    default: false,
-  },
+  booleanField('a_drug_warfarin', 'a_warfarin'),
+  booleanField('a_drug_apixaban', 'a_apixaban'),
+  booleanField('a_drug_rivaroxaban', 'a_rivaroxaban'),
+  booleanField('a_drug_dabigatran', 'a_dabigatran'),
+  booleanField('a_drug_edoxaban', 'a_edoxaban'),
+  booleanField('a_drug_unknown', 'a_unknown'),
   {
     key: 'a_lkw',
     selector: 'a_lkw',

--- a/js/storage/helpers.js
+++ b/js/storage/helpers.js
@@ -1,0 +1,11 @@
+export function booleanField(key, selector) {
+  return {
+    key,
+    selector,
+    get: (el) => el?.checked || false,
+    set: (el, value) => {
+      if (el) el.checked = !!value;
+    },
+    default: false,
+  };
+}


### PR DESCRIPTION
## Summary
- add reusable `booleanField` helper for checkbox fields
- simplify drug field definitions using the helper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b07ee736288320b3a5a43dc7719661