### PR TITLE
Add light theme with toggle

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -1,8 +1,9 @@
 ﻿:root {
-  color-scheme: dark;
   --header-height: 48px;
 }
+
 :root.dark {
+  color-scheme: dark;
   --bg: #0c1218;
   --card: #121a24;
   --ink: #e9f2fb;
@@ -20,6 +21,27 @@
   --btn-active-bg: #101720;
   --ghost-hover-bg: #18222e;
   --ghost-active-bg: #0d1319;
+}
+
+:root.light {
+  color-scheme: light;
+  --bg: #ffffff;
+  --card: #f1f5f9;
+  --ink: #0f172a;
+  --muted: #475569;
+  --line: #cbd5e1;
+  --accent: #4ea0f5;
+  --red: #e53935;
+  --yellow: #ffb74d;
+  --green: #00c853;
+  --ink2: #1e293b;
+  --button-bg: var(--card);
+  --yellow-text: #271400;
+  --yellow-border: #bf7d19;
+  --btn-hover-bg: #e2e8f0;
+  --btn-active-bg: #cbd5e1;
+  --ghost-hover-bg: #e2e8f0;
+  --ghost-active-bg: #cbd5e1;
 }
 *,
 *::before,

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="lt" class="dark">
+<html lang="lt" class="light">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -77,7 +77,9 @@
 
           </div>
         </details>
-      
+
+        <button id="themeToggle" class="btn" aria-label="Perjungti temą">🌙</button>
+
 <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
 
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -21,7 +21,9 @@ import { setupLkw } from './lkw.js';
 import { initNIHSS } from './nihss.js';
 import { initI18n } from './i18n.js';
 import { initAnalytics, track } from './analytics.js';
+import { initTheme, setupThemeToggle } from './theme.js';
 
+initTheme();
 initErrorLogger();
 
 if ('serviceWorker' in navigator) {
@@ -75,6 +77,7 @@ function bind() {
   setupBpHandlers();
   setupPillState();
   setupLkw(inputs);
+  setupThemeToggle();
 
   const { updateSaveStatus } = setupAutosave(inputs, {
     scheduleSave,

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,0 +1,30 @@
+const THEME_KEY = 'theme';
+
+export function initTheme() {
+  const saved = localStorage.getItem(THEME_KEY);
+  const preferred = saved || 'light';
+  const root = document.documentElement;
+  root.classList.remove('light', 'dark');
+  root.classList.add(preferred);
+}
+
+export function setupThemeToggle() {
+  const btn = document.getElementById('themeToggle');
+  if (!btn) return;
+  const root = document.documentElement;
+
+  const update = () => {
+    btn.textContent = root.classList.contains('dark') ? '☀️' : '🌙';
+  };
+
+  btn.addEventListener('click', () => {
+    const isDark = root.classList.contains('dark');
+    const newTheme = isDark ? 'light' : 'dark';
+    root.classList.remove('light', 'dark');
+    root.classList.add(newTheme);
+    localStorage.setItem(THEME_KEY, newTheme);
+    update();
+  });
+
+  update();
+}


### PR DESCRIPTION
## Summary
- define light color variables and color scheme
- add theme toggle button and script
- default page to light theme with persistent switch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5b3a721c483209abd16bc2cc876e9