### PR TITLE
Add custom medication modal for BP entries

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -3,6 +3,7 @@
 import { createBpEntry } from './bpEntry.js';
 import { pad } from './time.js';
 import { bpMeds } from './bpMeds.js';
+import { medicationModal } from './modal.js';
 
 export function validateBp(sys, dia) {
   if (
@@ -51,7 +52,7 @@ export function setupBpEntry() {
       bpMedList.hidden = isHidden;
       bpCorrBtn.setAttribute('aria-expanded', (!isHidden).toString());
     });
-    bpMedList.addEventListener('click', (e) => {
+    bpMedList.addEventListener('click', async (e) => {
       const btn = e.target.closest('.bp-med');
       if (!btn) return;
       const med = btn.dataset.med;
@@ -59,10 +60,9 @@ export function setupBpEntry() {
       let dose = medObj?.dose || '';
       let medName = med;
       if (med === 'Kita') {
-        const input = prompt('Įveskite vaisto pavadinimą');
+        const input = await medicationModal();
         if (!input) return;
-        medName = input.trim();
-        if (!medName) return;
+        medName = input;
       }
       const now = new Date();
       const time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;

--- a/js/modal.js
+++ b/js/modal.js
@@ -114,3 +114,19 @@ export function promptModal(title, defaultValue = '') {
     ],
   });
 }
+
+export function medicationModal(defaultValue = '') {
+  return showModal({
+    title: 'Įveskite vaisto pavadinimą',
+    input: { value: defaultValue },
+    buttons: [
+      {
+        label: 'OK',
+        value: (v) => v.trim(),
+        class: 'primary',
+        autofocus: true,
+      },
+      { label: 'Cancel', value: null },
+    ],
+  });
+}

--- a/test/kitaMedModal.test.js
+++ b/test/kitaMedModal.test.js
@@ -1,0 +1,74 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// Test that clicking 'Kita' shows modal and uses entered name to create entry
+
+test(
+  'Kita medication uses modal input for entry',
+  { concurrency: false },
+  async () => {
+    document.body.innerHTML = `
+    <form>
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <ul id="bpMedList" role="list">
+        <li><button type="button" class="btn bp-med" data-med="Kita">Kita</button></li>
+      </ul>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+
+    const { setupBpEntry } = await import('../js/bp.js');
+    setupBpEntry();
+
+    const medBtn = document.querySelector('.bp-med');
+    medBtn.click();
+
+    await tick();
+    const overlay = document.querySelector('.modal-overlay');
+    const input = overlay.querySelector('input');
+    input.value = 'CustomMed';
+    const [okBtn] = overlay.querySelectorAll('button');
+    okBtn.click();
+
+    await tick();
+    const entry = document.querySelector('#bpEntries .bp-entry strong');
+    assert.equal(entry.textContent, 'CustomMed');
+  },
+);
+
+// Test that cancelling the modal does not create an entry
+
+test(
+  'canceling Kita medication modal creates no entry',
+  { concurrency: false },
+  async () => {
+    document.body.innerHTML = `
+    <form>
+      <button id="bpCorrBtn" class="btn" type="button"></button>
+      <ul id="bpMedList" role="list">
+        <li><button type="button" class="btn bp-med" data-med="Kita">Kita</button></li>
+      </ul>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+
+    const { setupBpEntry } = await import('../js/bp.js');
+    setupBpEntry();
+
+    const medBtn = document.querySelector('.bp-med');
+    medBtn.click();
+
+    await tick();
+    const overlay = document.querySelector('.modal-overlay');
+    const buttons = overlay.querySelectorAll('button');
+    const cancelBtn = buttons[1];
+    cancelBtn.click();
+
+    await tick();
+    const entries = document.querySelector('#bpEntries');
+    assert.equal(entries.children.length, 0);
+  },
+);


### PR DESCRIPTION
## Summary
- implement medication modal to prompt for custom blood pressure medications
- use modal when selecting `Kita` in BP entries
- add tests covering this new flow

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb3ece52f483208608d70ba71131c0