### PR TITLE
Respect API_BASE for analytics events

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ are persisted to the database.
 
 ### Configuring the API base URL
 
-By default the frontend sends requests to `/api`. When deploying the app in an
-environment where the API lives elsewhere, set the base URL either by defining
-`window.API_BASE` before loading the scripts or via the `API_BASE`
+By default the frontend sends requests to `/api`. This base URL is used for
+both patient synchronization and analytics event uploads. When deploying the
+app in an environment where the API lives elsewhere, set the base URL either by
+defining `window.API_BASE` before loading the scripts or via the `API_BASE`
 environment variable at build time:
 
 ```html

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -4,6 +4,10 @@ import { t } from './i18n.js';
 
 const LS_KEY = 'analytics_events';
 let buffer = [];
+const API_BASE =
+  (typeof window !== 'undefined' && window.API_BASE) ||
+  (typeof process !== 'undefined' && process.env.API_BASE) ||
+  '/api';
 
 function loadEvents() {
   const raw = localStorage.getItem(LS_KEY);
@@ -43,7 +47,7 @@ export async function sync() {
   const events = loadEvents();
   if (!events.length) return;
   try {
-    const res = await fetch('/api/events', {
+    const res = await fetch(`${API_BASE}/events`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(events),


### PR DESCRIPTION
## Summary
- use configurable API_BASE when posting analytics events
- document that patient sync and analytics use the same API base URL

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b94847105c8320ab9ea320bea9349e