### PR TITLE
feat: add client-side analytics buffer and sync

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -2,6 +2,69 @@ import * as state from './state.js';
 import { diffMinutes } from './time.js';
 import { t } from './i18n.js';
 
+const LS_KEY = 'analytics_events';
+let buffer = [];
+
+function loadEvents() {
+  const raw = localStorage.getItem(LS_KEY);
+  if (!raw) return [];
+  try {
+    const events = JSON.parse(raw);
+    return Array.isArray(events) ? events : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveEvents(events) {
+  try {
+    if (events.length) localStorage.setItem(LS_KEY, JSON.stringify(events));
+    else localStorage.removeItem(LS_KEY);
+  } catch (e) {
+    console.error('Failed to save analytics events', e);
+  }
+}
+
+export function track(eventName, payload = {}) {
+  buffer.push({
+    event: eventName,
+    payload,
+    ts: new Date().toISOString(),
+  });
+}
+
+export async function sync() {
+  if (!navigator.onLine) return;
+  const events = loadEvents();
+  if (!events.length) return;
+  try {
+    const res = await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ events }),
+    });
+    if (res.ok) localStorage.removeItem(LS_KEY);
+  } catch (e) {
+    console.error('Failed to sync analytics', e);
+  }
+}
+
+export function flush() {
+  const stored = loadEvents();
+  if (buffer.length) {
+    saveEvents(stored.concat(buffer));
+    buffer = [];
+  }
+  return sync();
+}
+
+export function initAnalytics() {
+  window.addEventListener('online', sync);
+  window.addEventListener('offline', flush);
+  setInterval(flush, 30000);
+  sync();
+}
+
 /**
  * Render analytics KPIs into the analytics section.
  */

--- a/js/app.js
+++ b/js/app.js
@@ -19,6 +19,7 @@ import { setupPillState } from './pill.js';
 import { setupLkw } from './lkw.js';
 import { initNIHSS } from './nihss.js';
 import { initI18n } from './i18n.js';
+import { initAnalytics } from './analytics.js';
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
@@ -46,7 +47,7 @@ function flushSave(id, name, cb) {
 
 function bind() {
   const inputs = getInputs();
-
+  initAnalytics();
   setupIntervals(inputs);
   setupHeaderHeight();
   setupToolbarNavigation();


### PR DESCRIPTION
## Summary
- add analytics event buffer with track/flush/sync
- persist events in localStorage and sync when online
- initialize analytics during app startup

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b49e3266788320ab477788b146f6ae