### PR TITLE
Improve bp-entry layout for small screens

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -630,9 +630,23 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry {
   display: grid;
-  grid-template-columns: auto auto auto 1fr auto;
+  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
   gap: 6px;
   align-items: stretch;
+}
+
+@media (max-width: 480px) {
+  .bp-entry {
+    grid-template-columns: 1fr;
+  }
+  .bp-entry .input-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .bp-entry .btn,
+  .bp-entry [data-remove-bp] {
+    width: 100%;
+  }
 }
 
 .bp-entry [data-remove-bp] {


### PR DESCRIPTION
## Summary
- make blood pressure entry grid auto-fit with minmax
- stack time, dose, and notes fields on narrow viewports
- expand buttons to full width for better touch targets

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc5136a1e483208946e7d655f299a9