### PR TITLE
Disable thrombolysis start button when onset time unknown

### DIFF
--- a/js/drugControls.js
+++ b/js/drugControls.js
@@ -10,7 +10,13 @@ export function setupDrugControls(inputs) {
     const w = Number((inputs.weight?.value || '').replace(/,/g, '.'));
     const weightValid = Number.isFinite(w) && w > 0;
     const drugTypeValid = Boolean(inputs.drugType?.value);
-    startThrombolysisBtn.disabled = !(weightValid && drugTypeValid);
+    const requirementsInvalid = !(weightValid && drugTypeValid);
+    startThrombolysisBtn.dataset.requirementsInvalid = requirementsInvalid
+      ? 'true'
+      : 'false';
+    startThrombolysisBtn.disabled =
+      requirementsInvalid ||
+      startThrombolysisBtn.dataset.lkwDisabled === 'true';
   };
 
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>

--- a/js/lkw.js
+++ b/js/lkw.js
@@ -53,7 +53,11 @@ export function setupLkw(inputs) {
     const startBtn = document.getElementById('startThrombolysis');
     tab?.classList.toggle('disabled', disabled);
     tab?.toggleAttribute('disabled', disabled);
-    if (startBtn) startBtn.disabled = disabled;
+    if (startBtn) {
+      startBtn.dataset.lkwDisabled = disabled ? 'true' : 'false';
+      startBtn.disabled =
+        disabled || startBtn.dataset.requirementsInvalid === 'true';
+    }
   };
   inputs.lkw_type.forEach((o) =>
     o.addEventListener('change', updateThrombolysisAccess),

--- a/test/lkwThrombolysisButton.test.js
+++ b/test/lkwThrombolysisButton.test.js
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+import { setupLkw } from '../js/lkw.js';
+import { setupDrugControls } from '../js/drugControls.js';
+import { getInputs } from '../js/state.js';
+
+test('startThrombolysis button disables on unknown LKW', () => {
+  const inputs = getInputs();
+  setupLkw(inputs);
+  setupDrugControls(inputs);
+
+  inputs.weight.value = '70';
+  inputs.weight.dispatchEvent(new Event('input', { bubbles: true }));
+  inputs.drugType.value = 'tpa';
+  inputs.drugType.dispatchEvent(new Event('change', { bubbles: true }));
+
+  const startBtn = document.getElementById('startThrombolysis');
+
+  const lkwUnknown = inputs.lkw_type.find((o) => o.value === 'unknown');
+  lkwUnknown.checked = true;
+  lkwUnknown.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, true);
+
+  inputs.weight.value = '80';
+  inputs.weight.dispatchEvent(new Event('input', { bubbles: true }));
+  assert.equal(startBtn.disabled, true);
+
+  const lkwKnown = inputs.lkw_type.find((o) => o.value === 'known');
+  lkwKnown.checked = true;
+  lkwKnown.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, false);
+});


### PR DESCRIPTION
## Summary
- prevent thrombolysis start button from enabling when last known well is unknown
- track button disable state from onset time and dosage requirements
- add regression test for unknown onset

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9a64743a4832095fa6a9369bae883