### PR TITLE
feat: make API base configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,25 @@ This happens automatically when the page goes online and can also be triggered
 manually via the **Sync** button. Keep the backend server running so changes
 are persisted to the database.
 
+### Configuring the API base URL
+
+By default the frontend sends requests to `/api`. When deploying the app in an
+environment where the API lives elsewhere, set the base URL either by defining
+`window.API_BASE` before loading the scripts or via the `API_BASE`
+environment variable at build time:
+
+```html
+<script>
+  window.API_BASE = 'https://example.com/api';
+</script>
+```
+
+```sh
+API_BASE=https://example.com/api npm run build
+```
+
+If no API is available, the sync logic silently skips network calls.
+
 ## Offline support
 
 The app registers a Service Worker that caches the core HTML, CSS, JavaScript


### PR DESCRIPTION
## Summary
- read API base from `window.API_BASE` or `API_BASE` env var
- skip syncing errors when `/api/patients` returns 404
- document configuring API base for deployments

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `node - <<'NODE'
import { restorePatients } from './js/sync.js';

// stub globals
global.navigator = { onLine: true };
const errors = [];
console.error = (...args) => { errors.push(args.join(' ')); };

global.fetch = async () => ({ status:404, ok:false, json: async () => ({}) });

await restorePatients();
console.log('errors', errors.length);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b93f39d3e88320be733850cc36ee9c