### PR TITLE
Add post-treatment blood pressure fields

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -643,7 +643,7 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry {
   display: grid;
-  grid-template-columns: auto auto 1fr auto;
+  grid-template-columns: auto auto auto auto 1fr auto;
   gap: 4px;
   align-items: center;
   border: 1px solid var(--line);
@@ -654,6 +654,10 @@ section[data-tab='Intervencijos'] h3 {
 
 .bp-entry .dose-input {
   max-width: 6rem;
+}
+
+.bp-entry .bp-after input {
+  max-width: 4rem;
 }
 
 @media (max-width: 480px) {

--- a/js/bpEntry.js
+++ b/js/bpEntry.js
@@ -1,6 +1,15 @@
 import { pad } from './time.js';
+import { validateBp } from './bp.js';
 
-export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
+export function createBpEntry(
+  med,
+  dose = '',
+  time,
+  notes = '',
+  unit = '',
+  bpSysAfter = '',
+  bpDiaAfter = '',
+) {
   const ts = `${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
   const entryId = `bp_entry_${ts}`;
   const timeId = `bp_time_${ts}`;
@@ -77,6 +86,49 @@ export function createBpEntry(med, dose = '', time, notes = '', unit = '') {
   unitSpan.textContent = placeholder;
   doseGroup.appendChild(unitSpan);
   entry.appendChild(doseGroup);
+
+  const bpAfterGroup = document.createElement('div');
+  bpAfterGroup.className = 'input-group flex-nowrap bp-after';
+
+  const sysAfterInput = document.createElement('input');
+  sysAfterInput.type = 'number';
+  sysAfterInput.name = 'bp_sys_after';
+  sysAfterInput.className = 'bp-sys-after';
+  sysAfterInput.placeholder = 'Sistolinis';
+  sysAfterInput.min = '30';
+  sysAfterInput.max = '300';
+  sysAfterInput.step = '1';
+  sysAfterInput.value = bpSysAfter;
+
+  const diaAfterInput = document.createElement('input');
+  diaAfterInput.type = 'number';
+  diaAfterInput.name = 'bp_dia_after';
+  diaAfterInput.className = 'bp-dia-after';
+  diaAfterInput.placeholder = 'Diastolinis';
+  diaAfterInput.min = '10';
+  diaAfterInput.max = '200';
+  diaAfterInput.step = '1';
+  diaAfterInput.value = bpDiaAfter;
+
+  const validate = () => {
+    [sysAfterInput, diaAfterInput].forEach((i) => {
+      i.classList.remove('invalid');
+      i.setCustomValidity?.('');
+    });
+    if (!sysAfterInput.value || !diaAfterInput.value) return;
+    if (!validateBp(Number(sysAfterInput.value), Number(diaAfterInput.value))) {
+      [sysAfterInput, diaAfterInput].forEach((i) => {
+        i.classList.add('invalid');
+        i.setCustomValidity?.('Įveskite teisingą AKS (pvz. 120/80).');
+      });
+    }
+  };
+  sysAfterInput.addEventListener('input', validate);
+  diaAfterInput.addEventListener('input', validate);
+
+  bpAfterGroup.appendChild(sysAfterInput);
+  bpAfterGroup.appendChild(diaAfterInput);
+  entry.appendChild(bpAfterGroup);
 
   const notesInput = document.createElement('input');
   notesInput.setAttribute('type', 'text');

--- a/js/storage.js
+++ b/js/storage.js
@@ -104,12 +104,15 @@ export function getPayload() {
     document.querySelectorAll('#bpEntries .bp-entry'),
   ).map((entry) => {
     const med = entry.querySelector('strong')?.textContent || '';
-    const [timeEl, doseEl, notesEl] = entry.querySelectorAll('input');
+    const [timeEl, doseEl, sysAfterEl, diaAfterEl, notesEl] =
+      entry.querySelectorAll('input');
     return {
       time: timeEl?.value || '',
       med,
       dose: doseEl?.value || '',
       unit: doseEl?.dataset.unit || doseEl?.placeholder || '',
+      bp_sys_after: sysAfterEl?.value || '',
+      bp_dia_after: diaAfterEl?.value || '',
       notes: notesEl?.value || '',
     };
   });
@@ -150,6 +153,8 @@ export function setPayload(p) {
         m.time,
         m.notes || '',
         m.unit || '',
+        m.bp_sys_after || '',
+        m.bp_dia_after || '',
       );
       bpContainer.appendChild(entry);
     });

--- a/test/bpEntryButtons.test.js
+++ b/test/bpEntryButtons.test.js
@@ -90,3 +90,31 @@ test('bp entry displays default dose from bpMeds', async () => {
   assert.equal(doseInput.placeholder, med.unit);
   assert.equal(unitSpan.textContent, med.unit);
 });
+
+test('bp entry creates and saves BP after inputs', async () => {
+  const med = bpMeds[0];
+  document.body.innerHTML = `
+    <form>
+      <input id="p_weight" type="number" />
+      <ul id="bpMedList" role="list"><li><button type="button" class="btn bp-med" data-med="${med.name}">${med.name}</button></li></ul>
+      <div id="bpEntries"></div>
+    </form>
+  `;
+  const { setupBpEntry } = await import('../js/bp.js');
+  const { getPayload } = await import('../js/storage.js');
+
+  setupBpEntry();
+  document.querySelector('.bp-med').click();
+
+  const sysInput = document.querySelector('.bp-sys-after');
+  const diaInput = document.querySelector('.bp-dia-after');
+  assert.ok(sysInput);
+  assert.ok(diaInput);
+
+  sysInput.value = '150';
+  diaInput.value = '90';
+
+  const payload = getPayload();
+  assert.equal(payload.bp_meds[0].bp_sys_after, '150');
+  assert.equal(payload.bp_meds[0].bp_dia_after, '90');
+});

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -18,7 +18,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Kaptoprilis</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><div class="input-group flex-nowrap bp-after"><input name="bp_sys_after" value="150" /><input name="bp_dia_after" value="90" /></div><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';
@@ -77,6 +77,8 @@ test('copySummary builds data object and copies formatted text', async () => {
         med: 'Kaptoprilis',
         dose: '25',
         unit: 'mg',
+        bp_sys_after: '150',
+        bp_dia_after: '90',
         notes: 'požymai',
       },
     ],

--- a/test/removeBpEntry.test.js
+++ b/test/removeBpEntry.test.js
@@ -33,6 +33,7 @@ test('bp entry can be removed even when #p_weight is invalid or empty', async ()
   `;
   const { setupBpEntry } = await import('../js/bp.js');
   const { handleBpEntriesClick } = await import('../js/bpEntries.js');
+  const { getPayload } = await import('../js/storage.js');
 
   setupBpEntry();
 
@@ -43,9 +44,17 @@ test('bp entry can be removed even when #p_weight is invalid or empty', async ()
   // invalid weight
   medBtn.click();
   assert.equal(bpEntries.children.length, 1);
+  const sysInput = bpEntries.querySelector('.bp-sys-after');
+  const diaInput = bpEntries.querySelector('.bp-dia-after');
+  sysInput.value = '150';
+  diaInput.value = '90';
+  let payload = getPayload();
+  assert.equal(payload.bp_meds[0].bp_sys_after, '150');
   document.getElementById('p_weight').value = 'abc';
   bpEntries.querySelector('button[data-remove-bp]').click();
   assert.equal(bpEntries.children.length, 0);
+  payload = getPayload();
+  assert.equal(payload.bp_meds.length, 0);
 
   // empty weight
   medBtn.click();

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -18,7 +18,7 @@ test('summaryTemplate generates summary text correctly', async () => {
   document.querySelector('input[name="a_speech"]').checked = true;
 
   const bpEntries = document.getElementById('bpEntries');
-  bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><input value="požymai" /></div>`;
+  bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><div class="input-group flex-nowrap bp-after"><input name="bp_sys_after" value="150" /><input name="bp_dia_after" value="90" /></div><input value="požymai" /></div>`;
 
   inputs.a_personal.value = '12345678901';
   inputs.a_name.value = 'Jonas Jonaitis';


### PR DESCRIPTION
## Summary
- track systolic/diastolic BP after antihypertensive meds with validation
- extend BP entry layout and storage schema for post-med BP values
- update tests for creating, saving, and removing new BP fields

## Testing
- `npm test`
- `npx eslint js/bpEntry.js js/storage.js test/bpEntryButtons.test.js test/removeBpEntry.test.js test/copySummary.test.js test/summaryTemplate.test.js` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c296b0816483208d0500c593b647fb