### PR TITLE
Use /api as default API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Leave the server running while using the app.
 The browser stores patient records in `localStorage` so the app works offline.
 When connectivity is available the client:
 
-1. Sends any unsynced patients to `POST api/patients`.
-2. Fetches the latest records from `GET api/patients`.
+1. Sends any unsynced patients to `POST /api/patients`.
+2. Fetches the latest records from `GET /api/patients`.
 
 This happens automatically when the page goes online and can also be triggered
 manually via the **Sync** button. Keep the backend server running so changes
@@ -106,7 +106,7 @@ are persisted to the database.
 
 ### Configuring the API base URL
 
-By default the frontend sends requests to `api`. This base URL is used for
+By default the frontend sends requests to `/api`. This base URL is used for
 both patient synchronization and analytics event uploads. When deploying the
 app in an environment where the API lives elsewhere, set the base URL either by
 defining `window.API_BASE` before loading the scripts or via the `API_BASE`

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -7,7 +7,7 @@ let buffer = [];
 const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
   (typeof process !== 'undefined' && process.env.API_BASE) ||
-  'api';
+  '/api';
 
 function loadEvents() {
   const raw = localStorage.getItem(LS_KEY);

--- a/js/sync.js
+++ b/js/sync.js
@@ -6,7 +6,7 @@ const LS_KEY = 'insultoKomandaPatients_v1';
 const API_BASE =
   (typeof window !== 'undefined' && window.API_BASE) ||
   (typeof process !== 'undefined' && process.env.API_BASE) ||
-  'api';
+  '/api';
 
 function loadLocalPatients() {
   try {

--- a/test/apiBaseOverride.test.js
+++ b/test/apiBaseOverride.test.js
@@ -1,0 +1,58 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+// Ensure process.env.API_BASE is respected in sync.js
+
+test(
+  'process.env.API_BASE overrides default in sync.js',
+  { concurrency: false },
+  async () => {
+    process.env.API_BASE = 'https://example.com/api';
+    navigator.onLine = true;
+    localStorage.setItem(
+      'insultoKomandaPatients_v1',
+      JSON.stringify({ a: { needsSync: true, name: 'Alice' } }),
+    );
+    const calls = [];
+    const origFetch = global.fetch;
+    global.fetch = async (url) => {
+      calls.push(url);
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+
+    const { syncPatients } = await import('../js/sync.js?env');
+    await syncPatients();
+
+    assert.equal(calls[0], 'https://example.com/api/patients');
+    global.fetch = origFetch;
+    delete process.env.API_BASE;
+  },
+);
+
+// Ensure window.API_BASE is respected in analytics.js
+
+test(
+  'window.API_BASE overrides default in analytics.js',
+  { concurrency: false },
+  async () => {
+    window.API_BASE = 'https://example.com/api';
+    navigator.onLine = true;
+    localStorage.setItem(
+      'analytics_events',
+      JSON.stringify([{ event: 'load' }]),
+    );
+    const calls = [];
+    const origFetch = global.fetch;
+    global.fetch = async (url) => {
+      calls.push(url);
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+
+    const { sync } = await import('../js/analytics.js?win');
+    await sync();
+
+    assert.equal(calls[0], 'https://example.com/api/events');
+    global.fetch = origFetch;
+  },
+);


### PR DESCRIPTION
## Summary
- default to `/api` for frontend API requests in sync and analytics modules
- update documentation to show `/api` endpoints
- add tests ensuring `window.API_BASE` and `process.env.API_BASE` override the default

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b95786e7888320ae7dd53faecd65bd