### PR TITLE
Convert local storage button to switch toggle

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -98,27 +98,60 @@
 #bpCorrBtn[aria-expanded='true']:active {
   background: #1a56aa;
 }
-#enableLocalBtn[aria-pressed='true'] {
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+}
+
+.switch input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.switch .slider {
+  position: relative;
+  width: 40px;
+  height: 24px;
+  background: var(--button-bg);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  transition: background-color 0.2s;
+}
+
+.switch .slider::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  transform: translateY(-50%);
+  background: var(--ink);
+  border-radius: 50%;
+  transition: transform 0.2s, background-color 0.2s;
+}
+
+.switch input:checked + .slider {
   background: var(--accent);
-  color: #fff;
   border-color: #2d74b8;
 }
-#enableLocalBtn[aria-pressed='true']:hover {
-  background: #2368c5;
+
+.switch input:checked + .slider::before {
+  transform: translate(16px, -50%);
+  background: #fff;
 }
-#enableLocalBtn[aria-pressed='true']:active {
-  background: #1a56aa;
+
+.switch input:focus-visible + .slider {
+  outline: 3px solid var(--accent);
+  outline-offset: 2px;
 }
-#enableLocalBtn[aria-pressed='false'] {
-  background: var(--button-bg);
-  color: var(--ink);
-  border-color: var(--line);
-}
-#enableLocalBtn[aria-pressed='false']:hover {
-  background: var(--btn-hover-bg);
-}
-#enableLocalBtn[aria-pressed='false']:active {
-  background: var(--btn-active-bg);
+
+.switch-label {
+  font-weight: 600;
 }
 .bp-med:active,
 .bp-med.selected {

--- a/index.html
+++ b/index.html
@@ -79,11 +79,11 @@
         </div>
       </details>
       
-<button id="enableLocalBtn" title="Enable local storage" aria-label="Enable local storage" class="btn" data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage" aria-pressed="true">
-
-<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><polyline points="17 21 17 13 7 13 7 21"/><polyline points="7 3 7 8 15 8"/></svg>
-
- <span class="btn-label" data-i18n="local_storage">Local storage</span></button>
+<label class="switch" title="Enable local storage" data-i18n-title="enable_local_storage">
+  <input type="checkbox" id="enableLocalBtn" role="switch" aria-label="Enable local storage" data-i18n-aria-label="enable_local_storage" />
+  <span class="slider"></span>
+  <span class="switch-label" data-i18n="local_storage">Local storage</span>
+</label>
 
       
 <button id="joinCollabBtn" title="Bendradarbiauti" aria-label="Bendradarbiauti" class="btn" data-i18n-title="collaborate" data-i18n-aria-label="collaborate">

--- a/js/sync.js
+++ b/js/sync.js
@@ -136,17 +136,20 @@ if (typeof document !== 'undefined') {
     syncPatients().then(restorePatients);
   });
   const enableLocalBtn = document.getElementById('enableLocalBtn');
-  enableLocalBtn?.setAttribute('aria-pressed', window.disableSync);
-  enableLocalBtn?.addEventListener('click', () => {
-    const enabled = enableLocalBtn.getAttribute('aria-pressed') !== 'true';
-    enableLocalBtn.setAttribute('aria-pressed', enabled);
-    window.disableSync = enabled;
-    localStorage.setItem('disableSync', String(enabled));
-    if (enabled) {
-      showToast(t('local_storage_enabled'), { type: 'info' });
-    } else {
-      showToast(t('local_storage_disabled'), { type: 'info' });
-      syncPatients().then(restorePatients);
-    }
-  });
+  if (enableLocalBtn) {
+    enableLocalBtn.checked = window.disableSync;
+    enableLocalBtn.setAttribute('aria-checked', window.disableSync);
+    enableLocalBtn.addEventListener('change', () => {
+      const enabled = enableLocalBtn.checked;
+      enableLocalBtn.setAttribute('aria-checked', enabled);
+      window.disableSync = enabled;
+      localStorage.setItem('disableSync', String(enabled));
+      if (enabled) {
+        showToast(t('local_storage_enabled'), { type: 'info' });
+      } else {
+        showToast(t('local_storage_disabled'), { type: 'info' });
+        syncPatients().then(restorePatients);
+      }
+    });
+  }
 }

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -34,17 +34,21 @@
           {{ actionButton('saveBtn', 'Išsaugoti vietoje (naršyklėje)', icon('save')) }}
         </div>
       </details>
-      {{
-        actionButton(
-          'enableLocalBtn',
-          'Enable local storage',
-          icon('save'),
-          'Local storage',
-          '',
-          'data-i18n-title="enable_local_storage" data-i18n-aria-label="enable_local_storage" aria-pressed="true"',
-          'local_storage'
-        )
-      }}
+      <label
+        class="switch"
+        title="Enable local storage"
+        data-i18n-title="enable_local_storage"
+      >
+        <input
+          type="checkbox"
+          id="enableLocalBtn"
+          role="switch"
+          aria-label="Enable local storage"
+          data-i18n-aria-label="enable_local_storage"
+        />
+        <span class="slider"></span>
+        <span class="switch-label" data-i18n="local_storage">Local storage</span>
+      </label>
       {{
         actionButton(
           'joinCollabBtn',


### PR DESCRIPTION
## Summary
- Replace local storage action button with accessible checkbox switch
- Add switch styling to components stylesheet
- Update sync logic to respond to checkbox state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd2497a2883208b86419d42a52b1b