### PR TITLE
fix: use relative api base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Leave the server running while using the app.
 The browser stores patient records in `localStorage` so the app works offline.
 When connectivity is available the client:
 
-1. Sends any unsynced patients to `POST /api/patients`.
-2. Fetches the latest records from `GET /api/patients`.
+1. Sends any unsynced patients to `POST api/patients`.
+2. Fetches the latest records from `GET api/patients`.
 
 This happens automatically when the page goes online and can also be triggered
 manually via the **Sync** button. Keep the backend server running so changes
@@ -106,7 +106,7 @@ are persisted to the database.
 
 ### Configuring the API base URL
 
-By default the frontend sends requests to `/api`. This base URL is used for
+By default the frontend sends requests to `api`. This base URL is used for
 both patient synchronization and analytics event uploads. When deploying the
 app in an environment where the API lives elsewhere, set the base URL either by
 defining `window.API_BASE` before loading the scripts or via the `API_BASE`

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -7,7 +7,7 @@ let buffer = [];
 const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
   (typeof process !== 'undefined' && process.env.API_BASE) ||
-  '/api';
+  'api';
 
 function loadEvents() {
   const raw = localStorage.getItem(LS_KEY);

--- a/js/sync.js
+++ b/js/sync.js
@@ -6,7 +6,7 @@ const LS_KEY = 'insultoKomandaPatients_v1';
 const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
   (typeof process !== 'undefined' && process.env.API_BASE) ||
-  '/api';
+  'api';
 
 function loadLocalPatients() {
   try {


### PR DESCRIPTION
## Summary
- use relative `api` base path for patient sync and analytics
- document relative default API base in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b951f685588320833f74a3057a6058