### PR TITLE
Use translated yes/no in analytics

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,5 +1,6 @@
 import * as state from './state.js';
 import { diffMinutes } from './time.js';
+import { t } from './i18n.js';
 
 /**
  * Render analytics KPIs into the analytics section.
@@ -29,5 +30,5 @@ export function renderAnalytics() {
   setText('analytics_dtn', Number.isFinite(dtn) ? String(dtn) : '');
   setText('analytics_dtd', Number.isFinite(dtd) ? String(dtd) : '');
   setText('analytics_lkwd', Number.isFinite(lkwDoor) ? String(lkwDoor) : '');
-  setText('analytics_bp', bpOk == null ? '' : bpOk ? 'Taip' : 'Ne');
+  setText('analytics_bp', bpOk == null ? '' : bpOk ? t('yes') : t('no'));
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,5 +21,7 @@
   "storage_full": "Failed to save: storage limit reached.",
   "close": "Close",
   "invalid_weight": "Enter a valid weight.",
-  "invalid_concentration": "Enter a valid concentration."
+  "invalid_concentration": "Enter a valid concentration.",
+  "yes": "Yes",
+  "no": "No"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -21,5 +21,7 @@
   "storage_full": "Nepavyko išsaugoti: naršyklės saugykla pilna.",
   "close": "Uždaryti",
   "invalid_weight": "Įveskite teisingą svorį.",
-  "invalid_concentration": "Įveskite teisingą koncentraciją."
+  "invalid_concentration": "Įveskite teisingą koncentraciją.",
+  "yes": "Taip",
+  "no": "Ne"
 }

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 import { renderAnalytics } from '../js/analytics.js';
+import { t } from '../js/i18n.js';
 
 // set up DOM and run renderAnalytics
 
@@ -33,5 +34,5 @@ test('renderAnalytics computes KPI values', () => {
   assert.equal(document.getElementById('analytics_dtn').textContent, '30');
   assert.equal(document.getElementById('analytics_dtd').textContent, '20');
   assert.equal(document.getElementById('analytics_lkwd').textContent, '120');
-  assert.equal(document.getElementById('analytics_bp').textContent, 'Taip');
+  assert.equal(document.getElementById('analytics_bp').textContent, t('yes'));
 });


### PR DESCRIPTION
## Summary
- Add `yes` and `no` to English and Lithuanian locale files
- Replace hardcoded blood pressure answers with translated `t('yes')`/`t('no')`
- Update analytics test to expect translated `yes`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b49cf4964c8320b5d04b6bb8814138