### PR TITLE
Allow bp doses with units

### DIFF
--- a/js/bp.js
+++ b/js/bp.js
@@ -51,6 +51,7 @@ export function setupBpEntry() {
       const med = btn.dataset.med;
       const medObj = bpMeds.find((m) => m.name === med);
       let dose = medObj?.dose || '';
+      let unit = medObj?.unit || '';
       let medName = med;
       if (med === 'Kita') {
         const input = await medicationModal();
@@ -59,7 +60,7 @@ export function setupBpEntry() {
       }
       const now = new Date();
       const time = `${pad(now.getHours())}:${pad(now.getMinutes())}`;
-      const entry = createBpEntry(medName, dose, time);
+      const entry = createBpEntry(medName, dose, time, '', unit);
       bpEntries.appendChild(entry);
     });
   }

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -1,6 +1,6 @@
 import { pad } from './time.js';
 
-export function createBpEntry(med, dose = '', time, notes = '') {
+export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
   const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
   const entryId = `bp_entry_${ts}`;
   const timeId = `bp_time_${ts}`;
@@ -34,18 +34,29 @@ export function createBpEntry(med, dose = '', time, notes = '') {
   group.appendChild(nowBtn);
 
   const doseInput = document.createElement('input');
-  doseInput.type = 'number';
-  doseInput.step = '0.1';
-  doseInput.placeholder = 'mg';
+  doseInput.type = 'text';
   doseInput.className = 'dose-input';
-  doseInput.value = dose;
+  let doseValue = dose;
+  let unitValue = unit;
+  if (dose && typeof dose === 'string' && !unit) {
+    const match = dose.trim().match(/^(\d+(?:[.,]\d+)?)(.*)$/);
+    if (match) {
+      doseValue = match[1].replace(',', '.');
+      unitValue = match[2].trim();
+    }
+  }
+  doseInput.value = doseValue;
+  const placeholder = unitValue || 'mg';
+  doseInput.placeholder = placeholder;
+  if (unitValue) doseInput.dataset.unit = unitValue;
   const validateDose = () => {
-    if (!doseInput.value) {
+    const value = doseInput.value.trim();
+    if (!value) {
       doseInput.classList.remove('invalid');
       doseInput.setCustomValidity?.('');
       return;
     }
-    const num = Number(doseInput.value);
+    const num = Number.parseFloat(value);
     if (!Number.isFinite(num)) {
       doseInput.classList.add('invalid');
       doseInput.setCustomValidity?.('Enter a valid dose');

--- a/js/bpMeds.js
+++ b/js/bpMeds.js
@@ -1,7 +1,7 @@
 export const bpMeds = [
-  { name: 'Labetololis', dose: '10 mg' },
-  { name: 'Enalaprilis', dose: '1.25 mg' },
-  { name: 'Metoprololis', dose: '5 mg' },
-  { name: 'Natrio nitroprusidas', dose: '0.3 µg/kg/min' },
-  { name: 'Kita', dose: '' },
+  { name: 'Labetololis', dose: '10', unit: 'mg' },
+  { name: 'Enalaprilis', dose: '1.25', unit: 'mg' },
+  { name: 'Metoprololis', dose: '5', unit: 'mg' },
+  { name: 'Natrio nitroprusidas', dose: '0.3', unit: 'µg/kg/min' },
+  { name: 'Kita', dose: '', unit: '' },
 ];

--- a/js/storage.js
+++ b/js/storage.js
@@ -109,6 +109,7 @@ export function getPayload() {
       time: timeEl?.value || '',
       med,
       dose: doseEl?.value || '',
+      unit: doseEl?.dataset.unit || doseEl?.placeholder || '',
       notes: notesEl?.value || '',
     };
   });
@@ -148,6 +149,7 @@ export function setPayload(p) {
         m.dose || '',
         m.time,
         m.notes || '',
+        m.unit || '',
       );
       bpContainer.appendChild(entry);
     });

--- a/js/summary.js
+++ b/js/summary.js
@@ -150,8 +150,8 @@ export function summaryTemplate({
     bpMeds.forEach((m) =>
       lines.push(
         `- ${m.med} ${m.time || '—'} ${m.dose || ''}${
-          m.notes ? ` (${m.notes})` : ''
-        }`.trim(),
+          m.unit ? ` ${m.unit}` : ''
+        }${m.notes ? ` (${m.notes})` : ''}`.trim(),
       ),
     );
   }

--- a/test/bpDoseInput.test.js
+++ b/test/bpDoseInput.test.js
@@ -3,16 +3,20 @@ import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 import { createBpEntry } from '../js/bpEntry.js';
 
-test('dose input is configured for numeric values', () => {
-  const entry = createBpEntry('Med');
+test('dose input accepts text and validates numeric part', () => {
+  const entry = createBpEntry('Med', '5 mg');
   const doseInput = entry.querySelector('.dose-input');
 
   assert.ok(doseInput);
-  assert.equal(doseInput.type, 'number');
-  assert.equal(doseInput.step, '0.1');
+  assert.equal(doseInput.type, 'text');
   assert.equal(doseInput.placeholder, 'mg');
+  assert.equal(doseInput.value, '5');
 
   doseInput.value = '5.5';
   doseInput.dispatchEvent(new Event('input'));
   assert(!doseInput.classList.contains('invalid'));
+
+  doseInput.value = 'abc';
+  doseInput.dispatchEvent(new Event('input'));
+  assert(doseInput.classList.contains('invalid'));
 });

--- a/test/bpEntryButtons.test.js
+++ b/test/bpEntryButtons.test.js
@@ -69,3 +69,22 @@ test('bp entry defaults to local time', async () => {
 
   global.Date = RealDate;
 });
+
+test('bp entry displays default dose from bpMeds', async () => {
+  const med = bpMeds[0];
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="number" />
+      <ul id="bpMedList" role="list"><li><button type="button" class="btn bp-med" data-med="${med.name}">${med.name}</button></li></ul>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+  const { setupBpEntry } = await import('../js/bp.js');
+
+  setupBpEntry();
+  document.querySelector('.bp-med').click();
+
+  const doseInput = document.querySelector('.dose-input');
+  assert.equal(doseInput.value, med.dose);
+  assert.equal(doseInput.placeholder, med.unit);
+});

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -18,7 +18,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><input value="25 mg" /><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><input value="25" data-unit="mg" placeholder="mg" /><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';
@@ -72,7 +72,13 @@ test('copySummary builds data object and copies formatted text', async () => {
       infusion: null,
     },
     bpMeds: [
-      { time: '10:00', med: 'Kaptoprilis', dose: '25 mg', notes: 'požymai' },
+      {
+        time: '10:00',
+        med: 'Kaptoprilis',
+        dose: '25',
+        unit: 'mg',
+        notes: 'požymai',
+      },
     ],
     activation: {
       lkw: '<4.5',


### PR DESCRIPTION
## Summary
- support text doses with units and validate numeric parts
- capture medication units separately and show defaults on entries
- add tests for default bp med doses and updated serialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc7ee1b2b88320adb683e82b157042