### PR TITLE
Add database configuration example and docs

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://user:password@host:5432/dbname

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ npm run build
 
 For additional database setup details and using Docker Compose for a local PostgreSQL instance, see [docs/postgres.md](docs/postgres.md).
 
+## Database setup
+
+Create a `.env` file in the project root with your database connection string:
+
+```sh
+DATABASE_URL=postgres://user:password@host:5432/dbname
+```
+
+Replace `user`, `password`, `host`, and `dbname` with your own PostgreSQL credentials.  
+You may also set `PORT` to choose the server's HTTP port (default: `3000`).
+
 ## Real-time collaboration
 
 The app ships with a small WebSocket server that syncs form data between browsers.


### PR DESCRIPTION
## Summary
- add `.env` with sample `DATABASE_URL`
- document database configuration in new "Database setup" section of README

## Testing
- `npm test` *(fails: TypeError window.matchMedia is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68b88ea94a2c8320aac39200078f7335