### PR TITLE
Recompute dosages when loading stored data

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -1,5 +1,5 @@
 import { getInputs } from './state.js';
-import { updateDrugDefaults } from './drugs.js';
+import { updateDrugDefaults, calcDrugs } from './drugs.js';
 import { updateAge } from './age.js';
 import { createBpEntry } from './bpEntry.js';
 import { FIELD_DEFS } from './storage/fields.js';
@@ -138,6 +138,7 @@ export function setPayload(p) {
   }
   updateAge();
   updateDrugDefaults();
+  calcDrugs();
 }
 
 export function savePatient(id, name) {


### PR DESCRIPTION
## Summary
- ensure dosage fields are recalculated when stored patient data is loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2be3e75708320ba3176b38bb9d300