### PR TITLE
Track per-patient dirty state with indicator

### DIFF
--- a/test/dirtyIndicator.test.js
+++ b/test/dirtyIndicator.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+// Test that dirty indicator appears and disappears after save
+
+test(
+  'dirty flag indicator toggles with autosave',
+  { concurrency: false },
+  async () => {
+    const { setupAutosave } = await import('../js/autosave.js');
+    const { getInputs } = await import('../js/state.js');
+    const { getActivePatientId } = await import('../js/patients.js');
+
+    const inputs = getInputs();
+    let saveCb;
+    setupAutosave(inputs, {
+      scheduleSave(id, name, cb) {
+        saveCb = cb;
+      },
+      flushSave() {},
+    });
+
+    const id = getActivePatientId();
+    const select = document.getElementById('patientSelect');
+    const field = document.getElementById('a_name');
+    field.value = 'Test';
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+
+    let opt = Array.from(select.options).find((o) => o.value === id);
+    assert.ok(opt.textContent.endsWith(' •'));
+
+    saveCb?.();
+    opt = Array.from(select.options).find((o) => o.value === id);
+    assert.ok(!opt.textContent.endsWith(' •'));
+  },
+);

--- a/test/patientSearch.test.js
+++ b/test/patientSearch.test.js
@@ -23,7 +23,12 @@ test(
     Object.keys(getPatientStore()).forEach((id) => removePatient(id));
 
     const inputs = getInputs();
-    setupAutosave(inputs, { scheduleSave() {}, flushSave() {} });
+    setupAutosave(inputs, {
+      scheduleSave(id, name, cb) {
+        cb?.();
+      },
+      flushSave() {},
+    });
 
     const firstId = getActivePatientId();
     renamePatient(firstId, 'Alice');


### PR DESCRIPTION
## Summary
- track dirty state per patient and mark unsaved patients in the select list
- clear dirty state after saving or deleting a patient
- add tests covering dirty indicators and patient search when autosave clears

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdbdcce344832096656dbaa478ae64