### PR TITLE
Centralize time button handling

### DIFF
--- a/js/bpEntries.js
+++ b/js/bpEntries.js
@@ -1,25 +1,13 @@
-import { setNow, triggerChange } from './time.js';
-import { openTimePicker } from './timePicker.js';
+import { handleTimeButton } from './timeControls.js';
 import { setupBpEntry, setupBpInput } from './bp.js';
 
 export function handleBpEntriesClick(event) {
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
 
-  if (target.matches('button[data-now]')) {
-    setNow(target.dataset.now);
-  } else if (target.matches('button[data-time-picker]')) {
-    const input = document.getElementById(target.dataset.timePicker);
-    if (input) openTimePicker(input);
-  } else if (target.matches('button[data-stepup]')) {
-    const input = document.getElementById(target.dataset.stepup);
-    input?.stepUp(5);
-    if (input) triggerChange(input);
-  } else if (target.matches('button[data-stepdown]')) {
-    const input = document.getElementById(target.dataset.stepdown);
-    input?.stepDown(5);
-    if (input) triggerChange(input);
-  } else if (target.matches('button[data-remove-bp]')) {
+  if (handleTimeButton(target)) return;
+
+  if (target.matches('button[data-remove-bp]')) {
     const entry = document.getElementById(target.dataset.removeBp);
     entry?.remove();
   }

--- a/js/timeButtons.js
+++ b/js/timeButtons.js
@@ -1,44 +1,9 @@
-import { $$ } from './state.js';
-import { openTimePicker } from './timePicker.js';
-import { setNow, triggerChange } from './time.js';
+import { handleTimeButton } from './timeControls.js';
 
 export function setupTimeButtons() {
-  $$('button[data-now]').forEach((b) =>
-    b.addEventListener('click', () => setNow(b.getAttribute('data-now'))),
-  );
-
-  $$('button[data-time-picker]').forEach((b) =>
-    b.addEventListener('click', () => {
-      const target = document.getElementById(
-        b.getAttribute('data-time-picker'),
-      );
-      openTimePicker(target);
-    }),
-  );
-
-  $$('button[data-stepup]').forEach((b) =>
-    b.addEventListener('click', () => {
-      const target = document.getElementById(b.getAttribute('data-stepup'));
-      target?.stepUp(5);
-      if (target) triggerChange(target);
-    }),
-  );
-
-  $$('button[data-stepdown]').forEach((b) =>
-    b.addEventListener('click', () => {
-      const target = document.getElementById(b.getAttribute('data-stepdown'));
-      target?.stepDown(5);
-      if (target) triggerChange(target);
-    }),
-  );
-
-  $$('button[data-set]').forEach((b) =>
-    b.addEventListener('click', () => {
-      const target = document.getElementById(b.dataset.set);
-      if (target) {
-        target.value = b.dataset.val ?? '';
-        triggerChange(target);
-      }
-    }),
-  );
+  document.addEventListener('click', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLElement)) return;
+    handleTimeButton(target);
+  });
 }

--- a/js/timeControls.js
+++ b/js/timeControls.js
@@ -1,0 +1,46 @@
+import { setNow, triggerChange } from './time.js';
+import { openTimePicker } from './timePicker.js';
+
+export function handleTimeButton(target) {
+  if (!(target instanceof HTMLElement)) return false;
+  const button = target.closest('button');
+  if (!button) return false;
+
+  const { now, timePicker, stepup, stepdown, set, val } = button.dataset;
+
+  if (now !== undefined) {
+    setNow(now);
+    return true;
+  }
+
+  if (timePicker !== undefined) {
+    const input = document.getElementById(timePicker);
+    if (input) openTimePicker(input);
+    return true;
+  }
+
+  if (stepup !== undefined) {
+    const input = document.getElementById(stepup);
+    input?.stepUp(5);
+    if (input) triggerChange(input);
+    return true;
+  }
+
+  if (stepdown !== undefined) {
+    const input = document.getElementById(stepdown);
+    input?.stepDown(5);
+    if (input) triggerChange(input);
+    return true;
+  }
+
+  if (set !== undefined) {
+    const input = document.getElementById(set);
+    if (input) {
+      input.value = val ?? '';
+      triggerChange(input);
+    }
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary
- add `handleTimeButton` module to interpret time button data-* attributes
- delegate `setupTimeButtons` clicks through shared handler
- reuse `handleTimeButton` in BP entry click handler

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0931ead748320804023f746539093