### PR TITLE
Refactor patient persistence logic

### DIFF
--- a/js/patients.js
+++ b/js/patients.js
@@ -13,14 +13,17 @@ function generateId() {
   return `${Date.now().toString(36)}_${Math.random().toString(36).slice(2)}`;
 }
 
+function persistActivePatient(inputs) {
+  patients[activeId] = {
+    ...getPayload(),
+    summary: inputs.summary?.value || '',
+    name: patients[activeId].name,
+  };
+}
+
 export function addPatient(id, data = {}) {
   const inputs = getInputs();
-  if (activeId)
-    patients[activeId] = {
-      ...getPayload(),
-      summary: inputs.summary?.value || '',
-      name: patients[activeId].name,
-    };
+  if (activeId) persistActivePatient(inputs);
   const newId = id || generateId();
   const {
     summary = '',
@@ -37,12 +40,7 @@ export function addPatient(id, data = {}) {
 export function switchPatient(id) {
   if (!patients[id]) return;
   const inputs = getInputs();
-  if (activeId)
-    patients[activeId] = {
-      ...getPayload(),
-      summary: inputs.summary?.value || '',
-      name: patients[activeId].name,
-    };
+  if (activeId) persistActivePatient(inputs);
   activeId = id;
   setPayload(patients[id]);
   if (inputs.summary) inputs.summary.value = patients[id].summary || '';

--- a/test/patients.test.js
+++ b/test/patients.test.js
@@ -86,3 +86,29 @@ test('addPatient keeps provided ID and data', () => {
   assert.strictEqual(patients[existingId].summary, 's');
   assert.strictEqual(patients[existingId].name, 'Existing');
 });
+
+test('addPatient persists previous patient data', () => {
+  localStorage.clear();
+  resetInputs();
+  Object.keys(getPatientStore()).forEach((id) => removePatient(id));
+
+  const id1 = addPatient();
+  inputs.nih0.value = '1';
+  addPatient();
+  const patients = getPatientStore();
+  assert.strictEqual(patients[id1].p_nihss0, '1');
+});
+
+test('switchPatient persists previous patient data', () => {
+  localStorage.clear();
+  resetInputs();
+  Object.keys(getPatientStore()).forEach((id) => removePatient(id));
+
+  const id1 = addPatient();
+  inputs.nih0.value = '1';
+  const id2 = addPatient();
+  inputs.nih0.value = '2';
+  switchPatient(id1);
+  const patients = getPatientStore();
+  assert.strictEqual(patients[id2].p_nihss0, '2');
+});


### PR DESCRIPTION
## Summary
- Extract repeated persistence into `persistActivePatient`
- Save active patient at start of `addPatient` and `switchPatient`
- Test that adding or switching patients saves previous data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0a6722af48320a9608f4a840cba04