### PR TITLE
style: disable buttons properly

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -21,6 +21,11 @@
 .btn:active {
   background: var(--btn-active-bg);
 }
+.btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  pointer-events: none;
+}
 .btn:focus-visible {
   outline: 3px solid var(--accent);
   outline-offset: 2px;

--- a/js/drugControls.js
+++ b/js/drugControls.js
@@ -14,9 +14,11 @@ export function setupDrugControls(inputs) {
     startThrombolysisBtn.dataset.requirementsInvalid = requirementsInvalid
       ? 'true'
       : 'false';
-    startThrombolysisBtn.disabled =
+    const startDisabled =
       requirementsInvalid ||
       startThrombolysisBtn.dataset.lkwDisabled === 'true';
+    startThrombolysisBtn.disabled = startDisabled;
+    startThrombolysisBtn.toggleAttribute('disabled', startDisabled);
   };
 
   [inputs.def_tnk, inputs.def_tpa].forEach((el) =>

--- a/js/lkw.js
+++ b/js/lkw.js
@@ -42,8 +42,10 @@ export function setupLkw(inputs) {
     tab?.toggleAttribute('disabled', disabled);
     if (startBtn) {
       startBtn.dataset.lkwDisabled = disabled ? 'true' : 'false';
-      startBtn.disabled =
+      const startDisabled =
         disabled || startBtn.dataset.requirementsInvalid === 'true';
+      startBtn.disabled = startDisabled;
+      startBtn.toggleAttribute('disabled', startDisabled);
     }
   };
   inputs.lkw_type.forEach((o) =>

--- a/test/lkwThrombolysisButton.test.js
+++ b/test/lkwThrombolysisButton.test.js
@@ -21,13 +21,16 @@ test('startThrombolysis button disables on unknown LKW', () => {
   lkwUnknown.checked = true;
   lkwUnknown.dispatchEvent(new Event('change', { bubbles: true }));
   assert.equal(startBtn.disabled, true);
+  assert.equal(startBtn.hasAttribute('disabled'), true);
 
   inputs.weight.value = '80';
   inputs.weight.dispatchEvent(new Event('input', { bubbles: true }));
   assert.equal(startBtn.disabled, true);
+  assert.equal(startBtn.hasAttribute('disabled'), true);
 
   const lkwKnown = inputs.lkw_type.find((o) => o.value === 'known');
   lkwKnown.checked = true;
   lkwKnown.dispatchEvent(new Event('change', { bubbles: true }));
   assert.equal(startBtn.disabled, false);
+  assert.equal(startBtn.hasAttribute('disabled'), false);
 });


### PR DESCRIPTION
## Summary
- fade and block disabled buttons
- ensure thrombolysis button toggles disabled attribute
- test disabled attribute behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c268c83a808320a43dfd56f719c488