### PR TITLE
Use icons for patient menu actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,16 +40,16 @@
           >
           <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
           
-<button id="newPatientBtn" title="Naujas pacientas" class="btn" >🆕 <span class="btn-label">Naujas</span></button>
+<button id="newPatientBtn" title="Naujas pacientas" aria-label="Naujas pacientas" class="btn">🆕 <span class="btn-label">Naujas</span></button>
 
           
-<button id="renamePatientBtn" title="Pervardyti pacientą" class="btn" >✏️ <span class="btn-label">Pervardyti</span></button>
+<button id="renamePatientBtn" title="Pervardyti pacientą" aria-label="Pervardyti pacientą" class="btn">✏️</button>
 
           
-<button id="deletePatientBtn" title="Ištrinti pacientą" class="btn" >🗑️ <span class="btn-label">Trinti</span></button>
+<button id="deletePatientBtn" title="Ištrinti pacientą" aria-label="Ištrinti pacientą" class="btn">🗑️</button>
 
           
-<button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" class="btn" >💾 <span class="btn-label">Išsaugoti</span></button>
+<button id="saveBtn" title="Išsaugoti vietoje (naršyklėje)" aria-label="Išsaugoti vietoje (naršyklėje)" class="btn">💾</button>
 
         </div>
       </details>
@@ -1552,7 +1552,7 @@
           ></textarea>
           <div class="sticky-actions">
             
-<button id="copySummaryBtn" title="Kopijuoti santrauką" class="btn" >📋 <span class="btn-label">Kopijuoti</span></button>
+<button id="copySummaryBtn" title="Kopijuoti santrauką" aria-label="Kopijuoti santrauką" class="btn">📋 <span class="btn-label">Kopijuoti</span></button>
 
           </div>
         </section>

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -1,5 +1,5 @@
-{% macro actionButton(id, title, icon, label, classes='', attrs='') %}
-<button id="{{ id }}"{% if title %} title="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}" {{ attrs|safe }}>{{ icon }} <span class="btn-label">{{ label }}</span></button>
+{% macro actionButton(id, title, icon, label='', classes='', attrs='') %}
+<button id="{{ id }}"{% if title %} title="{{ title }}" aria-label="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}"{% if attrs %} {{ attrs|safe }}{% endif %}>{{ icon }}{% if label %} <span class="btn-label">{{ label }}</span>{% endif %}</button>
 {% endmacro %}
 
 {% macro timeInput(id, wrapperId='', wrapperClass='row') %}

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -29,9 +29,9 @@
           >
           <select id="patientSelect" title="Pacientai" aria-label="Pacientai" class="btn"></select>
           {{ actionButton('newPatientBtn', 'Naujas pacientas', '🆕', 'Naujas') }}
-          {{ actionButton('renamePatientBtn', 'Pervardyti pacientą', '✏️', 'Pervardyti') }}
-          {{ actionButton('deletePatientBtn', 'Ištrinti pacientą', '🗑️', 'Trinti') }}
-          {{ actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', '💾', 'Išsaugoti') }}
+          {{ actionButton('renamePatientBtn', 'Pervardyti pacientą', '✏️') }}
+          {{ actionButton('deletePatientBtn', 'Ištrinti pacientą', '🗑️') }}
+          {{ actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', '💾') }}
         </div>
       </details>
       {{ actionButton('navToggle', '', '☰', 'Meniu', '', 'aria-expanded="false" aria-controls="mainNav"') }}


### PR DESCRIPTION
## Summary
- show only icons for Rename, Delete, and Save buttons in the patient menu
- allow optional labels in `actionButton` macro and set aria-label from title

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b14f5bc8bc83208e9769ef030d11f3