### PR TITLE
Handle analytics flush errors in navigation

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -35,7 +35,9 @@ export function setupNavigation(inputs) {
       setNow('d_time');
     if (id === 'analytics') renderAnalytics();
     track('section_view', { id });
-    flush();
+    flush().catch(() => {
+      /* log or ignore analytics errors */
+    });
     document.body.classList.remove('nav-open');
     if (navToggle) navToggle.setAttribute('aria-expanded', 'false');
   };


### PR DESCRIPTION
## Summary
- prevent analytics flush failures from disrupting navigation by catching errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68baf871a6648320bc612a4667d8556b