### PR TITLE
Implement patient sync and restore merging

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -171,6 +171,7 @@ export function savePatient(id, name) {
     name: patientName,
     created: patients[patientId]?.created || now,
     lastUpdated: now,
+    needsSync: true,
     data: {
       version:
         (patients[patientId]?.data?.version || 0) < SCHEMA_VERSION

--- a/js/sync.js
+++ b/js/sync.js
@@ -1,33 +1,97 @@
+import { showToast } from './toast.js';
+import { t } from './i18n.js';
+import { track } from './analytics.js';
+
 const LS_KEY = 'insultoKomandaPatients_v1';
 
-export async function syncPatients() {
+function loadLocalPatients() {
   try {
-    const data = localStorage.getItem(LS_KEY) || '{}';
-    await fetch('/api/patients', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: data,
-    });
-  } catch (e) {
-    console.error('Failed to sync patients', e);
+    return JSON.parse(localStorage.getItem(LS_KEY) || '{}');
+  } catch {
+    return {};
   }
 }
 
+function saveLocalPatients(patients) {
+  localStorage.setItem(LS_KEY, JSON.stringify(patients));
+}
+
+export async function syncPatients() {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return;
+  const patients = loadLocalPatients();
+  let changed = false;
+  let failed = false;
+  for (const [id, p] of Object.entries(patients)) {
+    if (!p?.needsSync) continue;
+    try {
+      const res = await fetch('/api/patients', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(p),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      p.needsSync = false;
+      changed = true;
+    } catch (e) {
+      failed = true;
+      console.error('Failed to sync patient', id, e);
+      track('error', {
+        message: 'Failed to sync patient',
+        patientId: id,
+        stack: e?.stack,
+        source: 'sync.js',
+      });
+    }
+  }
+  if (changed) saveLocalPatients(patients);
+  if (failed) showToast(t('sync_failed'), { type: 'error' });
+}
+
 export async function restorePatients() {
+  if (typeof navigator !== 'undefined' && !navigator.onLine) return;
   try {
     const res = await fetch('/api/patients');
-    if (!res.ok) return;
-    const data = await res.json();
-    if (data && typeof data === 'object') {
-      localStorage.setItem(LS_KEY, JSON.stringify(data));
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const serverData = await res.json();
+    if (!serverData || typeof serverData !== 'object') return;
+    const localData = loadLocalPatients();
+    let changed = false;
+    const merged = { ...localData };
+    for (const [id, remote] of Object.entries(serverData)) {
+      const local = merged[id];
+      if (!local) {
+        merged[id] = { ...remote, needsSync: false };
+        changed = true;
+      } else {
+        const lt = new Date(local.lastUpdated || 0).getTime();
+        const rt = new Date(remote.lastUpdated || 0).getTime();
+        if (rt > lt) {
+          merged[id] = { ...remote, needsSync: false };
+          changed = true;
+        }
+      }
     }
+    if (changed) saveLocalPatients(merged);
   } catch (e) {
     console.error('Failed to restore patients', e);
+    track('error', {
+      message: 'Failed to restore patients',
+      stack: e?.stack,
+      source: 'sync.js',
+    });
+    showToast(t('restore_failed'), { type: 'error' });
   }
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('online', () => {
+    syncPatients();
+    restorePatients();
+  });
 }
 
 if (typeof document !== 'undefined') {
   document.getElementById('syncBtn')?.addEventListener('click', () => {
-    syncPatients();
+    syncPatients().then(restorePatients);
   });
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -26,5 +26,7 @@
   "room_id": "Room ID",
   "join": "Join",
   "yes": "Yes",
-  "no": "No"
+  "no": "No",
+  "sync_failed": "Failed to sync patients.",
+  "restore_failed": "Failed to restore patients."
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -26,5 +26,7 @@
   "room_id": "Kambario ID",
   "join": "Prisijungti",
   "yes": "Taip",
-  "no": "Ne"
+  "no": "Ne",
+  "sync_failed": "Nepavyko sinchronizuoti pacientų.",
+  "restore_failed": "Nepavyko atkurti pacientų."
 }


### PR DESCRIPTION
## Summary
- Mark saved patients as needing sync and invoke syncing when online
- Push individual patient updates and merge remote data on restore
- Translate sync error messages for English and Lithuanian

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87ae04b848320aa415ff29440e8d4