### PR TITLE
Style BP entries as cards

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -633,6 +633,10 @@ section[data-tab='Intervencijos'] h3 {
   grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
   gap: 6px;
   align-items: stretch;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--card-bg);
+  padding: 8px;
 }
 
 .bp-entry .dose-input {
@@ -641,7 +645,8 @@ section[data-tab='Intervencijos'] h3 {
 
 @media (max-width: 480px) {
   .bp-entry {
-    grid-template-columns: 1fr;
+    display: flex;
+    flex-direction: column;
   }
   .bp-entry .input-group {
     flex-direction: column;
@@ -650,6 +655,9 @@ section[data-tab='Intervencijos'] h3 {
   .bp-entry .btn,
   .bp-entry [data-remove-bp] {
     width: 100%;
+  }
+  .bp-entry [data-remove-bp] {
+    height: auto;
   }
 }
 

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -6,7 +6,7 @@ export function createBpEntry(med, dose = '', time, notes = '') {
   const timeId = `bp_time_${ts}`;
 
   const entry = document.createElement('div');
-  entry.className = 'bp-entry mt-6';
+  entry.className = 'bp-entry mt-6 card';
   entry.id = entryId;
 
   const strong = document.createElement('strong');


### PR DESCRIPTION
## Summary
- Add `card` class to BP entries
- Style `.bp-entry` with border, radius, and background for card effect
- Switch `.bp-entry` layout to vertical flex on narrow screens

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc711773308320b47d459e9d94e23e