### PR TITLE
Prompt for custom BP medication names

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -52,9 +52,16 @@ export function setupBpEntry() {
       btn.addEventListener('click', () => {
         const med = btn.dataset.med;
         const dose = btn.dataset.dose || '';
+        let medName = med;
+        if (med === 'Kita') {
+          const input = prompt('Įveskite vaisto pavadinimą');
+          if (!input) return;
+          medName = input.trim();
+          if (!medName) return;
+        }
         const now = new Date();
         const time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
-        const entry = createBpEntry(med, dose, time);
+        const entry = createBpEntry(medName, dose, time);
         bpEntries.appendChild(entry);
         bpMedList.classList.add('hidden');
         bpMedList.hidden = true;

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -18,7 +18,7 @@ test('summaryTemplate generates summary text correctly', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><input value="25 mg" /><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><input value="25 mg" /><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';
@@ -55,7 +55,7 @@ test('summaryTemplate generates summary text correctly', async () => {
   assert(summary.includes('- Koncentracija: 5 mg/ml'));
   assert(summary.includes('- Bendra dozė: 20 mg (4 ml)'));
   assert(
-    summary.includes('AKS KOREKCIJA:\n- Kaptoprilis 10:00 25 mg (požymai)'),
+    summary.includes('AKS KOREKCIJA:\n- Nifedipinas 10:00 25 mg (požymai)'),
   );
   assert(
     summary.includes('AKTYVACIJA:\n- Preliminarus susirgimo laikas: <4.5'),


### PR DESCRIPTION
## Summary
- Prompt user for medication name when selecting "Kita" in BP correction list
- Pass entered name to BP entry creation
- Update summary template test to expect the chosen medication name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb1f2841e883208eff0abc4f327eef