### PR TITLE
Use local time formatting for BP entries

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -1,6 +1,7 @@
 // Event handlers for created entries are delegated in app.js
 
 import { createBpEntry } from './bpEntry.js';
+import { pad } from './time.js';
 
 export function validateBp(sys, dia) {
   if (
@@ -51,8 +52,9 @@ export function setupBpEntry() {
       btn.addEventListener('click', () => {
         const med = btn.dataset.med;
         const dose = btn.dataset.dose || '';
-        const now = new Date().toISOString().slice(11, 16);
-        const entry = createBpEntry(med, dose, now);
+        const now = new Date();
+        const time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
+        const entry = createBpEntry(med, dose, time);
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
         bpMedList.hidden = true;

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -1,3 +1,5 @@
+import { pad } from './time.js';
+
 export function createBpEntry(med, dose = '', time, notes = '') {
   const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
   const entryId = `bp_entry_${ts}`;
@@ -20,7 +22,8 @@ export function createBpEntry(med, dose = '', time, notes = '') {
   timeInput.id = timeId;
   timeInput.className = 'time-input';
   timeInput.step = '60';
-  timeInput.value = time ?? new Date().toISOString().slice(11, 16);
+  const now = new Date();
+  timeInput.value = time ?? `${pad(now.getHours())}:${pad(now.getMinutes())}`;
   group.appendChild(timeInput);
 
   const timePickerBtn = document.createElement('button');

--- a/test/bpEntryButtons.test.js
+++ b/test/bpEntryButtons.test.js
@@ -83,3 +83,36 @@ test('now button sets time even when #p_weight is invalid or empty', async () =>
   nowBtn.click();
   assert.notEqual(timeInput.value, '');
 });
+
+test('bp entry defaults to local time', async () => {
+  const RealDate = Date;
+  const fixed = new RealDate('2024-01-02T03:04');
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      if (args.length === 0) return new RealDate(fixed);
+      return new RealDate(...args);
+    }
+    static now() {
+      return fixed.getTime();
+    }
+  };
+
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="number" />
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <div id="bpMedList"><button type="button" class="btn bp-med" data-med="Med" data-dose="1"></button></div>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+
+  const { setupBpEntry } = await import('../js/bp.js');
+
+  setupBpEntry();
+  document.querySelector('.bp-med').click();
+
+  const timeInput = document.querySelector('.time-input');
+  assert.equal(timeInput.value, '03:04');
+
+  global.Date = RealDate;
+});


### PR DESCRIPTION
## Summary
- Default blood pressure medication entries to local HH:MM using reusable `pad` helper
- Create BP entries with local time in setup handler
- Add test confirming BP entry time uses local format

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb08dabee08320a944fd7708e1bd4c