### PR TITLE
Patobulintas BP šalinimo mygtukas

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -653,18 +653,18 @@ section[data-tab='Intervencijos'] h3 {
     flex-direction: column;
     align-items: stretch;
   }
-  .bp-entry .btn,
-  .bp-entry [data-remove-bp] {
+  .bp-entry .btn {
     width: 100%;
   }
   .bp-entry [data-remove-bp] {
-    height: auto;
+    width: 24px;
+    height: 24px;
   }
 }
 
 .bp-entry [data-remove-bp] {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   padding: 0;
   display: flex;
   align-items: center;

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -79,6 +79,7 @@ export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
   removeBtn.className = 'btn ghost';
   removeBtn.type = 'button';
   removeBtn.setAttribute('data-remove-bp', entryId);
+  removeBtn.setAttribute('aria-label', 'Pašalinti');
   const closeIcon = document.createElement('img');
   closeIcon.src = 'icons/close.svg';
   closeIcon.alt = '';


### PR DESCRIPTION
## Summary
- sutvarkytas BP įrašų šalinimo mygtuko pločio/aukščio valdymas ir pašalinta nebūtina taisyklė
- pridėtas aria-label šalinimo mygtukui geresniam prieinamumui

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf06b232e48320aa8357463f49a17e