### PR TITLE
feat: handle db connection failures

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -17,13 +17,19 @@ app.get('/api/patients', async (_req, res) => {
   let client;
   try {
     client = await pool.connect();
+  } catch (err) {
+    console.error('Error connecting to database for GET /api/patients', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+
+  try {
     const { rows } = await client.query('SELECT * FROM patients');
     res.status(200).json(rows);
   } catch (err) {
     console.error('Error fetching patients', err);
     res.status(500).json({ error: 'Internal server error' });
   } finally {
-    client?.release();
+    client.release();
   }
 });
 
@@ -37,6 +43,12 @@ app.post('/api/patients', async (req, res) => {
   let client;
   try {
     client = await pool.connect();
+  } catch (err) {
+    console.error('Error connecting to database for POST /api/patients', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+
+  try {
     const query =
       'INSERT INTO patients (patient_id, name, payload, last_updated) VALUES ($1, $2, $3, NOW()) ON CONFLICT (patient_id) DO UPDATE SET name = EXCLUDED.name, payload = EXCLUDED.payload, last_updated = NOW() RETURNING *';
     const values = [patient_id || null, name, payload || null];
@@ -46,7 +58,7 @@ app.post('/api/patients', async (req, res) => {
     console.error('Error upserting patient', err);
     res.status(500).json({ error: 'Internal server error' });
   } finally {
-    client?.release();
+    client.release();
   }
 });
 
@@ -64,6 +76,12 @@ app.post('/api/events', async (req, res) => {
   let client;
   try {
     client = await pool.connect();
+  } catch (err) {
+    console.error('Error connecting to database for POST /api/events', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+
+  try {
     const query =
       'INSERT INTO events (event, payload) VALUES ' +
       events.map((_, i) => `($${i * 2 + 1}, $${i * 2 + 2})`).join(', ');
@@ -74,7 +92,7 @@ app.post('/api/events', async (req, res) => {
     console.error('Error inserting events', err);
     res.status(500).json({ error: 'Internal server error' });
   } finally {
-    client?.release();
+    client.release();
   }
 });
 


### PR DESCRIPTION
## Summary
- log database connection failures in patients and events routes
- respond with HTTP 500 when DB connection cannot be established

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b892c3db748320bab4543bdfc84156