### PR TITLE
Allow hiding 'Now' buttons for selected time inputs

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,14 +193,16 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="a_gmp_time"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="a_gmp_time"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -447,14 +449,16 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="t_door"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="t_door"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -514,14 +518,7 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="t_lkw"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -566,14 +563,7 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="t_sleep_start"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -618,14 +608,7 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="t_sleep_end"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -1494,14 +1477,16 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="t_thrombolysis"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="t_thrombolysis"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -1560,14 +1545,16 @@
 
 
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="d_time"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="d_time"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      
     <button
       type="button"
       class="btn ghost"
@@ -1612,24 +1599,24 @@
                     value="Rengiamasi MTE atlikimui"
                   />Rengiamasi MTE atlikimui</label
                 >
-                <label class="pill"
-                  ><input
-                    type="radio"
-                    name="d_decision"
-                    value="Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika"
-                  />Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika</label
-                >
-                <label class="pill"
-                  ><input
-                    type="radio"
-                    name="d_decision"
-                    value="Insultas nenustatytas"
-                  />Insultas nenustatytas</label
-                >
-              </div>
-            </fieldset>
-          </form>
-        </section>
+                  <label class="pill"
+                    ><input
+                      type="radio"
+                      name="d_decision"
+                      value="Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika"
+                    />Reperfuzinis gydymas kontraindikuotinas, taikyti konservatyvią taktika</label
+                  >
+                  <label class="pill"
+                    ><input
+                      type="radio"
+                      name="d_decision"
+                      value="Insultas nenustatytas"
+                    />Insultas nenustatytas</label
+                  >
+                </div>
+              </fieldset>
+            </form>
+          </section>
 
 
                 <!-- Santrauka HIS sistemai -->

--- a/templates/macros.njk
+++ b/templates/macros.njk
@@ -26,7 +26,7 @@
 {% endif %}
 {% endmacro %}
 
-{% macro timeInput(id, wrapperId='', wrapperClass='row') %}
+{% macro timeInput(id, wrapperId='', wrapperClass='row', showNow=true) %}
 <div class="{{ wrapperClass }}"{% if wrapperId %} id="{{ wrapperId }}"{% endif %}>
   <div class="input-group">
     <input
@@ -44,14 +44,16 @@
     >
       {{ icon('date-picker') | safe }}
     </button>
-    <button
-      type="button"
-      class="btn ghost"
-      data-now="{{ id }}"
-      aria-label="Dabar"
-    >
-      Dabar
-    </button>
+      {% if showNow %}
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="{{ id }}"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      {% endif %}
     <button
       type="button"
       class="btn ghost"

--- a/templates/sections/arrival.njk
+++ b/templates/sections/arrival.njk
@@ -30,15 +30,15 @@
                   vidurio laikas</label
                 >
               </div>
-              {{ timeInput('t_lkw', 'lkwTimeRow', 'row mt-4') }}
+              {{ timeInput('t_lkw', 'lkwTimeRow', 'row mt-4', false) }}
               <div id="sleepTimeRow" class="grid-2 mt-4 hidden">
                 <div>
                   <label for="t_sleep_start">Miego pradžia</label>
-                  {{ timeInput('t_sleep_start', '', '') }}
+                  {{ timeInput('t_sleep_start', '', '', false) }}
                 </div>
                 <div>
                   <label for="t_sleep_end">Miego pabaiga</label>
-                  {{ timeInput('t_sleep_end', '', '') }}
+                  {{ timeInput('t_sleep_end', '', '', false) }}
                 </div>
               </div>
             </fieldset>


### PR DESCRIPTION
## Summary
- add `showNow` toggle to `timeInput` macro
- hide "Dabar" buttons for LKW and sleep start/end times
- regenerate index.html without those "Dabar" buttons

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badb2b93f4832083651e69abc69872