### PR TITLE
feat: add export summary button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1616,7 +1616,10 @@
           ></textarea>
           <div class="sticky-actions">
             
-<button id="copySummaryBtn" title="Kopijuoti santrauką" aria-label="Kopijuoti santrauką" class="btn">📋 <span class="btn-label">Kopijuoti</span></button>
+<button id="copySummaryBtn" title="Kopijuoti santrauką" aria-label="Kopijuoti santrauką" class="btn" data-i18n-title="copy_summary" data-i18n-aria-label="copy_summary">📋 <span class="btn-label" data-i18n="copy">Kopijuoti</span></button>
+
+            
+<button id="exportSummaryBtn" title="Eksportuoti santrauką" aria-label="Eksportuoti santrauką" class="btn" data-i18n-title="export_summary" data-i18n-aria-label="export_summary">⬇️ <span class="btn-label" data-i18n="export_summary">Eksportuoti santrauką</span></button>
 
           </div>
         </section>

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -1,5 +1,5 @@
-{% macro actionButton(id, title, icon, label='', classes='', attrs='') %}
-<button id="{{ id }}"{% if title %} title="{{ title }}" aria-label="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}"{% if attrs %} {{ attrs|safe }}{% endif %}>{{ icon | safe }}{% if label %} <span class="btn-label">{{ label }}</span>{% endif %}</button>
+{% macro actionButton(id, title, icon, label='', classes='', attrs='', labelKey='') %}
+<button id="{{ id }}"{% if title %} title="{{ title }}" aria-label="{{ title }}"{% endif %} class="btn{% if classes %} {{ classes }}{% endif %}"{% if attrs %} {{ attrs|safe }}{% endif %}>{{ icon | safe }}{% if label %} <span class="btn-label"{% if labelKey %} data-i18n="{{ labelKey }}"{% endif %}>{{ label }}</span>{% endif %}</button>
 {% endmacro %}
 
 {% macro icon(name) %}

--- a/templates/sections/summary.njk
+++ b/templates/sections/summary.njk
@@ -12,6 +12,27 @@
             placeholder="Santrauka generuojama automatiškai"
           ></textarea>
           <div class="sticky-actions">
-            {{ actionButton('copySummaryBtn', 'Kopijuoti santrauką', '📋', 'Kopijuoti') }}
+            {{
+              actionButton(
+                'copySummaryBtn',
+                'Kopijuoti santrauką',
+                '📋',
+                'Kopijuoti',
+                '',
+                'data-i18n-title="copy_summary" data-i18n-aria-label="copy_summary"',
+                'copy'
+              )
+            }}
+            {{
+              actionButton(
+                'exportSummaryBtn',
+                'Eksportuoti santrauką',
+                '⬇️',
+                'Eksportuoti santrauką',
+                '',
+                'data-i18n-title="export_summary" data-i18n-aria-label="export_summary"',
+                'export_summary'
+              )
+            }}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add i18n-ready export summary button beside copy control
- support translated action button labels

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b70ef0a3b08320a741e68273ab7bd6