### PR TITLE
feat: show summary copy success

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -182,16 +182,24 @@ export function summaryTemplate({
 export function copySummary(data) {
   const inputs = getInputs();
   if (inputs.summary) inputs.summary.value = summaryTemplate(data);
+  const text = inputs.summary.value;
   if (window.isSecureContext && navigator.clipboard) {
-    navigator.clipboard.writeText(inputs.summary.value).catch((err) => {
-      showToast('Nepavyko nukopijuoti: ' + err, { type: 'error' });
-    });
+    return navigator.clipboard
+      .writeText(text)
+      .then(() => text)
+      .catch((err) => {
+        showToast('Nepavyko nukopijuoti: ' + err, { type: 'error' });
+        throw err;
+      });
   } else {
     inputs.summary.select();
     const ok = document.execCommand('copy');
-    if (!ok) showToast('Nepavyko nukopijuoti', { type: 'error' });
+    if (!ok) {
+      showToast('Nepavyko nukopijuoti', { type: 'error' });
+      return Promise.reject(new Error('copy failed'));
+    }
+    return Promise.resolve(text);
   }
-  return inputs.summary.value;
 }
 
 export function openPrintWindow(win) {

--- a/js/summaryHandlers.js
+++ b/js/summaryHandlers.js
@@ -5,6 +5,8 @@ import {
   exportSummaryPDF,
 } from './summary.js';
 import { getActivePatient } from './patients.js';
+import { showToast } from './toast.js';
+import { t } from './i18n.js';
 
 export function setupSummaryHandlers(inputs) {
   document.getElementById('summary')?.addEventListener('focus', () => {
@@ -19,8 +21,12 @@ export function setupSummaryHandlers(inputs) {
     const patient = getActivePatient();
     if (!patient) return;
     const data = collectSummaryData(patient);
-    const text = copySummary(data);
-    patient.summary = text;
+    copySummary(data)
+      .then((text) => {
+        patient.summary = text;
+        showToast(t('summary_copied'), { type: 'success' });
+      })
+      .catch(() => {});
   });
   document.getElementById('exportSummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
@@ -30,5 +36,6 @@ export function setupSummaryHandlers(inputs) {
     inputs.summary.value = text;
     patient.summary = text;
     exportSummaryPDF(data);
+    showToast(t('summary_exported'), { type: 'success' });
   });
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -8,6 +8,8 @@
   "language": "Language",
   "copy_summary": "Copy summary",
   "export_summary": "Export summary",
+  "summary_copied": "Summary copied.",
+  "summary_exported": "Summary exported.",
   "saved_locally": "Saved locally.",
   "rename_prompt": "New name",
   "patient_renamed": "Patient renamed.",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -8,6 +8,8 @@
   "language": "Kalba",
   "copy_summary": "Kopijuoti santrauką",
   "export_summary": "Eksportuoti santrauką",
+  "summary_copied": "Santrauka nukopijuota.",
+  "summary_exported": "Santrauka eksportuota.",
   "saved_locally": "Išsaugota naršyklėje.",
   "rename_prompt": "Naujas pavadinimas",
   "patient_renamed": "Pacientas pervadintas.",

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -99,7 +99,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   });
 
   const expected = summaryTemplate(data);
-  const copied = copySummary(data);
+  const copied = await copySummary(data);
   assert.equal(global.__copied, expected);
   assert.equal(inputs.summary.value, expected);
   assert.equal(copied, expected);


### PR DESCRIPTION
## Summary
- return a promise from `copySummary` on successful clipboard writes
- display localized success toasts after copying or exporting summaries
- add i18n strings and adjust tests for async copy

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdd2127bb4832080fcdc0f6fa7f729