### PR TITLE
Improve toast responsiveness on narrow screens

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -460,6 +460,7 @@ section[data-tab='Intervencijos'] h3 {
     opacity 0.3s,
     transform 0.3s;
   position: relative;
+  max-width: calc(100vw - 40px);
 }
 .toast.success {
   background: var(--green);
@@ -480,6 +481,17 @@ section[data-tab='Intervencijos'] h3 {
 .toast.hide {
   opacity: 0;
   transform: translateY(10px);
+}
+
+@media (max-width: 480px) {
+  .toast-container {
+    top: 20px;
+    bottom: auto;
+    left: 50%;
+    right: auto;
+    transform: translateX(-50%);
+    align-items: center;
+  }
 }
 
 .info-box {


### PR DESCRIPTION
## Summary
- limit toast width to viewport and center on narrow screens
- reposition toast container to top center below 480px

## Testing
- `npm run lint`
- `npm test` *(fails: window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b7db906ee08320a3b24b8661c43eb0