### PR TITLE
refactor: centralize timepicker change events

### DIFF
--- a/js/timePicker.js
+++ b/js/timePicker.js
@@ -1,3 +1,5 @@
+import { triggerChange } from './time.js';
+
 export function openTimePicker(target) {
   if (!target) return;
   if (typeof document === 'undefined' || typeof window === 'undefined') {
@@ -115,8 +117,7 @@ export function openTimePicker(target) {
         val = `${d}T${h}:${m}`;
       }
       target.value = val;
-      target.dispatchEvent(new Event('input', { bubbles: true }));
-      target.dispatchEvent(new Event('change', { bubbles: true }));
+      triggerChange(target);
     }
     dialog.remove();
   });


### PR DESCRIPTION
## Summary
- use `triggerChange` helper in `timePicker` instead of manual event dispatch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0acb7cc488320a79b6f65ff3a060b