### PR TITLE
Add analytics module and navigation tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,6 +135,14 @@
     role="tab"
     ><span class="tab-icon">📄</span>Santrauka</a
   >
+  <a
+    id="analytics-tab"
+    href="#analytics"
+    data-section="analytics"
+    class="tab btn"
+    role="tab"
+    ><span class="tab-icon">📊</span>Analytics</a
+  >
 </nav>
 
     <div id="appForm">
@@ -1579,6 +1587,24 @@
 <button id="copySummaryBtn" title="Kopijuoti santrauką" aria-label="Kopijuoti santrauką" class="btn">📋 <span class="btn-label">Kopijuoti</span></button>
 
           </div>
+        </section>
+        <section
+          id="analytics"
+          class="card full-span hidden"
+          role="tabpanel"
+          aria-labelledby="analytics-tab"
+        >
+          <h2>Analytics</h2>
+          <dl>
+            <dt>Door-to-Needle (min)</dt>
+            <dd id="analytics_dtn"></dd>
+            <dt>Door-to-Decision (min)</dt>
+            <dd id="analytics_dtd"></dd>
+            <dt>Last Known Well to Door (min)</dt>
+            <dd id="analytics_lkwd"></dd>
+            <dt>Initial BP within range</dt>
+            <dd id="analytics_bp"></dd>
+          </dl>
         </section>
 
                 <details class="settings">

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,33 @@
+import * as state from './state.js';
+import { diffMinutes } from './time.js';
+
+/**
+ * Render analytics KPIs into the analytics section.
+ */
+export function renderAnalytics() {
+  const inputs = state.getInputs();
+  const door = inputs.door?.value;
+  const needle = inputs.t_thrombolysis?.value;
+  const decision = inputs.d_time?.value;
+  const lkw = inputs.lkw?.value;
+  const sys = parseInt(inputs.bp_sys?.value || '', 10);
+  const dia = parseInt(inputs.bp_dia?.value || '', 10);
+
+  const dtn = diffMinutes(door, needle);
+  const dtd = diffMinutes(door, decision);
+  const lkwDoor = diffMinutes(lkw, door);
+  const bpOk =
+    Number.isFinite(sys) && Number.isFinite(dia)
+      ? sys < 185 && dia < 110
+      : null;
+
+  const setText = (id, value) => {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  };
+
+  setText('analytics_dtn', Number.isFinite(dtn) ? String(dtn) : '');
+  setText('analytics_dtd', Number.isFinite(dtd) ? String(dtd) : '');
+  setText('analytics_lkwd', Number.isFinite(lkwDoor) ? String(lkwDoor) : '');
+  setText('analytics_bp', bpOk == null ? '' : bpOk ? 'Yes' : 'No');
+}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -2,6 +2,7 @@ import { $, $$ } from './state.js';
 import { collectSummaryData, summaryTemplate } from './summary.js';
 import { setNow } from './time.js';
 import { getActivePatient } from './patients.js';
+import { renderAnalytics } from './analytics.js';
 
 export function setupNavigation(inputs) {
   const tabs = $$('nav .tab');
@@ -32,6 +33,7 @@ export function setupNavigation(inputs) {
     }
     if (id === 'decision' && inputs.d_time && !inputs.d_time.value)
       setNow('d_time');
+    if (id === 'analytics') renderAnalytics();
     document.body.classList.remove('nav-open');
     if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
   };

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+import { renderAnalytics } from '../js/analytics.js';
+
+// set up DOM and run renderAnalytics
+
+test('renderAnalytics computes KPI values', () => {
+  document.body.innerHTML = `
+    <section id="analytics">
+      <dd id="analytics_dtn"></dd>
+      <dd id="analytics_dtd"></dd>
+      <dd id="analytics_lkwd"></dd>
+      <dd id="analytics_bp"></dd>
+    </section>
+    <input id="t_door" type="datetime-local" />
+    <input id="t_thrombolysis" type="datetime-local" />
+    <input id="d_time" type="datetime-local" />
+    <input id="t_lkw" type="datetime-local" />
+    <input id="p_bp_sys" type="number" />
+    <input id="p_bp_dia" type="number" />
+  `;
+
+  document.querySelector('#t_door').value = '2024-01-01T10:00';
+  document.querySelector('#t_thrombolysis').value = '2024-01-01T10:30';
+  document.querySelector('#d_time').value = '2024-01-01T10:20';
+  document.querySelector('#t_lkw').value = '2024-01-01T08:00';
+  document.querySelector('#p_bp_sys').value = '180';
+  document.querySelector('#p_bp_dia').value = '100';
+
+  renderAnalytics();
+
+  assert.equal(document.getElementById('analytics_dtn').textContent, '30');
+  assert.equal(document.getElementById('analytics_dtd').textContent, '20');
+  assert.equal(document.getElementById('analytics_lkwd').textContent, '120');
+  assert.equal(document.getElementById('analytics_bp').textContent, 'Yes');
+});


### PR DESCRIPTION
## Summary
- add analytics module to compute door-to-needle, door-to-decision, last-known-well-to-door, and initial BP range
- integrate analytics tab into navigation and HTML layout
- cover KPI calculations with unit test

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b406bf7db083208bc61c8cf06016d2