### PR TITLE
Show LKW messages only when radio selected

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -112,7 +112,11 @@ export function initActivation() {
   };
 
   lkwInputs.forEach((el) => {
-    el.addEventListener('change', () => {
+    el.addEventListener('change', (e) => {
+      if (!e.isTrusted || !e.target.checked || !el.checked) {
+        updateLkwBadge();
+        return;
+      }
       if (el.value === '<4.5') {
         showToast('Aktyvuokite insulto komandą', { type: 'info' });
       } else if (el.value === '4.5-24') {


### PR DESCRIPTION
## Summary
- Only show activation toasts when LKW radio buttons are checked by the user.
- Ignore programmatic changes and unchecked radios while always updating the SPS badge.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9848226c0832098ee7821cf2573aa