### PR TITLE
Expand BP entry layout and standardize close icon size

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -631,7 +631,7 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry {
   display: grid;
-  grid-template-columns: auto auto auto 1fr auto;
+  grid-template-columns: auto auto 1fr auto;
   gap: 4px;
   align-items: center;
   border: 1px solid var(--line);

--- a/icons/close.svg
+++ b/icons/close.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><path fill="#66757F" d="m29 7-2-2-9 9-9-9-2 2 9 9-9 9 2 2 9-9 9 9 2-2-9-9z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36" width="16" height="16"><path fill="#66757F" d="m29 7-2-2-9 9-9-9-2 2 9 9-9 9 2 2 9-9 9 9 2-2-9-9z"/></svg>


### PR DESCRIPTION
## Summary
- widen BP entry notes column by switching grid to `auto auto 1fr auto`
- add explicit 16×16 dimensions to close icon

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf298e940c8320859b1c4a18110f3e