### PR TITLE
Add collaborative session syncing

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,15 @@
   <body>
     
   <div id="toastContainer" class="toast-container"></div>
+  <dialog id="collabDialog">
+    <form method="dialog">
+      <label for="collabRoomInput">Session ID</label>
+      <input id="collabRoomInput" type="text" />
+      <menu>
+        <button id="collabJoinBtn" class="btn">Join</button>
+      </menu>
+    </form>
+  </dialog>
   <header>
   <div class="wrap">
     <div class="brand">
@@ -79,6 +88,7 @@
         </details>
 
         <button id="syncBtn" class="btn">Sync Now</button>
+        <button id="joinCollabBtn" class="btn">Join Session</button>
 
         <button id="themeToggle" class="btn" aria-label="Perjungti temą">🌙</button>
 

--- a/js/collab.js
+++ b/js/collab.js
@@ -1,0 +1,65 @@
+let ws;
+let roomId;
+let suppress = false;
+let getPayload;
+let setPayload;
+
+async function ensureStorage() {
+  if (!getPayload || !setPayload) {
+    ({ getPayload, setPayload } = await import('./storage.js'));
+  }
+}
+
+async function broadcast() {
+  if (suppress) return;
+  if (!ws || ws.readyState !== WebSocket.OPEN || !roomId) return;
+  await ensureStorage();
+  ws.send(
+    JSON.stringify({ type: 'update', room: roomId, payload: getPayload() }),
+  );
+}
+
+function connect() {
+  if (typeof WebSocket === 'undefined') return;
+  const proto = location.protocol === 'https:' ? 'wss' : 'ws';
+  ws = new WebSocket(`${proto}://${location.host}/ws`);
+  ws.addEventListener('open', () => {
+    ws.send(JSON.stringify({ type: 'join', room: roomId }));
+    broadcast();
+  });
+  ws.addEventListener('message', async (ev) => {
+    let msg;
+    try {
+      msg = JSON.parse(ev.data);
+    } catch {
+      return;
+    }
+    if (msg.type === 'update' && msg.room === roomId && msg.payload) {
+      await ensureStorage();
+      suppress = true;
+      setPayload(msg.payload);
+      suppress = false;
+    }
+  });
+}
+
+export function initCollab() {
+  const joinBtn = document.getElementById('joinCollabBtn');
+  const dialog = document.getElementById('collabDialog');
+  const input = document.getElementById('collabRoomInput');
+  const joinDialogBtn = document.getElementById('collabJoinBtn');
+  const form = document.getElementById('appForm');
+
+  form?.addEventListener('input', () => {
+    void broadcast();
+  });
+
+  joinBtn?.addEventListener('click', () => dialog?.showModal());
+  joinDialogBtn?.addEventListener('click', () => {
+    dialog?.close();
+    const room = input?.value?.trim();
+    if (!room) return;
+    roomId = room;
+    connect();
+  });
+}

--- a/js/state.js
+++ b/js/state.js
@@ -1,4 +1,6 @@
 // Shared state and DOM helpers
+import { initCollab } from './collab.js';
+
 export const $ = (sel) => document.querySelector(sel);
 export const $$ = (sel) => Array.from(document.querySelectorAll(sel));
 
@@ -105,4 +107,5 @@ export function getInputs() {
 
 if (typeof document !== 'undefined') {
   state.autosave = dom.getAutosaveInput()?.value || 'on';
+  initCollab();
 }


### PR DESCRIPTION
## Summary
- add `collab.js` to sync form payloads over WebSocket rooms
- initialize collaboration in state module
- provide session join dialog and button

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5ee9e631483208b0cc08bf65f8329