### PR TITLE
Add notification helpers and settings toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,6 +1630,13 @@
                     <option value="off">Išjungtas</option>
                   </select>
                 </div>
+                <div>
+                  <label>Pranešimai</label>
+                  <select id="notifications">
+                    <option value="on">Įjungti</option>
+                    <option value="off">Išjungti</option>
+                  </select>
+                </div>
               </div>
             </div>
           </details>

--- a/js/app.js
+++ b/js/app.js
@@ -22,6 +22,7 @@ import { initNIHSS } from './nihss.js';
 import { initI18n } from './i18n.js';
 import { initAnalytics, track } from './analytics.js';
 import { initTheme, setupThemeToggle } from './theme.js';
+import { setupNotificationToggle } from './notifications.js';
 
 initTheme();
 initErrorLogger();
@@ -78,6 +79,7 @@ function bind() {
   setupPillState();
   setupLkw(inputs);
   setupThemeToggle();
+  setupNotificationToggle();
 
   const { updateSaveStatus } = setupAutosave(inputs, {
     scheduleSave,

--- a/js/intervals.js
+++ b/js/intervals.js
@@ -1,5 +1,6 @@
 import { diffMinutes } from './time.js';
 import { showToast } from './toast.js';
+import { notify } from './notifications.js';
 
 const INTERVAL_LIMITS = {
   lkwThrombolysis: 270,
@@ -23,13 +24,14 @@ export function setupIntervals(inputs) {
         const over = diff > INTERVAL_LIMITS.lkwThrombolysis;
         lkwIntervalBox.classList.toggle('error', over);
         if (over) {
-          if (!lkwToastShown)
-            showToast(
-              'Viršytas Paskutinį kartą matytas sveikas→trombolizės intervalas',
-              {
-                type: 'warning',
-              },
-            );
+          if (!lkwToastShown) {
+            const msg =
+              'Viršytas Paskutinį kartą matytas sveikas→trombolizės intervalas';
+            showToast(msg, {
+              type: 'warning',
+            });
+            notify(msg);
+          }
           lkwToastShown = true;
         } else {
           lkwToastShown = false;
@@ -48,10 +50,13 @@ export function setupIntervals(inputs) {
         const over = diff > INTERVAL_LIMITS.doorThrombolysis;
         doorIntervalBox.classList.toggle('error', over);
         if (over) {
-          if (!doorToastShown)
-            showToast('Viršytas durų→trombolizės intervalas', {
+          if (!doorToastShown) {
+            const msg = 'Viršytas durų→trombolizės intervalas';
+            showToast(msg, {
               type: 'warning',
             });
+            notify(msg);
+          }
           doorToastShown = true;
         } else {
           doorToastShown = false;

--- a/js/notifications.js
+++ b/js/notifications.js
@@ -1,0 +1,41 @@
+const LS_KEY = 'notifications';
+
+export function requestPermission() {
+  if (typeof Notification === 'undefined') return Promise.resolve('denied');
+  if (Notification.permission === 'default') {
+    return Notification.requestPermission();
+  }
+  return Promise.resolve(Notification.permission);
+}
+
+function isEnabled() {
+  return (
+    typeof localStorage !== 'undefined' &&
+    localStorage.getItem(LS_KEY) !== 'off'
+  );
+}
+
+export function notify(message) {
+  if (typeof Notification === 'undefined') return;
+  if (!isEnabled()) return;
+  if (Notification.permission === 'granted') {
+    new Notification(message);
+  } else if (Notification.permission === 'default') {
+    requestPermission().then((perm) => {
+      if (perm === 'granted') new Notification(message);
+    });
+  }
+}
+
+export function setupNotificationToggle() {
+  if (typeof document === 'undefined') return;
+  const select = document.getElementById('notifications');
+  if (!select) return;
+  const saved = localStorage.getItem(LS_KEY) || 'off';
+  select.value = saved;
+  select.addEventListener('change', () => {
+    localStorage.setItem(LS_KEY, select.value);
+    if (select.value === 'on') requestPermission();
+  });
+  if (saved === 'on') requestPermission();
+}


### PR DESCRIPTION
## Summary
- add Notification API helper with requestPermission and notify
- show notifications alongside toast alerts for interval thresholds
- allow enabling/disabling notifications via settings with preference stored in localStorage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ebfbe2c083208b2e9a70e430453f