### PR TITLE
Respect saved theme preference on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,23 @@
 <!doctype html>
-<html lang="lt" class="dark">
+<html lang="lt">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script>
+      (function () {
+        let saved;
+        try {
+          saved = localStorage.getItem('theme');
+        } catch {
+          /* ignore */
+        }
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = saved || (prefersDark ? 'dark' : 'light');
+        const root = document.documentElement;
+        root.classList.remove('light', 'dark');
+        root.classList.add(theme);
+      })();
+    </script>
     <title>Insulto komandos forma</title>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="manifest" href="/manifest.json" />

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,8 +1,14 @@
 const THEME_KEY = 'theme';
 
 export function initTheme() {
-  const saved = localStorage.getItem(THEME_KEY);
-  const preferred = saved || 'light';
+  let saved;
+  try {
+    saved = localStorage.getItem(THEME_KEY);
+  } catch {
+    /* ignore */
+  }
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const preferred = saved || (prefersDark ? 'dark' : 'light');
   const root = document.documentElement;
   root.classList.remove('light', 'dark');
   root.classList.add(preferred);


### PR DESCRIPTION
## Summary
- Apply user's saved or system theme before CSS loads
- Align `initTheme` logic with initial theme selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b745416f9483208920b0c7355b6626