### PR TITLE
Persist sync toggle in local storage

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -14,7 +14,7 @@ let lastSyncFailToast = 0;
 let consecutiveSyncFails = 0;
 
 if (typeof window !== 'undefined') {
-  window.disableSync = true;
+  window.disableSync = localStorage.getItem('disableSync') === 'true';
 }
 
 function loadLocalPatients() {
@@ -136,10 +136,12 @@ if (typeof document !== 'undefined') {
     syncPatients().then(restorePatients);
   });
   const enableLocalBtn = document.getElementById('enableLocalBtn');
+  enableLocalBtn?.setAttribute('aria-pressed', window.disableSync);
   enableLocalBtn?.addEventListener('click', () => {
     const enabled = enableLocalBtn.getAttribute('aria-pressed') !== 'true';
     enableLocalBtn.setAttribute('aria-pressed', enabled);
     window.disableSync = enabled;
+    localStorage.setItem('disableSync', String(enabled));
     if (enabled) {
       showToast(t('local_storage_enabled'), { type: 'info' });
     } else {


### PR DESCRIPTION
## Summary
- Load previously saved sync preference from localStorage on startup
- Store sync toggle state in localStorage and update aria-pressed accordingly

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baf6249ea08320806001524e399781