### PR TITLE
feat: add global error logging

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -22,6 +22,11 @@ function saveEvents(events) {
     else localStorage.removeItem(LS_KEY);
   } catch (e) {
     console.error('Failed to save analytics events', e);
+    track('error', {
+      message: 'Failed to save analytics events',
+      stack: e?.stack,
+      source: 'analytics.js',
+    });
   }
 }
 
@@ -46,6 +51,11 @@ export async function sync() {
     if (res.ok) localStorage.removeItem(LS_KEY);
   } catch (e) {
     console.error('Failed to sync analytics', e);
+    track('error', {
+      message: 'Failed to sync analytics',
+      stack: e?.stack,
+      source: 'analytics.js',
+    });
   }
 }
 

--- a/js/app.js
+++ b/js/app.js
@@ -1,3 +1,4 @@
+import { initErrorLogger } from './errorLogger.js';
 import { getInputs } from './state.js';
 import { updateDrugDefaults } from './drugs.js';
 import { updateAge } from './age.js';
@@ -19,12 +20,19 @@ import { setupPillState } from './pill.js';
 import { setupLkw } from './lkw.js';
 import { initNIHSS } from './nihss.js';
 import { initI18n } from './i18n.js';
-import { initAnalytics } from './analytics.js';
+import { initAnalytics, track } from './analytics.js';
+
+initErrorLogger();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
     navigator.serviceWorker.register('/sw.js').catch((err) => {
       console.error('Service worker registration failed', err);
+      track('error', {
+        message: 'Service worker registration failed',
+        stack: err?.stack,
+        source: 'serviceWorker',
+      });
     });
   });
 }
@@ -80,6 +88,11 @@ async function init() {
     await initI18n();
   } catch (err) {
     console.error('Failed to initialize i18n', err);
+    track('error', {
+      message: 'Failed to initialize i18n',
+      stack: err?.stack,
+      source: 'i18n',
+    });
   } finally {
     bind();
   }

--- a/js/errorLogger.js
+++ b/js/errorLogger.js
@@ -1,0 +1,21 @@
+import { track } from './analytics.js';
+
+/**
+ * Initialize global error logging by listening to browser error events
+ * and forwarding them to the analytics tracker.
+ */
+export function initErrorLogger() {
+  window.addEventListener('error', (event) => {
+    const message = event.message;
+    const stack = event.error?.stack;
+    const source = event.filename || event.target?.src || '';
+    track('error', { message, stack, source });
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const reason = event.reason;
+    const message = reason?.message || String(reason);
+    const stack = reason?.stack;
+    track('error', { message, stack, source: 'unhandledrejection' });
+  });
+}

--- a/js/storage.js
+++ b/js/storage.js
@@ -61,6 +61,11 @@ export function getPatients() {
     return patients;
   } catch (e) {
     console.error(e);
+    track('error', {
+      message: e?.message || 'Failed to load patients',
+      stack: e?.stack,
+      source: 'storage.js',
+    });
     localStorage.removeItem(LS_KEY);
     return {};
   }
@@ -73,6 +78,11 @@ function setPatients(patients) {
     else localStorage.removeItem(LS_KEY);
   } catch (e) {
     console.error(e);
+    track('error', {
+      message: e?.message || 'Failed to save patients',
+      stack: e?.stack,
+      source: 'storage.js',
+    });
     showToast(t('storage_full'), { type: 'error' });
   }
 }


### PR DESCRIPTION
## Summary
- log window errors and unhandled promise rejections through analytics
- initialize error logger during app startup
- track previously logged errors for more context

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_68b5299c84e48320b729fcba83410089