### PR TITLE
feat: auto-name patients and rename via input

### DIFF
--- a/js/autosave.js
+++ b/js/autosave.js
@@ -166,23 +166,20 @@ export function setupAutosave(
     closePatientMenu();
   });
 
-  $('#newPatientBtn')?.addEventListener('click', async () => {
+  $('#newPatientBtn')?.addEventListener('click', () => {
     const id = addPatient();
-    const enteredName = await promptModal(t('rename_prompt'), '');
-    if (enteredName) {
-      renamePatient(id, enteredName);
-      refreshPatientSelect(id);
-    } else {
-      refreshPatientSelect(id);
-    }
+    refreshPatientSelect(id);
     showToast(t('patient_created'), { type: 'success' });
     updateSaveStatus();
     closePatientMenu();
   });
 
-  const handleChange = () => {
+  const handleChange = (e) => {
     const id = getActivePatientId();
     if (id) dirtyPatients.add(id);
+    if (e.target?.id === 'a_name' && id) {
+      renamePatient(id, e.target.value);
+    }
     updateActivePatient();
     if (!$('#summarySec').classList.contains('hidden')) {
       const patient = getActivePatient();

--- a/test/dirtyIndicator.test.js
+++ b/test/dirtyIndicator.test.js
@@ -23,15 +23,21 @@ test(
 
     const id = getActivePatientId();
     const select = document.getElementById('patientSelect');
+    let opt = Array.from(select.options).find((o) => o.value === id);
+    assert.strictEqual(opt.textContent, 'Pacientas 1');
+
     const field = document.getElementById('a_name');
     field.value = 'Test';
     field.dispatchEvent(new Event('input', { bubbles: true }));
 
-    let opt = Array.from(select.options).find((o) => o.value === id);
+    opt = Array.from(select.options).find((o) => o.value === id);
+    assert.ok(opt.textContent.startsWith('Test'));
     assert.ok(opt.textContent.endsWith(' •'));
+    const label = document.getElementById('patientMenuLabel');
+    assert.strictEqual(label.textContent, 'Test');
 
     saveCb?.();
     opt = Array.from(select.options).find((o) => o.value === id);
-    assert.ok(!opt.textContent.endsWith(' •'));
+    assert.strictEqual(opt.textContent, 'Test');
   },
 );

--- a/test/patients.test.js
+++ b/test/patients.test.js
@@ -112,3 +112,15 @@ test('switchPatient persists previous patient data', () => {
   const patients = getPatientStore();
   assert.strictEqual(patients[id2].p_nihss0, '2');
 });
+
+test('addPatient assigns default names sequentially', () => {
+  localStorage.clear();
+  resetInputs();
+  Object.keys(getPatientStore()).forEach((id) => removePatient(id));
+
+  const id1 = addPatient();
+  const id2 = addPatient();
+  const patients = getPatientStore();
+  assert.strictEqual(patients[id1].name, 'Pacientas 1');
+  assert.strictEqual(patients[id2].name, 'Pacientas 2');
+});


### PR DESCRIPTION
## Summary
- remove rename prompt when creating a new patient and rely on default name
- rename patients live when editing the name field
- test default patient names and UI rename behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c32d1627548320aae35cb70da54728