### PR TITLE
Handle array patient restore

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -63,7 +63,15 @@ export async function restorePatients() {
     const localData = loadLocalPatients();
     let changed = false;
     const merged = { ...localData };
-    for (const [id, remote] of Object.entries(serverData)) {
+    const remotes = Array.isArray(serverData)
+      ? serverData
+      : Object.entries(serverData).map(([id, data]) => ({
+          ...data,
+          patient_id: id,
+        }));
+    for (const remote of remotes) {
+      const id = remote?.patient_id;
+      if (!id) continue;
       const local = merged[id];
       if (!local) {
         merged[id] = { ...remote, needsSync: false };

--- a/test/restorePatients.test.js
+++ b/test/restorePatients.test.js
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+const { restorePatients } = await import('../js/sync.js');
+
+const LS_KEY = 'insultoKomandaPatients_v1';
+
+function setLocal(data) {
+  localStorage.setItem(LS_KEY, JSON.stringify(data));
+}
+
+function getLocal() {
+  return JSON.parse(localStorage.getItem(LS_KEY) || '{}');
+}
+
+test('restorePatients merges array responses using patient_id', async () => {
+  localStorage.clear();
+  setLocal({ local1: { name: 'Local', lastUpdated: '2020-01-01' } });
+  navigator.onLine = true;
+
+  const remotePatients = [
+    {
+      patient_id: 'remote1',
+      name: 'Remote',
+      lastUpdated: '2024-01-01',
+    },
+  ];
+
+  global.fetch = async () => ({
+    status: 200,
+    ok: true,
+    json: async () => remotePatients,
+  });
+
+  await restorePatients();
+
+  const stored = getLocal();
+  assert.ok(stored.local1);
+  assert.ok(stored.remote1);
+  assert.equal(stored.remote1.name, 'Remote');
+  assert.equal(stored.remote1.needsSync, false);
+});


### PR DESCRIPTION
## Summary
- support restoring patients from array responses using `patient_id`
- test restoration when server returns an array

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9599eac2c83208e99dcf717b7092c