### PR TITLE
feat: use accent variable for primary controls

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -36,14 +36,14 @@
 .btn.primary {
   background: var(--accent);
   color: #fff;
-  border-color: #2d74b8;
+  border-color: var(--accent);
 }
 .btn.primary:hover {
-  background: #2368c5;
+  background: color-mix(in srgb, var(--accent), #000 10%);
 }
 
 .btn.primary:active {
-  background: #1a56aa;
+  background: color-mix(in srgb, var(--accent), #000 20%);
 }
 .btn.warn {
   background: var(--yellow);
@@ -99,13 +99,13 @@
 #bpCorrBtn[aria-expanded='true'] {
   background: var(--accent);
   color: #fff;
-  border-color: #2d74b8;
+  border-color: var(--accent);
 }
 #bpCorrBtn[aria-expanded='true']:hover {
-  background: #2368c5;
+  background: color-mix(in srgb, var(--accent), #000 10%);
 }
 #bpCorrBtn[aria-expanded='true']:active {
-  background: #1a56aa;
+  background: color-mix(in srgb, var(--accent), #000 20%);
 }
 .switch {
   position: relative;
@@ -146,7 +146,7 @@
 
 .switch input:checked + .slider {
   background: var(--accent);
-  border-color: #2d74b8;
+  border-color: var(--accent);
 }
 
 .switch input:checked + .slider::before {


### PR DESCRIPTION
## Summary
- use `--accent` for primary button, BP correction button, and switch slider
- derive hover/active colors from accent

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2a17e117c8320990ef9f572539f60