### PR TITLE
Add CT result validation for thrombolysis

### DIFF
--- a/index.html
+++ b/index.html
@@ -1371,6 +1371,17 @@ Kontraindikacijos trombektomijai</summary>
               </ul>
               <div id="bpEntries" class="mt-10"></div>
             </div>
+            <fieldset class="mt-10">
+              <legend>KT rezultatas</legend>
+              <div class="grid-2">
+                <label class="pill"
+                  ><input type="radio" name="ct_result" value="clear" /> Be kraujavimo</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="ct_result" value="bleed" /> Kraujavimas</label
+                >
+              </div>
+            </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div class="grid-2">
               <div>

--- a/js/drugControls.js
+++ b/js/drugControls.js
@@ -14,9 +14,14 @@ export function setupDrugControls(inputs) {
     startThrombolysisBtn.dataset.requirementsInvalid = requirementsInvalid
       ? 'true'
       : 'false';
+    const ctBleed = inputs.ct_result?.some(
+      (n) => n.checked && n.value === 'bleed',
+    );
+    startThrombolysisBtn.dataset.ctBleed = ctBleed ? 'true' : 'false';
     const startDisabled =
       requirementsInvalid ||
-      startThrombolysisBtn.dataset.lkwDisabled === 'true';
+      startThrombolysisBtn.dataset.lkwDisabled === 'true' ||
+      ctBleed;
     startThrombolysisBtn.disabled = startDisabled;
     startThrombolysisBtn.toggleAttribute('disabled', startDisabled);
   };
@@ -37,6 +42,9 @@ export function setupDrugControls(inputs) {
     toggleStartBtn();
   });
   inputs.drugConc?.addEventListener('input', calcDrugs);
+  inputs.ct_result?.forEach((el) =>
+    el.addEventListener('change', toggleStartBtn),
+  );
 
   startThrombolysisBtn?.addEventListener('click', () => {
     setNow('t_thrombolysis');

--- a/js/state.js
+++ b/js/state.js
@@ -32,6 +32,7 @@ const selectorMap = {
   arrival_symptoms: ['#arrival_symptoms'],
   arrival_contra: ['input[name="arrival_contra"]', true],
   arrival_mt_contra: ['input[name="arrival_mt_contra"]', true],
+  ct_result: ['input[name="ct_result"]', true],
   drugType: ['#drug_type'],
   drugConc: ['#drug_conc'],
   doseTotal: ['#dose_total'],

--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -62,6 +62,12 @@ export const FIELD_DEFS = [
   { key: 'tpa_infusion', selector: 'tpaInf' },
   { key: 't_thrombolysis', selector: 't_thrombolysis' },
   {
+    key: 'ct_result',
+    selector: 'ct_result',
+    get: getRadioValue,
+    set: setRadioValue,
+  },
+  {
     key: 'arrival_lkw_type',
     selector: 'lkw_type',
     get: getRadioValue,

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -74,6 +74,17 @@
               </ul>
               <div id="bpEntries" class="mt-10"></div>
             </div>
+            <fieldset class="mt-10">
+              <legend>KT rezultatas</legend>
+              <div class="grid-2">
+                <label class="pill"
+                  ><input type="radio" name="ct_result" value="clear" /> Be kraujavimo</label
+                >
+                <label class="pill"
+                  ><input type="radio" name="ct_result" value="bleed" /> Kraujavimas</label
+                >
+              </div>
+            </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div class="grid-2">
               <div>

--- a/test/lkwThrombolysisButton.test.js
+++ b/test/lkwThrombolysisButton.test.js
@@ -34,3 +34,27 @@ test('startThrombolysis button disables on unknown LKW', () => {
   assert.equal(startBtn.disabled, false);
   assert.equal(startBtn.hasAttribute('disabled'), false);
 });
+
+test('startThrombolysis button disables on CT bleed', () => {
+  const inputs = getInputs();
+  setupDrugControls(inputs);
+
+  inputs.weight.value = '70';
+  inputs.weight.dispatchEvent(new Event('input', { bubbles: true }));
+  inputs.drugType.value = 'tpa';
+  inputs.drugType.dispatchEvent(new Event('change', { bubbles: true }));
+
+  const startBtn = document.getElementById('startThrombolysis');
+
+  const ctClear = inputs.ct_result.find((o) => o.value === 'clear');
+  ctClear.checked = true;
+  ctClear.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, false);
+  assert.equal(startBtn.hasAttribute('disabled'), false);
+
+  const ctBleed = inputs.ct_result.find((o) => o.value === 'bleed');
+  ctBleed.checked = true;
+  ctBleed.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, true);
+  assert.equal(startBtn.hasAttribute('disabled'), true);
+});


### PR DESCRIPTION
## Summary
- add CT result radio group before thrombolytic calculator
- store and validate CT result to disable thrombolysis when bleed selected
- test CT bleed disables start button

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c32f8f51dc8320aaffa6226b65fc82