### PR TITLE
Show dose units on AKS correction entries

### DIFF
--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -33,6 +33,9 @@ export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
   nowBtn.textContent = 'Dabar';
   group.appendChild(nowBtn);
 
+  const doseGroup = document.createElement('div');
+  doseGroup.className = 'input-group flex-nowrap';
+
   const doseInput = document.createElement('input');
   doseInput.type = 'text';
   doseInput.className = 'dose-input';
@@ -67,7 +70,13 @@ export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
   };
   doseInput.addEventListener('input', validateDose);
   validateDose();
-  entry.appendChild(doseInput);
+
+  doseGroup.appendChild(doseInput);
+  const unitSpan = document.createElement('span');
+  unitSpan.className = 'unit';
+  unitSpan.textContent = placeholder;
+  doseGroup.appendChild(unitSpan);
+  entry.appendChild(doseGroup);
 
   const notesInput = document.createElement('input');
   notesInput.setAttribute('type', 'text');

--- a/test/bpDoseInput.test.js
+++ b/test/bpDoseInput.test.js
@@ -6,11 +6,14 @@ import { createBpEntry } from '../js/bpEntry.js';
 test('dose input accepts text and validates numeric part', () => {
   const entry = createBpEntry('Med', '5 mg');
   const doseInput = entry.querySelector('.dose-input');
+  const unitSpan = entry.querySelector('.unit');
 
   assert.ok(doseInput);
+  assert.ok(unitSpan);
   assert.equal(doseInput.type, 'text');
   assert.equal(doseInput.placeholder, 'mg');
   assert.equal(doseInput.value, '5');
+  assert.equal(unitSpan.textContent, 'mg');
 
   doseInput.value = '5.5';
   doseInput.dispatchEvent(new Event('input'));

--- a/test/bpEntryButtons.test.js
+++ b/test/bpEntryButtons.test.js
@@ -85,6 +85,8 @@ test('bp entry displays default dose from bpMeds', async () => {
   document.querySelector('.bp-med').click();
 
   const doseInput = document.querySelector('.dose-input');
+  const unitSpan = document.querySelector('.bp-entry .unit');
   assert.equal(doseInput.value, med.dose);
   assert.equal(doseInput.placeholder, med.unit);
+  assert.equal(unitSpan.textContent, med.unit);
 });

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -18,7 +18,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><input value="25" data-unit="mg" placeholder="mg" /><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -18,7 +18,7 @@ test('summaryTemplate generates summary text correctly', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><input value="25 mg" /><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';


### PR DESCRIPTION
## Summary
- Display dose units beside blood pressure correction inputs so medications show mg or other units
- Update tests to verify unit labels render and carry through summaries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c05944a5408320819cd020f8c569f7