### PR TITLE
Ištrynimo mygtukas AKS vaisto įraše nebekeliauja į kitą eilutę

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -631,7 +631,7 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry {
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: auto auto auto 1fr auto;
   gap: 4px;
   align-items: center;
   border: 1px solid var(--line);


### PR DESCRIPTION
## Santrauka
- Pakoreguotas AKS korekcijos vaisto įrašo stiliaus aprašas, kad visi laukai ir trynimo mygtukas tilptų vienoje eilutėje.

## Testai
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be7bb795f88320933d5347db3dd784