### PR TITLE
fix: restore dark mode toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,8 +77,10 @@
 
           </div>
         </details>
-      
-<button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
+
+        <button id="themeToggle" class="btn" aria-label="Perjungti temą">🌙</button>
+
+        <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">☰ <span class="btn-label">Meniu</span></button>
 
     </div>
   </div>


### PR DESCRIPTION
## Summary
- restore theme toggle button in header to allow switching between light and dark modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67d89b3fc8320941240dbd1ed5ffe