### PR TITLE
Enable local storage by default and style toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
           role="switch"
           aria-label="Enable local storage"
           data-i18n-aria-label="enable_local_storage"
+          checked
         />
         <span class="slider"></span>
         <span class="switch-label" data-i18n="local_storage">Local storage</span>

--- a/js/sync.js
+++ b/js/sync.js
@@ -14,7 +14,8 @@ let lastSyncFailToast = 0;
 let consecutiveSyncFails = 0;
 
 if (typeof window !== 'undefined') {
-  window.disableSync = localStorage.getItem('disableSync') === 'true';
+  const saved = localStorage.getItem('disableSync');
+  window.disableSync = saved !== 'false';
 }
 
 function loadLocalPatients() {

--- a/templates/partials/header.njk
+++ b/templates/partials/header.njk
@@ -45,6 +45,7 @@
           role="switch"
           aria-label="Enable local storage"
           data-i18n-aria-label="enable_local_storage"
+          checked
         />
         <span class="slider"></span>
         <span class="switch-label" data-i18n="local_storage">Local storage</span>


### PR DESCRIPTION
## Summary
- Enable local storage by default by interpreting missing `disableSync` flag as enabled
- Mark local storage control as checked to show switch toggle on page load

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbf8de88c4832088a398d7ff52e84b