### PR TITLE
Guard analytics sync for non-browser environment

### DIFF
--- a/js/analytics.js
+++ b/js/analytics.js
@@ -61,7 +61,7 @@ export function track(eventName, payload = {}) {
 
 export async function sync() {
   if (DISABLE_ANALYTICS) return;
-  if (!navigator.onLine) return;
+  if (typeof navigator === 'undefined' || !navigator.onLine) return;
   if (!(await canPost())) return;
   const events = loadEvents();
   if (!events.length) return;

--- a/test/analyticsSyncNoNavigator.test.js
+++ b/test/analyticsSyncNoNavigator.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+test(
+  'sync aborts gracefully when navigator is undefined',
+  { concurrency: false },
+  async () => {
+    delete global.navigator;
+    localStorage.setItem(
+      'analytics_events',
+      JSON.stringify([{ event: 'load' }]),
+    );
+    let fetchCalled = false;
+    const origFetch = global.fetch;
+    global.fetch = async () => {
+      fetchCalled = true;
+      return { ok: true, status: 200, json: async () => ({}) };
+    };
+
+    const { sync } = await import('../js/analytics.js?nonav');
+    await sync();
+
+    assert.equal(fetchCalled, false);
+    global.fetch = origFetch;
+  },
+);


### PR DESCRIPTION
## Summary
- Prevent analytics sync when `navigator` is missing to allow safe usage in non-browser contexts
- Add regression test ensuring `sync()` aborts gracefully without `navigator`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baec27ced08320a140683ec0e00000