### PR TITLE
feat: validate numeric dose input

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -635,6 +635,10 @@ section[data-tab='Intervencijos'] h3 {
   align-items: stretch;
 }
 
+.bp-entry .dose-input {
+  max-width: 6rem;
+}
+
 @media (max-width: 480px) {
   .bp-entry {
     grid-template-columns: 1fr;

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -34,8 +34,28 @@ export function createBpEntry(med, dose = '', time, notes = '') {
   group.appendChild(nowBtn);
 
   const doseInput = document.createElement('input');
-  doseInput.setAttribute('type', 'text');
+  doseInput.type = 'number';
+  doseInput.step = '0.1';
+  doseInput.placeholder = 'mg';
+  doseInput.className = 'dose-input';
   doseInput.value = dose;
+  const validateDose = () => {
+    if (!doseInput.value) {
+      doseInput.classList.remove('invalid');
+      doseInput.setCustomValidity?.('');
+      return;
+    }
+    const num = Number(doseInput.value);
+    if (!Number.isFinite(num)) {
+      doseInput.classList.add('invalid');
+      doseInput.setCustomValidity?.('Enter a valid dose');
+    } else {
+      doseInput.classList.remove('invalid');
+      doseInput.setCustomValidity?.('');
+    }
+  };
+  doseInput.addEventListener('input', validateDose);
+  validateDose();
   entry.appendChild(doseInput);
 
   const notesInput = document.createElement('input');

--- a/test/bpDoseInput.test.js
+++ b/test/bpDoseInput.test.js
@@ -1,0 +1,18 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+import { createBpEntry } from '../js/bpEntry.js';
+
+test('dose input is configured for numeric values', () => {
+  const entry = createBpEntry('Med');
+  const doseInput = entry.querySelector('.dose-input');
+
+  assert.ok(doseInput);
+  assert.equal(doseInput.type, 'number');
+  assert.equal(doseInput.step, '0.1');
+  assert.equal(doseInput.placeholder, 'mg');
+
+  doseInput.value = '5.5';
+  doseInput.dispatchEvent(new Event('input'));
+  assert(!doseInput.classList.contains('invalid'));
+});


### PR DESCRIPTION
## Summary
- use numeric input for BP medication doses with 0.1 step and mg placeholder
- validate and style dose field for invalid numbers
- add unit test for numeric dose input configuration

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc53814d808320a203d010428b0bd4