### PR TITLE
Initialize theme before CSS to prevent dark flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,20 @@
 <!doctype html>
-<html lang="lt" class="dark">
+<html lang="lt">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Insulto komandos forma</title>
+    <script>
+      (() => {
+        let saved;
+        try {
+          saved = localStorage.getItem('theme');
+        } catch {}
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const preferred = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.add(preferred);
+      })();
+    </script>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="manifest" href="manifest.json" />
   </head>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,6 +1,10 @@
 const THEME_KEY = 'theme';
 
 export function initTheme() {
+  const root = document.documentElement;
+  if (root.classList.contains('light') || root.classList.contains('dark')) {
+    return;
+  }
   let saved;
   try {
     saved = localStorage.getItem(THEME_KEY);
@@ -9,8 +13,6 @@ export function initTheme() {
   }
   const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
   const preferred = saved || (prefersDark ? 'dark' : 'light');
-  const root = document.documentElement;
-  root.classList.remove('light', 'dark');
   root.classList.add(preferred);
 }
 

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -1,9 +1,20 @@
 <!doctype html>
-<html lang="lt" class="dark">
+<html lang="lt">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Insulto komandos forma</title>
+    <script>
+      (() => {
+        let saved;
+        try {
+          saved = localStorage.getItem('theme');
+        } catch {}
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const preferred = saved || (prefersDark ? 'dark' : 'light');
+        document.documentElement.classList.add(preferred);
+      })();
+    </script>
     <link rel="stylesheet" href="css/style.css" />
     <link rel="manifest" href="manifest.json" />
   </head>


### PR DESCRIPTION
## Summary
- Load saved or preferred theme in an inline script before the stylesheet
- Skip theme initialization if the document already has a theme class

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbebef2ae883209617443b05165628