### PR TITLE
Adjust tablet layout breakpoint

### DIFF
--- a/css/layout.css
+++ b/css/layout.css
@@ -105,7 +105,7 @@ header {
   align-items: center;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 600px) {
   .wrap {
     flex-direction: column;
     align-items: flex-start;
@@ -120,6 +120,20 @@ header {
 
   .brand .subtle {
     display: none;
+  }
+}
+
+@media (min-width: 601px) and (max-width: 768px) {
+  .wrap {
+    flex-direction: row;
+    align-items: center;
+  }
+
+  .header-actions {
+    margin-left: auto;
+    justify-content: flex-end;
+    width: auto;
+    margin-top: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- limit mobile breakpoint to 600px
- add tablet-specific media query keeping `.wrap` and `.header-actions` horizontal

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2bff046b48320886f0f0638d0f0bf