### PR TITLE
Copy service worker from src with error handling

### DIFF
--- a/build.js
+++ b/build.js
@@ -19,7 +19,12 @@ async function buildCss() {
 }
 
 async function copySw() {
-  await fs.copyFile('sw.js', 'sw.js');
+  try {
+    await fs.copyFile('src/sw.js', 'sw.js');
+  } catch (error) {
+    console.error('Failed to copy service worker:', error);
+    throw error;
+  }
 }
 
 try {

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,52 @@
+const CACHE_NAME = 'stroke-cache-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/css/style.css',
+  '/js/app.js',
+  '/locales/en.json',
+  '/locales/lt.json',
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key)))
+    )
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then((cached) => {
+      if (cached) {
+        return cached;
+      }
+      return fetch(event.request)
+        .then((response) => {
+          if (!response || response.status !== 200 || response.type === 'opaque') {
+            return response;
+          }
+          const responseClone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+          return response;
+        })
+        .catch(() => {
+          if (event.request.mode === 'navigate') {
+            return caches.match('/index.html');
+          }
+        });
+    })
+  );
+});
+


### PR DESCRIPTION
## Summary
- Copy service worker from src/sw.js during build with try/catch error handling.
- Include service worker source file under src/.

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6c9b567648320a0071f316755bb73