### PR TITLE
Prompt for patient name after creation

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -122,10 +122,17 @@ export function setupAutosave(
     patientMenu?.removeAttribute('open');
   });
 
-  $('#newPatientBtn')?.addEventListener('click', () => {
+  $('#newPatientBtn')?.addEventListener('click', async () => {
     const id = addPatient();
-    refreshPatientSelect(id);
+    const enteredName = await promptModal(t('rename_prompt'), '');
+    if (enteredName) {
+      renamePatient(id, enteredName);
+      refreshPatientSelect(id);
+    } else {
+      refreshPatientSelect(id);
+    }
     updateSaveStatus();
+    showToast(t('patient_created'), { type: 'success' });
     patientMenu?.removeAttribute('open');
   });
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -11,6 +11,7 @@
   "saved_locally": "Saved locally.",
   "rename_prompt": "New name",
   "patient_renamed": "Patient renamed.",
+  "patient_created": "Patient created.",
   "delete_patient_confirm": "Delete patient?",
   "patient_deleted": "Patient deleted.",
   "just_now": "just now",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -11,6 +11,7 @@
   "saved_locally": "Išsaugota naršyklėje.",
   "rename_prompt": "Naujas pavadinimas",
   "patient_renamed": "Pacientas pervadintas.",
+  "patient_created": "Pacientas sukurtas.",
   "delete_patient_confirm": "Ištrinti pacientą?",
   "patient_deleted": "Pacientas ištrintas.",
   "just_now": "ką tik",


### PR DESCRIPTION
## Summary
- prompt for a new patient name after creation and show success feedback
- add `patient_created` translations for English and Lithuanian

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0b47d3c24832083fd6e27d54ca623