### PR TITLE
Add development WebSocket server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,13 @@ To build optimized assets run:
 npm run build
 ```
 
-Open `index.html` in a browser to use the app.
+To start the WebSocket server during development run:
+
+```sh
+npm start
+```
+
+Leave this running and open `index.html` in a browser to use the app. The frontend connects to `ws://localhost:3000/ws` for real-time updates.
 
 ## Offline support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "insulto-komandos-forma",
       "version": "1.0.0",
       "dependencies": {
-        "nunjucks": "^3.2.4"
+        "nunjucks": "^3.2.4",
+        "ws": "^8.18.3"
       },
       "devDependencies": {
         "autoprefixer": "^10.4.21",
@@ -3121,7 +3122,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "format": "prettier --write \"js/**/*.js\" \"test/**/*.js\"",
     "test": "node --test",
     "build": "node build.js",
+    "start": "node server/wsServer.js",
     "prepare": "husky install",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint js test"
   },
   "dependencies": {
-    "nunjucks": "^3.2.4"
+    "nunjucks": "^3.2.4",
+    "ws": "^8.18.3"
   }
 }

--- a/server/wsServer.js
+++ b/server/wsServer.js
@@ -1,0 +1,52 @@
+import http from 'http';
+import { WebSocketServer, WebSocket } from 'ws';
+
+const server = http.createServer();
+const wss = new WebSocketServer({ server, path: '/ws' });
+
+const rooms = new Map(); // roomId -> Set of clients
+
+wss.on('connection', (socket) => {
+  let roomId;
+
+  socket.on('message', (data) => {
+    let message;
+    try {
+      message = JSON.parse(data.toString());
+    } catch {
+      return;
+    }
+
+    if (message.type === 'join' && typeof message.room === 'string') {
+      if (roomId) {
+        rooms.get(roomId)?.delete(socket);
+      }
+      roomId = message.room;
+      if (!rooms.has(roomId)) {
+        rooms.set(roomId, new Set());
+      }
+      rooms.get(roomId).add(socket);
+    } else if (message.type === 'update' && roomId) {
+      const payload = JSON.stringify({ type: 'update', payload: message.payload });
+      for (const client of rooms.get(roomId) || []) {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(payload);
+        }
+      }
+    }
+  });
+
+  socket.on('close', () => {
+    if (roomId && rooms.has(roomId)) {
+      rooms.get(roomId).delete(socket);
+      if (rooms.get(roomId).size === 0) {
+        rooms.delete(roomId);
+      }
+    }
+  });
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`WebSocket server listening on ws://localhost:${PORT}/ws`);
+});


### PR DESCRIPTION
## Summary
- add basic Node `ws` server for room-based updates
- expose `npm start` script to run the WebSocket server
- document running the server alongside the frontend

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b719c767e08320a41d7f8c557a05dc