### PR TITLE
Add patient sync and restore functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,8 @@
           </div>
         </details>
 
+        <button id="syncBtn" class="btn">Sync Now</button>
+
         <button id="themeToggle" class="btn" aria-label="Perjungti temą">🌙</button>
 
 <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>

--- a/js/storage.js
+++ b/js/storage.js
@@ -7,10 +7,12 @@ import { migrateSchema, SCHEMA_VERSION } from './storage/migrations.js';
 import { showToast } from './toast.js';
 import { t } from './i18n.js';
 import { track, flush } from './analytics.js';
+import { syncPatients, restorePatients } from './sync.js';
 
 const LS_KEY = 'insultoKomandaPatients_v1';
 
 window.addEventListener('unload', flush);
+if (typeof navigator !== 'undefined' && navigator.onLine) restorePatients();
 
 export function migratePatientRecord(id, p) {
   let changed = false;
@@ -179,6 +181,7 @@ export function savePatient(id, name) {
   };
   setPatients(patients);
   track('patient_save', { patientId, name: patientName });
+  if (typeof navigator !== 'undefined' && navigator.onLine) syncPatients();
   return patientId;
 }
 

--- a/js/sync.js
+++ b/js/sync.js
@@ -1,0 +1,33 @@
+const LS_KEY = 'insultoKomandaPatients_v1';
+
+export async function syncPatients() {
+  try {
+    const data = localStorage.getItem(LS_KEY) || '{}';
+    await fetch('/api/patients', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: data,
+    });
+  } catch (e) {
+    console.error('Failed to sync patients', e);
+  }
+}
+
+export async function restorePatients() {
+  try {
+    const res = await fetch('/api/patients');
+    if (!res.ok) return;
+    const data = await res.json();
+    if (data && typeof data === 'object') {
+      localStorage.setItem(LS_KEY, JSON.stringify(data));
+    }
+  } catch (e) {
+    console.error('Failed to restore patients', e);
+  }
+}
+
+if (typeof document !== 'undefined') {
+  document.getElementById('syncBtn')?.addEventListener('click', () => {
+    syncPatients();
+  });
+}


### PR DESCRIPTION
## Summary
- sync patients to `/api/patients` and restore from server
- call syncing after saves and on startup when online
- add **Sync Now** button in header

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ea0a7bbc832086c1867e7d7f4ee1