### PR TITLE
Adjust grid layouts for responsive design

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -639,7 +639,7 @@ section[data-tab='Intervencijos'] h3 {
 .grid-4 {
   display: grid;
   gap: 10px;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
 .bp-entry {
@@ -725,26 +725,10 @@ section[data-tab='Intervencijos'] h3 {
 .cols-3,
 .cols-4,
 .cols-auto {
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
 
-@media (max-width: 1024px) {
-  .grid-4,
-  .cols-4 {
-    grid-template-columns: repeat(3, 1fr);
-  }
-}
-
-@media (max-width: 768px) {
-  .grid-3,
-  .grid-4,
-  .cols-3,
-  .cols-4 {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (max-width: 480px) {
+@media (max-width: 900px) {
   .grid-2,
   .grid-3,
   .grid-4,


### PR DESCRIPTION
## Summary
- ensure two- and three-column grids stack on small screens with new 900px breakpoint
- widen grid column min width for better large-screen spacing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2ca34d96c832093547c69735ceb20