### PR TITLE
feat: add analytics for sw and connectivity

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -69,8 +69,14 @@ export function flush() {
 }
 
 export function initAnalytics() {
-  window.addEventListener('online', sync);
-  window.addEventListener('offline', flush);
+  window.addEventListener('online', () => {
+    track('online');
+    sync();
+  });
+  window.addEventListener('offline', () => {
+    track('offline');
+    flush();
+  });
   setInterval(flush, 30000);
   sync();
 }

--- a/js/app.js
+++ b/js/app.js
@@ -26,14 +26,22 @@ initErrorLogger();
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js').catch((err) => {
-      console.error('Service worker registration failed', err);
-      track('error', {
-        message: 'Service worker registration failed',
-        stack: err?.stack,
-        source: 'serviceWorker',
+    navigator.serviceWorker
+      .register('/sw.js')
+      .then((reg) => {
+        track('sw_register_success');
+        navigator.serviceWorker.ready.then(() => track('sw_active'));
+        reg.addEventListener('updatefound', () => track('sw_update_found'));
+      })
+      .catch((err) => {
+        console.error('Service worker registration failed', err);
+        track('sw_register_error', { message: err.message });
+        track('error', {
+          message: 'Service worker registration failed',
+          stack: err?.stack,
+          source: 'serviceWorker',
+        });
       });
-    });
   });
 }
 


### PR DESCRIPTION
## Summary
- track online/offline status in analytics
- capture service worker registration, activation, and update events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b52d38013883208a6f75ca7bf68ac3