### PR TITLE
Add PWA manifest and cache icons

### DIFF
--- a/build.js
+++ b/build.js
@@ -27,8 +27,17 @@ async function copySw() {
   }
 }
 
+async function copyManifest() {
+  try {
+    await fs.copyFile('src/manifest.json', 'manifest.json');
+  } catch (error) {
+    console.error('Failed to copy manifest:', error);
+    throw error;
+  }
+}
+
 try {
-  await Promise.all([buildHtml(), buildCss(), copySw()]);
+  await Promise.all([buildHtml(), buildCss(), copySw(), copyManifest()]);
 } catch (error) {
   console.error('Build failed:', error);
   process.exit(1);

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Insulto komandos forma</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
     

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Insulto komandos forma",
+  "short_name": "Stroke Team",
+  "start_url": "/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "/icons/activation.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}
+

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "Insulto komandos forma",
+  "short_name": "Stroke Team",
+  "start_url": "/",
+  "display": "standalone",
+  "icons": [
+    {
+      "src": "/icons/activation.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}
+

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'stroke-cache-v2';
+const CACHE_NAME = 'stroke-cache-v3';
 const ASSETS = [
   '/',
   '/index.html',
@@ -6,6 +6,20 @@ const ASSETS = [
   '/js/app.js',
   '/locales/en.json',
   '/locales/lt.json',
+  '/manifest.json',
+  '/icons/activation.svg',
+  '/icons/analytics.svg',
+  '/icons/arrival.svg',
+  '/icons/date-picker.svg',
+  '/icons/decision.svg',
+  '/icons/menu.svg',
+  '/icons/nihss.svg',
+  '/icons/settings.svg',
+  '/icons/sun.svg',
+  '/icons/moon.svg',
+  '/icons/summary.svg',
+  '/icons/thrombolysis.svg',
+  '/icons/warning.svg'
 ];
 
 self.addEventListener('install', (event) => {
@@ -40,7 +54,7 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  const allowedPaths = ['/css/', '/js/', '/locales/'];
+  const allowedPaths = ['/css/', '/js/', '/locales/', '/icons/', '/manifest.json'];
   if (!allowedPaths.some((path) => url.pathname.startsWith(path))) {
     return;
   }

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Insulto komandos forma</title>
     <link rel="stylesheet" href="css/style.css" />
+    <link rel="manifest" href="/manifest.json" />
   </head>
   <body>
     {% block content %}{% endblock %}


### PR DESCRIPTION
## Summary
- Add web app manifest and link it to the layout
- Cache icons and manifest in service worker
- Copy manifest during build

## Testing
- `npm run build`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b70b782ba083209caff9290cdd24cb