### PR TITLE
Redirect /patients to /api/patients and clarify docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Requires Node.js 20 or later and access to a PostgreSQL database.
    ```
 
    The API is now available at `http://localhost:3000`.
+   Patient endpoints are namespaced under `/api`; use `/api/patients` for
+   patient data. Requests to `/patients` without the `/api` prefix will be
+   redirected to the correct path.
 
 To build optimized assets run:
 

--- a/server/index.js
+++ b/server/index.js
@@ -83,6 +83,11 @@ const app = express();
 
 app.use(express.json());
 
+// Redirect legacy /patients path to the new /api/patients endpoint
+app.use('/patients', (req, res) => {
+  res.redirect(307, '/api/patients');
+});
+
 // GET /api/patients → return all patient records
 app.get('/api/patients', async (_req, res) => {
   let client;

--- a/test/patientsRedirect.test.js
+++ b/test/patientsRedirect.test.js
@@ -1,0 +1,24 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.NODE_ENV = 'test';
+
+const { app } = await import('../server/index.js');
+
+let server;
+let baseUrl;
+
+before(() => {
+  server = app.listen(0);
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  server.close();
+});
+
+test('GET /patients redirects to /api/patients', async () => {
+  const res = await fetch(`${baseUrl}/patients`, { redirect: 'manual' });
+  assert.equal(res.status, 307);
+  assert.equal(res.headers.get('location'), '/api/patients');
+});


### PR DESCRIPTION
## Summary
- redirect legacy `/patients` path to `/api/patients`
- document correct patient endpoint in README
- test redirect behaviour

## Testing
- `npm test` *(hangs after running; last output shows tests completed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b962a83cd88320ac311d8fbbbdcbdc