### PR TITLE
Add regression test for BP entry removal

### DIFF
--- a/docs/remove-bp-entry-regression.md
+++ b/docs/remove-bp-entry-regression.md
@@ -1,0 +1,10 @@
+# Remove BP Entry Regression Test
+
+A regression occurred when the remove button for blood pressure entries lacked
+`type="button"`. When inside a form with an invalid or empty weight field, the
+button behaved as a submit button and native validation blocked the click, so
+the entry could not be removed.
+
+`test/removeBpEntry.test.js` simulates real user interaction by clicking on the
+DOM nodes. It verifies that entries can be removed even when the weight input is
+invalid or empty, ensuring the button remains `type="button"`.

--- a/test/removeBpEntry.test.js
+++ b/test/removeBpEntry.test.js
@@ -2,10 +2,29 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 
+/*
+  Regression test:
+  Removing a blood pressure entry used to fail when the weight field contained
+  an invalid value or was empty. The remove button acted as a submit button and
+  native form validation prevented the click from firing. This test simulates a
+  real user clicking the buttons so that the regression is caught if the button
+  loses type="button" again.
+*/
+
 test('bp entry can be removed even when #p_weight is invalid or empty', async () => {
+  const origClick = window.HTMLButtonElement.prototype.click;
+  window.HTMLButtonElement.prototype.click = function () {
+    // Simulate native validation: submit buttons won't click when form invalid
+    if (this.type === 'submit') {
+      const form = this.form;
+      if (form && !form.checkValidity()) return;
+    }
+    return origClick.call(this);
+  };
+
   document.body.innerHTML = `
     <form>
-      <input id="p_weight" type="number" />
+      <input id="p_weight" type="text" pattern="\\d+" required />
       <button id="bpCorrBtn" class="btn" type="button"></button>
       <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
       <div id="bpEntries"></div>
@@ -33,4 +52,6 @@ test('bp entry can be removed even when #p_weight is invalid or empty', async ()
   document.getElementById('p_weight').value = '';
   bpEntries.querySelector('button[data-remove-bp]').click();
   assert.equal(bpEntries.children.length, 0);
+
+  window.HTMLButtonElement.prototype.click = origClick;
 });


### PR DESCRIPTION
## Summary
- simulate user clicks on BP entry remove button inside a form to exercise native validation
- ensure BP entries are removable even when weight input is invalid or empty
- document regression scenario for BP entry removal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68babb7f54a0832094934fd47040a097