### PR TITLE
Translate analytics tab to Lithuanian

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     data-section="analytics"
     class="tab btn"
     role="tab"
-    ><span class="tab-icon">📊</span>Analytics</a
+    ><span class="tab-icon">📊</span>Analitika</a
   >
 </nav>
 
@@ -1594,15 +1594,15 @@
           role="tabpanel"
           aria-labelledby="analytics-tab"
         >
-          <h2>Analytics</h2>
+          <h2>Analitika</h2>
           <dl>
-            <dt>Door-to-Needle (min)</dt>
+            <dt>Nuo atvykimo iki injekcijos (min)</dt>
             <dd id="analytics_dtn"></dd>
-            <dt>Door-to-Decision (min)</dt>
+            <dt>Nuo atvykimo iki sprendimo (min)</dt>
             <dd id="analytics_dtd"></dd>
-            <dt>Last Known Well to Door (min)</dt>
+            <dt>Nuo paskutinio žinomo sveiko iki atvykimo (min)</dt>
             <dd id="analytics_lkwd"></dd>
-            <dt>Initial BP within range</dt>
+            <dt>Pradinis kraujospūdis normos ribose</dt>
             <dd id="analytics_bp"></dd>
           </dl>
         </section>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -29,5 +29,5 @@ export function renderAnalytics() {
   setText('analytics_dtn', Number.isFinite(dtn) ? String(dtn) : '');
   setText('analytics_dtd', Number.isFinite(dtd) ? String(dtd) : '');
   setText('analytics_lkwd', Number.isFinite(lkwDoor) ? String(lkwDoor) : '');
-  setText('analytics_bp', bpOk == null ? '' : bpOk ? 'Yes' : 'No');
+  setText('analytics_bp', bpOk == null ? '' : bpOk ? 'Taip' : 'Ne');
 }

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -33,5 +33,5 @@ test('renderAnalytics computes KPI values', () => {
   assert.equal(document.getElementById('analytics_dtn').textContent, '30');
   assert.equal(document.getElementById('analytics_dtd').textContent, '20');
   assert.equal(document.getElementById('analytics_lkwd').textContent, '120');
-  assert.equal(document.getElementById('analytics_bp').textContent, 'Yes');
+  assert.equal(document.getElementById('analytics_bp').textContent, 'Taip');
 });


### PR DESCRIPTION
## Summary
- Localize analytics tab labels and headings to Lithuanian
- Show Lithuanian text for initial blood pressure outcome
- Adjust unit test for localized analytics output

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b42a7b8e088320a18f9549c9a88814