### PR TITLE
Fix analytics event sync payload

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -46,7 +46,7 @@ export async function sync() {
     const res = await fetch('/api/events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ events }),
+      body: JSON.stringify(events),
     });
     if (res.ok) localStorage.removeItem(LS_KEY);
   } catch (e) {


### PR DESCRIPTION
## Summary
- fix analytics event payload to send array directly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9465a593c8320a3161e4f9adfcd2c