### PR TITLE
Add patient search filter to patient menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,9 @@
           <span id="patientMenuLabel" class="btn-label">Pacientas</span>
         </summary>
         <div class="menu">
+          <input id="patientSearch" type="search" placeholder="Search…">
           <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
-          
+
 <button id="newPatientBtn" title="Naujas pacientas" class="btn primary" >🆕 <span class="btn-label">Naujas</span></button>
 
           

--- a/js/autosave.js
+++ b/js/autosave.js
@@ -29,6 +29,7 @@ export function setupAutosave(
   const patientSelect = $('#patientSelect');
   const patientMenu = $('#patientMenu');
   const patientMenuLabel = $('#patientMenuLabel');
+  const patientSearch = $('#patientSearch');
 
   const isDesktop = () =>
     typeof window.matchMedia === 'function'
@@ -60,13 +61,21 @@ export function setupAutosave(
     if (!patientSelect) return;
     patientSelect.innerHTML = '';
     const pats = getPatients();
+    const query = patientSearch?.value?.toLowerCase() || '';
     Object.entries(pats).forEach(([id, p], idx) => {
-      const opt = document.createElement('option');
-      opt.value = id;
-      opt.textContent = p.name || `Pacientas ${idx + 1}`;
-      patientSelect.appendChild(opt);
+      const name = p.name || `Pacientas ${idx + 1}`;
+      if (!query || name.toLowerCase().includes(query)) {
+        const opt = document.createElement('option');
+        opt.value = id;
+        opt.textContent = name;
+        patientSelect.appendChild(opt);
+      }
     });
-    if (selectedId) patientSelect.value = selectedId;
+    if (
+      selectedId &&
+      Array.from(patientSelect.options).some((opt) => opt.value === selectedId)
+    )
+      patientSelect.value = selectedId;
     const current = pats[selectedId || patientSelect.value];
     if (patientMenuLabel)
       patientMenuLabel.textContent = current?.name || 'Pacientas';
@@ -98,6 +107,9 @@ export function setupAutosave(
 
   const firstId = addPatient();
   refreshPatientSelect(firstId);
+  patientSearch?.addEventListener('input', () =>
+    refreshPatientSelect(getActivePatientId()),
+  );
 
   $('#saveBtn')?.addEventListener('click', () => {
     const id = getActivePatientId();

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -15,6 +15,7 @@
           <span id="patientMenuLabel" class="btn-label">Pacientas</span>
         </summary>
         <div class="menu">
+          <input id="patientSearch" type="search" placeholder="Search…">
           <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
           {{ actionButton('newPatientBtn', 'Naujas pacientas', '🆕', 'Naujas') }}
           {{ actionButton('renamePatientBtn', 'Pervardyti pacientą', '✏️', 'Pervardyti') }}

--- a/test/patientSearch.test.js
+++ b/test/patientSearch.test.js
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+// Test ensures patient search filters options and switching works
+
+test(
+  'patient search filters options and switches patients',
+  { concurrency: false },
+  async () => {
+    const { setupAutosave } = await import('../js/autosave.js');
+    const { getInputs } = await import('../js/state.js');
+    const {
+      addPatient,
+      removePatient,
+      getPatients: getPatientStore,
+      renamePatient,
+      getActivePatientId,
+    } = await import('../js/patients.js');
+
+    // reset state
+    localStorage.clear();
+    Object.keys(getPatientStore()).forEach((id) => removePatient(id));
+
+    const inputs = getInputs();
+    setupAutosave(inputs, { scheduleSave() {}, flushSave() {} });
+
+    const firstId = getActivePatientId();
+    renamePatient(firstId, 'Alice');
+    const id2 = addPatient(undefined, { name: 'Bob' });
+    addPatient(undefined, { name: 'Charlie' });
+
+    const searchInput = document.getElementById('patientSearch');
+    // refresh list with all patients
+    searchInput.value = '';
+    searchInput.dispatchEvent(new Event('input'));
+
+    const patientSelect = document.getElementById('patientSelect');
+    assert.strictEqual(patientSelect.options.length, 3);
+
+    // filter for Bob
+    searchInput.value = 'bo';
+    searchInput.dispatchEvent(new Event('input'));
+    assert.strictEqual(patientSelect.options.length, 1);
+    assert.strictEqual(patientSelect.options[0].textContent, 'Bob');
+
+    // selecting filtered option switches patient
+    patientSelect.value = id2;
+    patientSelect.dispatchEvent(new Event('change'));
+    assert.strictEqual(getActivePatientId(), id2);
+  },
+);


### PR DESCRIPTION
## Summary
- add search input to patient dropdown
- filter patient list in autosave.js based on search query and update as typed
- test patient search filtering and patient switching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b13fe4fdb483209d35d52505976c0d