### PR TITLE
Fix BP remove button size for alignment

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -663,8 +663,9 @@ section[data-tab='Intervencijos'] h3 {
 }
 
 .bp-entry [data-remove-bp] {
-  height: auto;
-  padding: 4px 6px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -672,6 +673,8 @@ section[data-tab='Intervencijos'] h3 {
 }
 
 .bp-entry [data-remove-bp] img {
+  width: 16px;
+  height: 16px;
   transition: filter 0.2s;
 }
 


### PR DESCRIPTION
## Summary
- Set fixed 32px square size for blood pressure remove button
- Constrain remove icon to 16px square for consistent appearance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be81f5404c8320931fc2539428f637