### PR TITLE
Add environment configuration support and examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+DATABASE_URL=postgres://user:password@localhost:5432/mydb
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+
+.env

--- a/server/wsServer.js
+++ b/server/wsServer.js
@@ -1,5 +1,8 @@
 import http from 'http';
 import { WebSocketServer, WebSocket } from 'ws';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const server = http.createServer();
 const wss = new WebSocketServer({ server, path: '/ws' });


### PR DESCRIPTION
## Summary
- ignore local `.env` files in version control
- add `.env.example` documenting `DATABASE_URL` and `PORT`
- load environment variables in WebSocket server using `dotenv`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b87dad218083209ed7177919870d1f