### PR TITLE
Use SVG for date picker buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,7 @@
       data-time-picker="a_gmp_time"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -233,7 +233,7 @@
                       data-time-picker="a_dob"
                       aria-label="Pasirinkti datą"
                     >
-                      📅
+                      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
                     </button>
                   </div>
                   <div id="a_age_display" class="subtle"></div>
@@ -423,7 +423,7 @@
       data-time-picker="t_door"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -486,7 +486,7 @@
       data-time-picker="t_lkw"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -534,7 +534,7 @@
       data-time-picker="t_sleep_start"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -582,7 +582,7 @@
       data-time-picker="t_sleep_end"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -1440,7 +1440,7 @@
       data-time-picker="t_thrombolysis"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"
@@ -1502,7 +1502,7 @@
       data-time-picker="d_time"
       aria-label="Pasirinkti datą ir laiką"
     >
-      📅
+      <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
     </button>
     <button
       type="button"


### PR DESCRIPTION
## Summary
- Replace calendar emoji with reusable SVG icon for all date picker buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5aa74c96c8320a50a8ded93e6bbbe