### PR TITLE
Toggle local storage by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
         </div>
       </details>
       
-<button id="enableLocalBtn" title="Enable local storage" aria-label="Enable local storage" class="btn" data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage">
+<button id="enableLocalBtn" title="Enable local storage" aria-label="Enable local storage" class="btn" data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage" aria-pressed="true">
 
 <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
 

--- a/js/sync.js
+++ b/js/sync.js
@@ -13,6 +13,10 @@ const MAX_CONSECUTIVE_SYNC_FAILS = 3;
 let lastSyncFailToast = 0;
 let consecutiveSyncFails = 0;
 
+if (typeof window !== 'undefined') {
+  window.disableSync = true;
+}
+
 function loadLocalPatients() {
   try {
     return JSON.parse(localStorage.getItem(LS_KEY) || '{}');
@@ -131,8 +135,16 @@ if (typeof document !== 'undefined') {
   document.getElementById('syncBtn')?.addEventListener('click', () => {
     syncPatients().then(restorePatients);
   });
-  document.getElementById('enableLocalBtn')?.addEventListener('click', () => {
-    window.disableSync = true;
-    showToast(t('local_storage_enabled'), { type: 'info' });
+  const enableLocalBtn = document.getElementById('enableLocalBtn');
+  enableLocalBtn?.addEventListener('click', () => {
+    const enabled = enableLocalBtn.getAttribute('aria-pressed') !== 'true';
+    enableLocalBtn.setAttribute('aria-pressed', enabled);
+    window.disableSync = enabled;
+    if (enabled) {
+      showToast(t('local_storage_enabled'), { type: 'info' });
+    } else {
+      showToast(t('local_storage_disabled'), { type: 'info' });
+      syncPatients().then(restorePatients);
+    }
   });
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -32,5 +32,6 @@
   "enable_local_storage": "Enable local storage",
   "local_storage": "Local storage",
   "local_storage_enabled": "Local storage enabled; server sync disabled.",
+  "local_storage_disabled": "Local storage disabled; server sync enabled.",
   "toggle_theme": "Toggle theme"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -32,5 +32,6 @@
   "enable_local_storage": "Įjungti vietinę saugyklą",
   "local_storage": "Vietinė saugykla",
   "local_storage_enabled": "Vietinė saugykla įjungta; serverio sinchronizavimas išjungtas.",
+  "local_storage_disabled": "Vietinė saugykla išjungta; serverio sinchronizavimas įjungtas.",
   "toggle_theme": "Perjungti temą"
 }

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -41,7 +41,7 @@
           icon('save'),
           'Local storage',
           '',
-          'data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage"',
+          'data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage" aria-pressed="true"',
           'local_storage'
         )
       }}

--- a/test/apiBaseOverride.test.js
+++ b/test/apiBaseOverride.test.js
@@ -22,6 +22,7 @@ test(
     };
 
     const { syncPatients } = await import('../js/sync.js?env');
+    window.disableSync = false;
     await syncPatients();
 
     assert.equal(calls[0], 'https://example.com/api/patients');


### PR DESCRIPTION
## Summary
- turn the Local storage button into an on/off toggle
- enable local storage by default and sync on demand
- add translations and adjust tests for the new toggle behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba8ce2ec108320a86e37687488ee2a