### PR TITLE
Prevent bp entry time controls from submitting forms

### DIFF
--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -25,7 +25,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
 
   const timePickerBtn = document.createElement('button');
   timePickerBtn.className = 'btn ghost';
-  timePickerBtn.type = 'button';
+  timePickerBtn.setAttribute('type', 'button');
   timePickerBtn.setAttribute('data-time-picker', timeId);
   timePickerBtn.setAttribute('aria-label', 'Pasirinkti laiką');
   const clockIcon = document.createElement('img');
@@ -36,7 +36,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
 
   const nowBtn = document.createElement('button');
   nowBtn.className = 'btn ghost';
-  nowBtn.type = 'button';
+  nowBtn.setAttribute('type', 'button');
   nowBtn.setAttribute('data-now', timeId);
   nowBtn.textContent = 'Dabar';
   group.appendChild(nowBtn);

--- a/test/bpEntryButtons.test.js
+++ b/test/bpEntryButtons.test.js
@@ -1,0 +1,85 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+test('time picker works even when #p_weight is invalid or empty', async () => {
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="number" />
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+
+  const { setupBpEntry } = await import('../js/bp.js');
+  const { handleBpEntriesClick } = await import('../js/bpEntries.js');
+
+  setupBpEntry();
+
+  const medBtn = document.querySelector('.bp-med');
+  const bpEntries = document.getElementById('bpEntries');
+  bpEntries.addEventListener('click', handleBpEntriesClick);
+
+  medBtn.click();
+
+  const timePickerBtn = bpEntries.querySelector('button[data-time-picker]');
+
+  window.HTMLDialogElement = window.HTMLElement;
+  const origCreate = document.createElement.bind(document);
+  let opened = 0;
+  document.createElement = (tag, opts) => {
+    const el = origCreate(tag, opts);
+    if (tag === 'dialog') {
+      el.showModal = () => {
+        opened++;
+      };
+      el.close = () => {};
+    }
+    return el;
+  };
+
+  document.getElementById('p_weight').value = 'abc';
+  timePickerBtn.click();
+  assert.equal(opened, 1);
+
+  document.getElementById('p_weight').value = '';
+  timePickerBtn.click();
+  assert.equal(opened, 2);
+
+  document.createElement = origCreate;
+});
+
+test('now button sets time even when #p_weight is invalid or empty', async () => {
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="number" />
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+
+  const { setupBpEntry } = await import('../js/bp.js');
+  const { handleBpEntriesClick } = await import('../js/bpEntries.js');
+
+  setupBpEntry();
+
+  const medBtn = document.querySelector('.bp-med');
+  const bpEntries = document.getElementById('bpEntries');
+  bpEntries.addEventListener('click', handleBpEntriesClick);
+
+  medBtn.click();
+  const timeInput = bpEntries.querySelector('.time-input');
+  const nowBtn = bpEntries.querySelector('button[data-now]');
+
+  timeInput.value = '';
+  document.getElementById('p_weight').value = 'abc';
+  nowBtn.click();
+  assert.notEqual(timeInput.value, '');
+
+  timeInput.value = '';
+  document.getElementById('p_weight').value = '';
+  nowBtn.click();
+  assert.notEqual(timeInput.value, '');
+});


### PR DESCRIPTION
## Summary
- Ensure bp entry time picker and 'Dabar' buttons do not submit forms by explicitly setting `type="button"`
- Cover time picker and now buttons with tests for invalid or empty weight fields

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68baaafb10748320ab0c679107bc6c7c