### PR TITLE
style: improve toast close button

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -613,6 +613,17 @@ section[data-tab='Intervencijos'] h3 {
   color: inherit;
   font-size: 16px;
   cursor: pointer;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+}
+
+.toast-close:hover,
+.toast-close:focus {
+  background: var(--ghost-hover-bg);
 }
 .arrival-timer {
   font-family: monospace;


### PR DESCRIPTION
## Summary
- center toast close button by applying fixed square size and flex layout
- add hover/focus background for clearer affordance

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27bfa90ac8320aa60d2da68529807