### PR TITLE
Remove SPS badge for 4.5-24h activation option

### DIFF
--- a/js/activation.js
+++ b/js/activation.js
@@ -92,29 +92,10 @@ export function initActivation() {
   });
 
   const lkwInputs = dom.getALkwInputs();
-  const spsInput = lkwInputs.find((el) => el.value === '4.5-24');
-  let spsBadge;
-  if (spsInput) {
-    const label = spsInput.closest('label');
-    if (label) {
-      spsBadge = document.createElement('span');
-      spsBadge.className = 'badge';
-      spsBadge.textContent = 'SPS';
-      spsBadge.style.display = 'none';
-      label.appendChild(spsBadge);
-    }
-  }
-
-  const updateLkwBadge = () => {
-    if (spsBadge && spsInput) {
-      spsBadge.style.display = spsInput.checked ? 'inline-block' : 'none';
-    }
-  };
 
   lkwInputs.forEach((el) => {
     el.addEventListener('change', (e) => {
       if (!e.isTrusted || !e.target.checked || !el.checked) {
-        updateLkwBadge();
         return;
       }
       if (el.value === '<4.5') {
@@ -122,8 +103,6 @@ export function initActivation() {
       } else if (el.value === '4.5-24') {
         showToast('Informuokite SPS gydytoją', { type: 'warning' });
       }
-      updateLkwBadge();
     });
   });
-  updateLkwBadge();
 }


### PR DESCRIPTION
## Summary
- stop inserting SPS badge when selecting the 4.5-24h last known well option

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc676bdb388320a2dbbaa9b5e0851a