### PR TITLE
Use closest for BP entry removal

### DIFF
--- a/js/bpEntries.js
+++ b/js/bpEntries.js
@@ -7,8 +7,9 @@ export function handleBpEntriesClick(event) {
 
   if (handleTimeButton(target)) return;
 
-  if (target.matches('button[data-remove-bp]')) {
-    const entry = document.getElementById(target.dataset.removeBp);
+  const removeBtn = target.closest('button[data-remove-bp]');
+  if (removeBtn) {
+    const entry = document.getElementById(removeBtn.dataset.removeBp);
     entry?.remove();
   }
 }

--- a/test/removeBpEntry.test.js
+++ b/test/removeBpEntry.test.js
@@ -55,3 +55,29 @@ test('bp entry can be removed even when #p_weight is invalid or empty', async ()
 
   window.HTMLButtonElement.prototype.click = origClick;
 });
+
+test('bp entry can be removed by clicking the icon inside the remove button', async () => {
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="text" pattern="\\d+" required />
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+  const { setupBpEntry } = await import('../js/bp.js');
+  const { handleBpEntriesClick } = await import('../js/bpEntries.js');
+
+  setupBpEntry();
+
+  const medBtn = document.querySelector('.bp-med');
+  const bpEntries = document.getElementById('bpEntries');
+  bpEntries.addEventListener('click', handleBpEntriesClick);
+
+  medBtn.click();
+  assert.equal(bpEntries.children.length, 1);
+
+  const removeIcon = bpEntries.querySelector('button[data-remove-bp] img');
+  removeIcon.dispatchEvent(new window.MouseEvent('click', { bubbles: true }));
+  assert.equal(bpEntries.children.length, 0);
+});


### PR DESCRIPTION
## Summary
- ensure nested elements inside BP removal button trigger deletion
- add regression test for icon clicks removing BP entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bad267432c83208fa0ee9156fd74c1