### PR TITLE
Show toast after refreshing patient selection

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -131,8 +131,8 @@ export function setupAutosave(
     } else {
       refreshPatientSelect(id);
     }
-    updateSaveStatus();
     showToast(t('patient_created'), { type: 'success' });
+    updateSaveStatus();
     patientMenu?.removeAttribute('open');
   });
 


### PR DESCRIPTION
## Summary
- Re-order patient creation handler to display a success toast right after updating the patient selector
- Keep localization for `patient_created` across English and Lithuanian locales

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0b619760c8320bca1aa9b64509dcc