### PR TITLE
Add local storage mode toggle

### DIFF
--- a/js/storage.js
+++ b/js/storage.js
@@ -12,7 +12,8 @@ import { syncPatients, restorePatients } from './sync.js';
 const LS_KEY = 'insultoKomandaPatients_v1';
 
 window.addEventListener('unload', flush);
-if (typeof navigator !== 'undefined' && navigator.onLine) restorePatients();
+if (typeof navigator !== 'undefined' && navigator.onLine && !window.disableSync)
+  restorePatients();
 
 export function migratePatientRecord(id, p) {
   let changed = false;
@@ -182,7 +183,12 @@ export function savePatient(id, name) {
   };
   setPatients(patients);
   track('patient_save', { patientId, name: patientName });
-  if (typeof navigator !== 'undefined' && navigator.onLine) syncPatients();
+  if (
+    !window.disableSync &&
+    typeof navigator !== 'undefined' &&
+    navigator.onLine
+  )
+    syncPatients();
   return patientId;
 }
 

--- a/js/sync.js
+++ b/js/sync.js
@@ -21,6 +21,7 @@ function saveLocalPatients(patients) {
 }
 
 export async function syncPatients() {
+  if (typeof window !== 'undefined' && window.disableSync) return;
   if (typeof navigator !== 'undefined' && !navigator.onLine) return;
   const patients = loadLocalPatients();
   let changed = false;
@@ -53,6 +54,7 @@ export async function syncPatients() {
 }
 
 export async function restorePatients() {
+  if (typeof window !== 'undefined' && window.disableSync) return;
   if (typeof navigator !== 'undefined' && !navigator.onLine) return;
   try {
     const res = await fetch(`${API_BASE}/patients`);
@@ -107,5 +109,9 @@ if (typeof window !== 'undefined') {
 if (typeof document !== 'undefined') {
   document.getElementById('syncBtn')?.addEventListener('click', () => {
     syncPatients().then(restorePatients);
+  });
+  document.getElementById('enableLocalBtn')?.addEventListener('click', () => {
+    window.disableSync = true;
+    showToast(t('local_storage_enabled'), { type: 'info' });
   });
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -28,5 +28,8 @@
   "yes": "Yes",
   "no": "No",
   "sync_failed": "Failed to sync patients.",
-  "restore_failed": "Failed to restore patients."
+  "restore_failed": "Failed to restore patients.",
+  "enable_local_storage": "Enable local storage",
+  "local_storage": "Local storage",
+  "local_storage_enabled": "Local storage enabled; server sync disabled."
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -28,5 +28,8 @@
   "yes": "Taip",
   "no": "Ne",
   "sync_failed": "Nepavyko sinchronizuoti pacientų.",
-  "restore_failed": "Nepavyko atkurti pacientų."
+  "restore_failed": "Nepavyko atkurti pacientų.",
+  "enable_local_storage": "Įjungti vietinę saugyklą",
+  "local_storage": "Vietinė saugykla",
+  "local_storage_enabled": "Vietinė saugykla įjungta; serverio sinchronizavimas išjungtas."
 }

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -36,6 +36,17 @@
       </details>
       {{
         actionButton(
+          'enableLocalBtn',
+          'Enable local storage',
+          icon('save'),
+          'Local storage',
+          '',
+          'data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage"',
+          'local_storage'
+        )
+      }}
+      {{
+        actionButton(
           'joinCollabBtn',
           'Bendradarbiauti',
           icon('users'),


### PR DESCRIPTION
## Summary
- add header button to enable local-only mode and show confirmation toast
- skip patient sync and restore when local-only mode is active
- add translations for new local-only controls

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97624bc8083208b42919c307d8d80