### PR TITLE
Round thrombolytic doses to whole numbers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1425,11 +1425,11 @@
             <div class="grid-2 mt-10">
               <div>
                 <label for="dose_total">Bendra dozė (mg)</label>
-                <input id="dose_total" type="number" step="0.1" readonly />
+                <input id="dose_total" type="number" step="1" readonly />
               </div>
               <div>
                 <label for="dose_volume">Tūris (ml)</label>
-                <input id="dose_volume" type="number" step="0.1" readonly />
+                <input id="dose_volume" type="number" step="1" readonly />
               </div>
             </div>
             <div id="tpaBreakdown" class="grid-2 mt-10 hidden">

--- a/js/computeDose.js
+++ b/js/computeDose.js
@@ -1,7 +1,7 @@
 const INFUSION_MINUTES = 60;
 
-function round1(n) {
-  return Math.round(n * 10) / 10;
+function round0(n) {
+  return Math.round(n);
 }
 
 export function computeDose(weight, concentration, type) {
@@ -11,25 +11,25 @@ export function computeDose(weight, concentration, type) {
   if (!Number.isFinite(c) || c <= 0) return null;
 
   if (type === 'tnk') {
-    const doseTotal = Math.min(25, round1(0.25 * w));
+    const doseTotal = Math.min(25, round0(0.25 * w));
     return {
       doseTotal,
-      doseVol: round1(doseTotal / c),
+      doseVol: round0(doseTotal / c),
       bolus: null,
       infusion: null,
     };
   }
 
   if (type === 'tpa') {
-    const doseTotal = Math.min(90, round1(0.9 * w));
-    const bolusMg = round1(doseTotal * 0.1);
-    const infusionMg = round1(doseTotal - bolusMg);
-    const bolusMl = round1(bolusMg / c);
-    const infusionMl = round1(infusionMg / c);
-    const rateMlH = round1((infusionMl / INFUSION_MINUTES) * 60);
+    const doseTotal = Math.min(90, round0(0.9 * w));
+    const bolusMg = round0(doseTotal * 0.1);
+    const infusionMg = round0(doseTotal - bolusMg);
+    const bolusMl = round0(bolusMg / c);
+    const infusionMl = round0(infusionMg / c);
+    const rateMlH = round0((infusionMl / INFUSION_MINUTES) * 60);
     return {
       doseTotal,
-      doseVol: round1(doseTotal / c),
+      doseVol: round0(doseTotal / c),
       bolus: { mg: bolusMg, ml: bolusMl },
       infusion: { mg: infusionMg, ml: infusionMl, rateMlH },
     };

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -137,11 +137,11 @@
             <div class="grid-2 mt-10">
               <div>
                 <label for="dose_total">Bendra dozė (mg)</label>
-                <input id="dose_total" type="number" step="0.1" readonly />
+                <input id="dose_total" type="number" step="1" readonly />
               </div>
               <div>
                 <label for="dose_volume">Tūris (ml)</label>
-                <input id="dose_volume" type="number" step="0.1" readonly />
+                <input id="dose_volume" type="number" step="1" readonly />
               </div>
             </div>
             <div id="tpaBreakdown" class="grid-2 mt-10 hidden">

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -28,8 +28,8 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   inputs.drugConc.value = '5';
   inputs.drugType.value = 'tnk';
   calcDrugs();
-  assert.strictEqual(inputs.doseTotal.value, '17.5');
-  assert.strictEqual(inputs.doseVol.value, '3.5');
+  assert.strictEqual(inputs.doseTotal.value, '18');
+  assert.strictEqual(inputs.doseVol.value, '4');
   assert.strictEqual(inputs.tpaBolus.value, '');
   assert.strictEqual(inputs.tpaInf.value, '');
 
@@ -45,8 +45,8 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '63');
   assert.strictEqual(inputs.doseVol.value, '63');
-  assert.strictEqual(inputs.tpaBolus.value, '6.3 mg (6.3 ml)');
-  assert.strictEqual(inputs.tpaInf.value, '56.7 mg (56.7 ml) · ~56.7 ml/val');
+  assert.strictEqual(inputs.tpaBolus.value, '6 mg (6 ml)');
+  assert.strictEqual(inputs.tpaInf.value, '57 mg (57 ml) · ~57 ml/val');
 
   inputs.weight.value = '120';
   inputs.drugConc.value = '1';

--- a/test/computeDose.test.js
+++ b/test/computeDose.test.js
@@ -12,8 +12,8 @@ test('computeDose returns null on invalid inputs', () => {
 test('computeDose calculates TNK dose and caps at 25 mg', () => {
   const normal = computeDose(70, 5, 'tnk');
   assert.deepStrictEqual(normal, {
-    doseTotal: 17.5,
-    doseVol: 3.5,
+    doseTotal: 18,
+    doseVol: 4,
     bolus: null,
     infusion: null,
   });
@@ -27,8 +27,8 @@ test('computeDose calculates tPA dose and caps at 90 mg', () => {
   assert.deepStrictEqual(normal, {
     doseTotal: 63,
     doseVol: 63,
-    bolus: { mg: 6.3, ml: 6.3 },
-    infusion: { mg: 56.7, ml: 56.7, rateMlH: 56.7 },
+    bolus: { mg: 6, ml: 6 },
+    infusion: { mg: 57, ml: 57, rateMlH: 57 },
   });
   const capped = computeDose(120, 1, 'tpa');
   assert.strictEqual(capped.doseTotal, 90);


### PR DESCRIPTION
## Summary
- round thrombolytic calculations to whole numbers
- update UI fields to reflect integer doses
- adjust dosing tests for integer values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb166fc6948320956270e26007899b