### PR TITLE
Rename thrombolysis start button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1450,7 +1450,7 @@
             </div>
             <div class="section-actions mt-10">
               <button type="button" id="startThrombolysis" class="btn success">
-                Pradėta trombolizė
+                Trombolizės pradžia
               </button>
             </div>
             <div id="thrombolysisStartRow" class="mt-10 hidden">

--- a/locales/en.json
+++ b/locales/en.json
@@ -34,5 +34,6 @@
   "local_storage_enabled": "Local storage enabled; server sync disabled.",
   "local_storage_disabled": "Local storage disabled; server sync enabled.",
   "toggle_theme": "Toggle theme",
-  "stroke_not_determined": "Stroke undetermined"
+  "stroke_not_determined": "Stroke undetermined",
+  "start_thrombolysis": "Thrombolysis start"
 }

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -34,5 +34,6 @@
   "local_storage_enabled": "Vietinė saugykla įjungta; serverio sinchronizavimas išjungtas.",
   "local_storage_disabled": "Vietinė saugykla išjungta; serverio sinchronizavimas įjungtas.",
   "toggle_theme": "Perjungti temą",
-  "stroke_not_determined": "Insultas nenustatytas"
+  "stroke_not_determined": "Insultas nenustatytas",
+  "start_thrombolysis": "Trombolizės pradžia"
 }

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -162,7 +162,7 @@
             </div>
             <div class="section-actions mt-10">
               <button type="button" id="startThrombolysis" class="btn success">
-                Pradėta trombolizė
+                Trombolizės pradžia
               </button>
             </div>
             <div id="thrombolysisStartRow" class="mt-10 hidden">


### PR DESCRIPTION
## Summary
- Rename thrombolysis start button to "Trombolizės pradžia"
- Update Lithuanian and English locale files for new label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68badc67f3ec8320b7a1ee4d21beff85