### PR TITLE
Restrict service worker caching to same-origin assets

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'stroke-cache-v1';
+const CACHE_NAME = 'stroke-cache-v2';
 const ASSETS = [
   '/',
   '/index.html',
@@ -27,25 +27,39 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
+  const url = new URL(event.request.url);
+
+  if (url.origin !== self.location.origin) {
+    return;
+  }
+
+  if (event.request.mode === 'navigate') {
+    event.respondWith(
+      fetch(event.request).catch(() => caches.match('/index.html'))
+    );
+    return;
+  }
+
+  const allowedPaths = ['/css/', '/js/', '/locales/'];
+  if (!allowedPaths.some((path) => url.pathname.startsWith(path))) {
+    return;
+  }
+
   event.respondWith(
     caches.match(event.request).then((cached) => {
       if (cached) {
         return cached;
       }
-      return fetch(event.request)
-        .then((response) => {
-          if (!response || response.status !== 200 || response.type === 'opaque') {
-            return response;
-          }
-          const responseClone = response.clone();
-          caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseClone));
+      return fetch(event.request).then((response) => {
+        if (!response || response.status !== 200 || response.type === 'opaque') {
           return response;
-        })
-        .catch(() => {
-          if (event.request.mode === 'navigate') {
-            return caches.match('/index.html');
-          }
-        });
+        }
+        const responseClone = response.clone();
+        caches
+          .open(CACHE_NAME)
+          .then((cache) => cache.put(event.request, responseClone));
+        return response;
+      });
     })
   );
 });


### PR DESCRIPTION
## Summary
- Only handle same-origin requests in service worker fetch handler
- Limit runtime caching to CSS, JS and locale paths
- Bump cache name to `stroke-cache-v2` for fresh assets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6cf0e813c8320ac8232479a9597e0