### PR TITLE
Fix time picker cancel button and add test

### DIFF
--- a/js/timePicker.js
+++ b/js/timePicker.js
@@ -88,6 +88,7 @@ export function openTimePicker(target) {
   cancelBtn.type = 'button';
   cancelBtn.className = 'btn ghost';
   cancelBtn.textContent = 'Atšaukti';
+  cancelBtn.addEventListener('click', () => dialog.close('cancel'));
   actions.appendChild(cancelBtn);
 
   const okBtn = document.createElement('button');

--- a/test/timePicker.test.js
+++ b/test/timePicker.test.js
@@ -1,0 +1,36 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+import { openTimePicker } from '../js/timePicker.js';
+
+test('cancel button closes time picker dialog', () => {
+  document.body.innerHTML =
+    '<input id="t" type="datetime-local" value="2024-01-01T12:30">';
+  const input = document.getElementById('t');
+
+  window.HTMLDialogElement = window.HTMLElement;
+  const origCreate = document.createElement.bind(document);
+  document.createElement = (tag, opts) => {
+    const el = origCreate(tag, opts);
+    if (tag === 'dialog') {
+      el.showModal = () => {};
+      el.close = (val) => {
+        el.returnValue = val;
+        el.dispatchEvent(new window.Event('close'));
+      };
+    }
+    return el;
+  };
+
+  openTimePicker(input);
+  const dialog = document.querySelector('dialog.time-picker-dialog');
+  assert.ok(dialog);
+
+  const cancelBtn = dialog.querySelector('button[value="cancel"]');
+  cancelBtn.click();
+
+  assert.ok(!document.body.contains(dialog));
+  assert.strictEqual(input.value, '2024-01-01T12:30');
+
+  document.createElement = origCreate;
+});


### PR DESCRIPTION
## Summary
- close custom time picker when cancel is pressed
- add regression test for canceling the dialog

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0d05841b4832085a50f1bd5034fa9