### PR TITLE
Align bp-entry input and button heights

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -6,6 +6,7 @@
   border-radius: 10px;
   cursor: pointer;
   font-weight: 600;
+  line-height: 1.2;
   transition:
     background-color 0.2s,
     color 0.2s;

--- a/css/forms.css
+++ b/css/forms.css
@@ -34,6 +34,7 @@ select:not(.btn) {
   background: var(--bg);
   color: var(--ink);
   font-size: 0.875rem;
+  line-height: 1.2;
 }
 
 input[type='date'],
@@ -77,6 +78,13 @@ textarea {
 .input-group .btn {
   min-width: 2.5rem;
   padding: 4px 6px;
+  line-height: 1.2;
+}
+
+.bp-entry input,
+.bp-entry .btn {
+  padding: 4px 6px;
+  line-height: 1.2;
 }
 
 .input-group.flex-nowrap {


### PR DESCRIPTION
## Summary
- ensure `.btn` and form inputs share a consistent line-height
- give `.bp-entry` inputs and buttons matching 4px 6px padding

## Testing
- `npm test`
- Verified via jsdom that `.bp-entry` inputs and `data-now` button share the same padding and line-height


------
https://chatgpt.com/codex/tasks/task_e_68be780ac4b88320b813a74b39456528