### PR TITLE
Add decision section group titles

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -939,6 +939,11 @@ details .card {
   margin-left: 18px;
 }
 
+.decision-group-title {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
 .contra-list {
   list-style: none;
   padding-left: 0;

--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -7,11 +7,13 @@
         >
           <h2>Sprendimas</h2>
           <form>
+            <div class="decision-group-title">Sprendimo laikas</div>
             <fieldset>
               <legend>Sprendimo laikas</legend>
               <label for="d_time">Sprendimo laikas</label>
               {{ timeInput('d_time') }}
             </fieldset>
+            <div class="decision-group-title">Sprendimas</div>
             <fieldset class="mt-10">
               <legend>Sprendimas</legend>
               <div>


### PR DESCRIPTION
## Summary
- add visible group titles to decision form sections
- style decision group titles with margin and font weight

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd01fdadf08320aa34315a2178a729