### PR TITLE
feat: add service worker for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ npm run build
 
 Open `index.html` in a browser to use the app.
 
+## Offline support
+
+The app registers a Service Worker that caches the core HTML, CSS, JavaScript
+and locale files so the interface continues to work offline after the first
+load.
+
 ## Draft storage schema
 
 Drafts saved to `localStorage` are wrapped in an object with a `version`

--- a/build.js
+++ b/build.js
@@ -18,8 +18,12 @@ async function buildCss() {
   await fs.writeFile('css/style.css', result.css);
 }
 
+async function copySw() {
+  await fs.copyFile('sw.js', 'sw.js');
+}
+
 try {
-  await Promise.all([buildHtml(), buildCss()]);
+  await Promise.all([buildHtml(), buildCss(), copySw()]);
 } catch (error) {
   console.error('Build failed:', error);
   process.exit(1);

--- a/js/app.js
+++ b/js/app.js
@@ -20,6 +20,14 @@ import { setupLkw } from './lkw.js';
 import { initNIHSS } from './nihss.js';
 import { initI18n } from './i18n.js';
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js').catch((err) => {
+      console.error('Service worker registration failed', err);
+    });
+  });
+}
+
 const SAVE_DEBOUNCE_MS = 500;
 let saveTimer;
 function scheduleSave(id, name, cb) {

--- a/sw.js
+++ b/sw.js
@@ -1,0 +1,52 @@
+const CACHE_NAME = 'stroke-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/css/style.css',
+  '/js/app.js',
+  '/locales/en.json',
+  '/locales/lt.json',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type === 'opaque') {
+            return response;
+          }
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => {
+          if (event.request.mode === 'navigate') {
+            return caches.match('/index.html');
+          }
+        });
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- add service worker to cache core assets for offline use
- register service worker when supported
- document offline capability in README

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1830848b48320b99bfe0801e05a2f