### PR TITLE
Fix summary initialization

### DIFF
--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1,6 +1,7 @@
 import { $, $$ } from './state.js';
 import { collectSummaryData, summaryTemplate } from './summary.js';
-import { getActivePatient } from './patients.js';
+import { getActivePatient, addPatient } from './patients.js';
+import { getPayload } from './storage.js';
 import { renderAnalytics, track, flush } from './analytics.js';
 
 export function setupNavigation(inputs) {
@@ -22,13 +23,15 @@ export function setupNavigation(inputs) {
       t.setAttribute('tabindex', selected ? '0' : '-1');
     });
     if (id === 'summarySec') {
-      const patient = getActivePatient();
-      if (patient) {
-        const data = collectSummaryData(patient);
-        const text = summaryTemplate(data);
-        inputs.summary.value = text;
-        patient.summary = text;
+      let patient = getActivePatient();
+      if (!patient) {
+        addPatient();
+        patient = getActivePatient();
       }
+      const data = collectSummaryData(patient || getPayload());
+      const text = summaryTemplate(data);
+      inputs.summary.value = text;
+      if (patient) patient.summary = text;
     }
     // Removed automatic setting of decision time; now handled via buttons with data-now="d_time"
     if (id === 'analytics') renderAnalytics();

--- a/js/summaryHandlers.js
+++ b/js/summaryHandlers.js
@@ -5,36 +5,48 @@ import {
   exportSummaryPDF,
 } from './summary.js';
 import { getActivePatient } from './patients.js';
+import { getPayload } from './storage.js';
 import { showToast } from './toast.js';
 import { t } from './i18n.js';
 
 export function setupSummaryHandlers(inputs) {
-  document.getElementById('summary')?.addEventListener('focus', () => {
+  if (document.readyState === 'loading') {
+    document.addEventListener(
+      'DOMContentLoaded',
+      () => setupSummaryHandlers(inputs),
+      { once: true },
+    );
+    return;
+  }
+
+  const summaryEl = document.getElementById('summary');
+  if (!summaryEl) return;
+
+  summaryEl.addEventListener('focus', () => {
     const patient = getActivePatient();
-    if (!patient) return;
-    const data = collectSummaryData(patient);
+    const data = collectSummaryData(patient || getPayload());
     const text = summaryTemplate(data);
     inputs.summary.value = text;
-    patient.summary = text;
+    if (patient) patient.summary = text;
   });
+
   document.getElementById('copySummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
-    if (!patient) return;
-    const data = collectSummaryData(patient);
+    const data = collectSummaryData(patient || getPayload());
     copySummary(data)
       .then((text) => {
-        patient.summary = text;
+        if (patient) patient.summary = text;
         showToast(t('summary_copied'), { type: 'success' });
       })
       .catch(() => {});
   });
+
   document.getElementById('exportSummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
-    if (!patient) return;
-    const data = collectSummaryData(patient);
+    const data = collectSummaryData(patient || getPayload());
     const text = summaryTemplate(data);
     inputs.summary.value = text;
-    patient.summary = text;
+    if (patient) patient.summary = text;
     exportSummaryPDF(data);
     showToast(t('summary_exported'), { type: 'success' });
   });


### PR DESCRIPTION
## Summary
- ensure summary tab initializes a patient and falls back to form data
- delay summary handlers until DOM ready and guard missing elements

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68be877472108320991d2d44649ac364