### PR TITLE
Reject blood pressure readings where diastolic ≥ systolic

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -11,7 +11,8 @@ export function validateBp(sys, dia) {
     sys < 30 ||
     sys > 300 ||
     dia < 10 ||
-    dia > 200
+    dia > 200 ||
+    dia >= sys
   )
     return false;
   return true;

--- a/test/bp.test.js
+++ b/test/bp.test.js
@@ -11,3 +11,8 @@ test('validateBp rejects out of range or NaN', () => {
   assert.equal(validateBp(120, NaN), false);
   assert.equal(validateBp(400, 50), false);
 });
+
+test('validateBp rejects when diastolic is not less than systolic', () => {
+  assert.equal(validateBp(100, 110), false);
+  assert.equal(validateBp(100, 100), false);
+});


### PR DESCRIPTION
## Summary
- Enforce that diastolic blood pressure must be lower than systolic in `validateBp`
- Test that inverted or equal blood pressure values are rejected

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb35eeef948320be2bce42bb12c20b