### PR TITLE
Add theme toggle button to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,11 +79,21 @@
         </div>
       </details>
       
+<button id="enableLocalBtn" title="Enable local storage" aria-label="Enable local storage" class="btn" data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
+
+ <span class="btn-label" data-i18n="local_storage">Local storage</span></button>
+
+      
 <button id="joinCollabBtn" title="Bendradarbiauti" aria-label="Bendradarbiauti" class="btn" data-i18n-title="collaborate" data-i18n-aria-label="collaborate">
 
 <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
 
  <span class="btn-label" data-i18n="collaborate">Bendradarbiauti</span></button>
+
+      
+<button id="themeToggle" title="Perjungti temą" aria-label="Perjungti temą" class="btn" data-i18n-title="toggle_theme" data-i18n-aria-label="toggle_theme"><img id="themeToggleIcon" src="icons/moon.svg" alt="" /></button>
 
       
 <button id="navToggle" class="btn" aria-expanded="false" aria-controls="mainNav">

--- a/locales/en.json
+++ b/locales/en.json
@@ -31,5 +31,6 @@
   "restore_failed": "Failed to restore patients.",
   "enable_local_storage": "Enable local storage",
   "local_storage": "Local storage",
-  "local_storage_enabled": "Local storage enabled; server sync disabled."
+  "local_storage_enabled": "Local storage enabled; server sync disabled.",
+  "toggle_theme": "Toggle theme"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -31,5 +31,6 @@
   "restore_failed": "Nepavyko atkurti pacientų.",
   "enable_local_storage": "Įjungti vietinę saugyklą",
   "local_storage": "Vietinė saugykla",
-  "local_storage_enabled": "Vietinė saugykla įjungta; serverio sinchronizavimas išjungtas."
+  "local_storage_enabled": "Vietinė saugykla įjungta; serverio sinchronizavimas išjungtas.",
+  "toggle_theme": "Perjungti temą"
 }

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -56,6 +56,16 @@
           'collaborate'
         )
       }}
+      {{
+        actionButton(
+          'themeToggle',
+          'Perjungti temą',
+          '<img id="themeToggleIcon" src="icons/moon.svg" alt="" />',
+          '',
+          '',
+          'data-i18n-title="toggle_theme" data-i18n-aria-label="toggle_theme"'
+        )
+      }}
       {{ actionButton('navToggle', '', icon('menu'), 'Meniu', '', 'aria-expanded="false" aria-controls="mainNav"') }}
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add theme toggle button and icon in header toolbar
- include English and Lithuanian translations for theme toggle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b99f291a2c8320a3342a76057b3f19