### PR TITLE
Ensure bp entry buttons do not submit forms

### DIFF
--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -25,6 +25,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
 
   const timePickerBtn = document.createElement('button');
   timePickerBtn.className = 'btn ghost';
+  timePickerBtn.type = 'button';
   timePickerBtn.setAttribute('data-time-picker', timeId);
   timePickerBtn.setAttribute('aria-label', 'Pasirinkti laiką');
   const clockIcon = document.createElement('img');
@@ -35,6 +36,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
 
   const nowBtn = document.createElement('button');
   nowBtn.className = 'btn ghost';
+  nowBtn.type = 'button';
   nowBtn.setAttribute('data-now', timeId);
   nowBtn.textContent = 'Dabar';
   group.appendChild(nowBtn);
@@ -52,6 +54,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
 
   const removeBtn = document.createElement('button');
   removeBtn.className = 'btn ghost';
+  removeBtn.type = 'button';
   removeBtn.setAttribute('data-remove-bp', entryId);
   const closeIcon = document.createElement('img');
   closeIcon.src = 'icons/close.svg';

--- a/test/removeBpEntry.test.js
+++ b/test/removeBpEntry.test.js
@@ -2,11 +2,14 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 
-test('bp entry can be added and removed', async () => {
+test('bp entry can be removed even when #p_weight is invalid or empty', async () => {
   document.body.innerHTML = `
-    <button id="bpCorrBtn" class="btn"></button>
-    <div id="bpMedList"><button class="btn bp-med" data-med="Med" data-dose="1"></button></div>
-    <div id="bpEntries"></div>
+    <form>
+      <input id="p_weight" type="number" />
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
+      <div id="bpEntries"></div>
+    </form>
   `;
   const { setupBpEntry } = await import('../js/bp.js');
   const { handleBpEntriesClick } = await import('../js/bpEntries.js');
@@ -14,15 +17,20 @@ test('bp entry can be added and removed', async () => {
   setupBpEntry();
 
   const medBtn = document.querySelector('.bp-med');
-  medBtn.click();
-
   const bpEntries = document.getElementById('bpEntries');
-  assert.equal(bpEntries.children.length, 1);
-
   bpEntries.addEventListener('click', handleBpEntriesClick);
 
-  const removeBtn = bpEntries.querySelector('button[data-remove-bp]');
-  removeBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  // invalid weight
+  medBtn.click();
+  assert.equal(bpEntries.children.length, 1);
+  document.getElementById('p_weight').value = 'abc';
+  bpEntries.querySelector('button[data-remove-bp]').click();
+  assert.equal(bpEntries.children.length, 0);
 
+  // empty weight
+  medBtn.click();
+  assert.equal(bpEntries.children.length, 1);
+  document.getElementById('p_weight').value = '';
+  bpEntries.querySelector('button[data-remove-bp]').click();
   assert.equal(bpEntries.children.length, 0);
 });


### PR DESCRIPTION
## Summary
- Set explicit `type="button"` on dynamically created blood pressure buttons to avoid unintended form submissions
- Test that bp entry removal works even with invalid or empty patient weight

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baa2f149cc83208c58a768c5010281