### PR TITLE
Localize drug dosing validation messages

### DIFF
--- a/js/drugs.js
+++ b/js/drugs.js
@@ -1,5 +1,6 @@
 import { dom } from './state.js';
 import { computeDose } from './computeDose.js';
+import { t } from './i18n.js';
 
 export function updateDrugDefaults() {
   const typeEl = dom.getDrugTypeInput();
@@ -54,13 +55,13 @@ export function calcDrugs() {
     if (!wValid) {
       weightEl.classList.add('invalid');
       if (weightEl.setCustomValidity)
-        weightEl.setCustomValidity('Įveskite teisingą svorį.');
+        weightEl.setCustomValidity(t('invalid_weight'));
       if (weightEl.reportValidity) weightEl.reportValidity();
     }
     if (!cValid) {
       concEl.classList.add('invalid');
       if (concEl.setCustomValidity)
-        concEl.setCustomValidity('Įveskite teisingą koncentraciją.');
+        concEl.setCustomValidity(t('invalid_concentration'));
       if (concEl.reportValidity) concEl.reportValidity();
     }
     return;

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,5 +19,7 @@
   "saved": "saved",
   "patient_actions": "Patient actions",
   "storage_full": "Failed to save: storage limit reached.",
-  "close": "Close"
+  "close": "Close",
+  "invalid_weight": "Enter a valid weight.",
+  "invalid_concentration": "Enter a valid concentration."
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -19,5 +19,7 @@
   "saved": "išsaugota",
   "patient_actions": "Paciento veiksmai",
   "storage_full": "Nepavyko išsaugoti: naršyklės saugykla pilna.",
-  "close": "Uždaryti"
+  "close": "Uždaryti",
+  "invalid_weight": "Įveskite teisingą svorį.",
+  "invalid_concentration": "Įveskite teisingą koncentraciją."
 }


### PR DESCRIPTION
## Summary
- add English and Lithuanian translations for invalid weight and concentration
- show localized validation errors in drug calculator

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b357aa88a8832094340ce02185cfe1