### PR TITLE
chore: compact bp-entry layout

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -630,13 +630,13 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr));
-  gap: 6px;
-  align-items: stretch;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 4px;
+  align-items: center;
   border: 1px solid var(--line);
   border-radius: 10px;
   background: var(--card-bg);
-  padding: 8px;
+  padding: 4px;
 }
 
 .bp-entry .dose-input {


### PR DESCRIPTION
## Summary
- tighten `.bp-entry` spacing and center items
- switch to explicit `grid-template-columns` for compact rows

## Testing
- `timeout 100000 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be651390408320ba91fdbc6f3475a8