### PR TITLE
feat: highlight pill focus

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -199,6 +199,10 @@
   color: var(--ink);
   font-weight: 700;
 }
+.pill:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
 .pill.checked {
   background: var(--accent);
   border-color: #2d74b8;

--- a/test/jsdomSetup.js
+++ b/test/jsdomSetup.js
@@ -7,6 +7,13 @@ const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 function applyDom() {
   const dom = new JSDOM(html, { url: 'http://localhost' });
   global.window = dom.window;
+  global.window.matchMedia =
+    global.window.matchMedia ||
+    (() => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+    }));
   global.document = dom.window.document;
   global.HTMLElement = dom.window.HTMLElement;
   global.Event = dom.window.Event;


### PR DESCRIPTION
## Summary
- show visible outline when pill inputs receive focus
- stub `window.matchMedia` in jsdom tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c26b875da08320825ae5bec4175440