### PR TITLE
Use fixed thrombolytic concentrations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1383,28 +1383,17 @@ Kontraindikacijos trombektomijai</summary>
               </div>
             </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
-            <div class="grid-2">
-              <div>
-                <label for="drug_type">Vaistas</label>
-                <select id="drug_type">
-                  <option value="tnk">
-                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
-                  </option>
-                  <option value="tpa">
-                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
-                    per 60 min
-                  </option>
-                </select>
-              </div>
-              <div>
-                <label>Koncentracija (mg/ml)</label>
-                <input
-                  id="drug_conc"
-                  type="number"
-                  step="0.01"
-                  placeholder="pvz. 5"
-                />
-              </div>
+            <div>
+              <label for="drug_type">Vaistas</label>
+              <select id="drug_type">
+                <option value="tnk">
+                  Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                </option>
+                <option value="tpa">
+                  Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                  per 60 min
+                </option>
+              </select>
             </div>
             <div class="grid-2 mt-10">
               <div>

--- a/js/computeDose.js
+++ b/js/computeDose.js
@@ -6,9 +6,11 @@ function round0(n) {
 
 export function computeDose(weight, concentration, type) {
   const w = Number(weight);
-  const c = Number(concentration);
+  let c = Number(concentration);
   if (!Number.isFinite(w) || w <= 0) return null;
-  if (!Number.isFinite(c) || c <= 0) return null;
+  if (!Number.isFinite(c) || c <= 0) {
+    c = type === 'tnk' ? 5 : 1;
+  }
 
   if (type === 'tnk') {
     const doseTotal = Math.min(25, round0(0.25 * w));

--- a/js/drugControls.js
+++ b/js/drugControls.js
@@ -41,7 +41,6 @@ export function setupDrugControls(inputs) {
     calcDrugs();
     toggleStartBtn();
   });
-  inputs.drugConc?.addEventListener('input', calcDrugs);
   inputs.ct_result?.forEach((el) =>
     el.addEventListener('change', toggleStartBtn),
   );

--- a/js/drugs.js
+++ b/js/drugs.js
@@ -4,23 +4,17 @@ import { t } from './i18n.js';
 
 export function updateDrugDefaults() {
   const typeEl = dom.getDrugTypeInput();
-  const concEl = dom.getDrugConcInput();
-  const defTnkEl = dom.getDefTnkInput();
-  const defTpaEl = dom.getDefTpaInput();
-  if (!typeEl || !concEl || !defTnkEl || !defTpaEl) return;
-  const type = typeEl.value;
-  const conc =
-    type === 'tnk' ? Number(defTnkEl.value || 5) : Number(defTpaEl.value || 1);
-  concEl.value = String(conc);
+  if (!typeEl) return;
   const tpaBreakdown = document.getElementById('tpaBreakdown');
   if (tpaBreakdown)
-    tpaBreakdown.style.display = type === 'tpa' ? 'grid' : 'none';
+    tpaBreakdown.style.display = typeEl.value === 'tpa' ? 'grid' : 'none';
 }
 
 export function calcDrugs() {
   const typeEl = dom.getDrugTypeInput();
   const weightEl = dom.getWeightInput();
-  const concEl = dom.getDrugConcInput();
+  const defTnkEl = dom.getDefTnkInput();
+  const defTpaEl = dom.getDefTpaInput();
   const doseTotalEl = dom.getDoseTotalInput();
   const doseVolEl = dom.getDoseVolInput();
   const tpaBolusEl = dom.getTpaBolusInput();
@@ -28,7 +22,6 @@ export function calcDrugs() {
   if (
     !typeEl ||
     !weightEl ||
-    !concEl ||
     !doseTotalEl ||
     !doseVolEl ||
     !tpaBolusEl ||
@@ -38,32 +31,24 @@ export function calcDrugs() {
 
   const type = typeEl.value;
   const w = Number((weightEl.value || '').replace(/,/g, '.'));
-  const conc = Number((concEl.value || '').replace(/,/g, '.'));
+  const conc =
+    type === 'tnk'
+      ? Number(defTnkEl?.value) || 5
+      : Number(defTpaEl?.value) || 1;
   const wValid = Number.isFinite(w) && w > 0;
-  const cValid = Number.isFinite(conc) && conc > 0;
 
-  [weightEl, concEl].forEach((el) => {
-    el.classList.remove('invalid');
-    if (el.setCustomValidity) el.setCustomValidity('');
-  });
+  weightEl.classList.remove('invalid');
+  if (weightEl.setCustomValidity) weightEl.setCustomValidity('');
 
-  if (!wValid || !cValid) {
+  if (!wValid) {
     doseTotalEl.value = '';
     doseVolEl.value = '';
     tpaBolusEl.value = '';
     tpaInfEl.value = '';
-    if (!wValid) {
-      weightEl.classList.add('invalid');
-      if (weightEl.setCustomValidity)
-        weightEl.setCustomValidity(t('invalid_weight'));
-      if (weightEl.reportValidity) weightEl.reportValidity();
-    }
-    if (!cValid) {
-      concEl.classList.add('invalid');
-      if (concEl.setCustomValidity)
-        concEl.setCustomValidity(t('invalid_concentration'));
-      if (concEl.reportValidity) concEl.reportValidity();
-    }
+    weightEl.classList.add('invalid');
+    if (weightEl.setCustomValidity)
+      weightEl.setCustomValidity(t('invalid_weight'));
+    if (weightEl.reportValidity) weightEl.reportValidity();
     return;
   }
 

--- a/js/state.js
+++ b/js/state.js
@@ -34,7 +34,6 @@ const selectorMap = {
   arrival_mt_contra: ['input[name="arrival_mt_contra"]', true],
   ct_result: ['input[name="ct_result"]', true],
   drugType: ['#drug_type'],
-  drugConc: ['#drug_conc'],
   doseTotal: ['#dose_total'],
   doseVol: ['#dose_volume'],
   tpaBolus: ['#tpa_bolus'],

--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -55,7 +55,6 @@ export const FIELD_DEFS = [
     set: (nodes, value) => setRadioValue(nodes, value || ''),
   },
   { key: 'drug_type', selector: 'drugType', default: 'tnk' },
-  { key: 'drug_conc', selector: 'drugConc' },
   { key: 'dose_total', selector: 'doseTotal' },
   { key: 'dose_volume', selector: 'doseVol' },
   { key: 'tpa_bolus', selector: 'tpaBolus' },

--- a/js/summary.js
+++ b/js/summary.js
@@ -28,7 +28,6 @@ export function collectSummaryData(payload) {
   };
   const drugs = {
     type: payload.drug_type || '',
-    conc: get(payload.drug_conc),
     totalDose: get(payload.dose_total),
     totalVol: get(payload.dose_volume),
     bolus: get(payload.tpa_bolus),
@@ -137,7 +136,8 @@ export function summaryTemplate({
   lines.push('VAISTAI:');
   const drugType = drugs.type === 'tnk' ? 'Tenekteplazė' : 'Alteplazė';
   lines.push(`- Tipas: ${drugType}`);
-  lines.push(`- Koncentracija: ${drugs.conc ? `${drugs.conc} mg/ml` : '—'}`);
+  const concLine = drugs.type === 'tnk' ? '5 mg/ml' : '1 mg/ml';
+  lines.push(`- Koncentracija: ${concLine}`);
   lines.push(
     `- Bendra dozė: ${
       drugs.totalDose ? `${drugs.totalDose} mg` : '—'

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -86,28 +86,17 @@
               </div>
             </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
-            <div class="grid-2">
-              <div>
-                <label for="drug_type">Vaistas</label>
-                <select id="drug_type">
-                  <option value="tnk">
-                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
-                  </option>
-                  <option value="tpa">
-                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
-                    per 60 min
-                  </option>
-                </select>
-              </div>
-              <div>
-                <label>Koncentracija (mg/ml)</label>
-                <input
-                  id="drug_conc"
-                  type="number"
-                  step="0.01"
-                  placeholder="pvz. 5"
-                />
-              </div>
+            <div>
+              <label for="drug_type">Vaistas</label>
+              <select id="drug_type">
+                <option value="tnk">
+                  Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                </option>
+                <option value="tpa">
+                  Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                  per 60 min
+                </option>
+              </select>
             </div>
             <div class="grid-2 mt-10">
               <div>

--- a/test/accessorsMock.test.js
+++ b/test/accessorsMock.test.js
@@ -10,7 +10,6 @@ import('../js/drugs.js').then(({ calcDrugs }) => {
 
     document.body.innerHTML = `
       <select id="drug_type"></select>
-      <input id="drug_conc" />
       <input id="p_weight" />
       <input id="dose_total" />
       <input id="dose_volume" />
@@ -22,7 +21,6 @@ import('../js/drugs.js').then(({ calcDrugs }) => {
     const { getInputs } = await import('../js/state.js');
     const inputs = getInputs();
     inputs.drugType.value = 'tnk';
-    inputs.drugConc.value = '5';
     inputs.weight.value = '70';
     assert.doesNotThrow(() => calcDrugs());
   });

--- a/test/calcDrugs.test.js
+++ b/test/calcDrugs.test.js
@@ -8,7 +8,6 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   const { calcDrugs } = await import('../js/drugs.js');
 
   inputs.weight.value = '0';
-  inputs.drugConc.value = '5';
   inputs.drugType.value = 'tnk';
   calcDrugs();
   assert(inputs.weight.classList.contains('invalid'));
@@ -16,17 +15,7 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
 
   inputs.weight.value = '70';
   inputs.weight.classList.remove('invalid');
-  inputs.drugConc.value = '0';
-  inputs.drugConc.classList.remove('invalid');
   inputs.doseTotal.value = '';
-  calcDrugs();
-  assert(inputs.drugConc.classList.contains('invalid'));
-  assert.strictEqual(inputs.doseTotal.value, '');
-
-  inputs.drugConc.classList.remove('invalid');
-  inputs.weight.value = '70';
-  inputs.drugConc.value = '5';
-  inputs.drugType.value = 'tnk';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '18');
   assert.strictEqual(inputs.doseVol.value, '4');
@@ -34,14 +23,12 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.strictEqual(inputs.tpaInf.value, '');
 
   inputs.weight.value = '200';
-  inputs.drugConc.value = '5';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '25');
   assert.strictEqual(inputs.doseVol.value, '5');
 
   inputs.drugType.value = 'tpa';
   inputs.weight.value = '70';
-  inputs.drugConc.value = '1';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '63');
   assert.strictEqual(inputs.doseVol.value, '63');
@@ -49,7 +36,6 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.strictEqual(inputs.tpaInf.value, '57 mg (57 ml) · ~57 ml/val');
 
   inputs.weight.value = '120';
-  inputs.drugConc.value = '1';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '90');
   assert.strictEqual(inputs.doseVol.value, '90');
@@ -57,22 +43,9 @@ test('calcDrugs handles dosing correctly, validates inputs, and resets outputs',
   assert.strictEqual(inputs.tpaInf.value, '81 mg (81 ml) · ~81 ml/val');
 
   inputs.weight.value = '70';
-  inputs.drugConc.value = '1';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '63');
   inputs.weight.value = '0';
-  calcDrugs();
-  assert.strictEqual(inputs.doseTotal.value, '');
-  assert.strictEqual(inputs.doseVol.value, '');
-  assert.strictEqual(inputs.tpaBolus.value, '');
-  assert.strictEqual(inputs.tpaInf.value, '');
-
-  inputs.weight.value = '70';
-  inputs.drugConc.value = '1';
-  calcDrugs();
-  assert.strictEqual(inputs.doseTotal.value, '63');
-
-  inputs.drugConc.value = '0';
   calcDrugs();
   assert.strictEqual(inputs.doseTotal.value, '');
   assert.strictEqual(inputs.doseVol.value, '');

--- a/test/computeDose.test.js
+++ b/test/computeDose.test.js
@@ -4,9 +4,8 @@ import assert from 'node:assert/strict';
 import { computeDose } from '../js/computeDose.js';
 
 test('computeDose returns null on invalid inputs', () => {
-  assert.strictEqual(computeDose(0, 1, 'tnk'), null);
-  assert.strictEqual(computeDose(70, 0, 'tnk'), null);
-  assert.strictEqual(computeDose(70, 1, 'foo'), null);
+  assert.strictEqual(computeDose(0, 5, 'tnk'), null);
+  assert.strictEqual(computeDose(70, 5, 'foo'), null);
 });
 
 test('computeDose calculates TNK dose and caps at 25 mg', () => {

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -40,7 +40,6 @@ test('copySummary builds data object and copies formatted text', async () => {
   inputs.a_temp.value = '37';
   inputs.arrival_symptoms.value = 'Dešinės rankos silpnumas';
   inputs.drugType.value = 'tnk';
-  inputs.drugConc.value = '5';
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
 
@@ -65,7 +64,6 @@ test('copySummary builds data object and copies formatted text', async () => {
     },
     drugs: {
       type: 'tnk',
-      conc: '5',
       totalDose: '20',
       totalVol: '4',
       bolus: null,

--- a/test/localStorage.test.js
+++ b/test/localStorage.test.js
@@ -95,7 +95,6 @@ test(
     inputs.lkw.value = '2024-01-01T08:00';
     inputs.door.value = '2024-01-01T08:30';
     inputs.drugType.value = 'tnk';
-    inputs.drugConc.value = '5';
     inputs.doseTotal.value = '10';
     inputs.doseVol.value = '2';
 

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -39,7 +39,6 @@ test('summaryTemplate generates summary text correctly', async () => {
   inputs.door.value = '2024-01-01T08:00';
   inputs.d_time.value = '2024-01-01T08:40';
   inputs.drugType.value = 'tnk';
-  inputs.drugConc.value = '5';
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
 

--- a/test/updateDrugDefaults.test.js
+++ b/test/updateDrugDefaults.test.js
@@ -2,19 +2,17 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import './jsdomSetup.js';
 
-test('updateDrugDefaults sets default concentrations correctly', async () => {
+test('updateDrugDefaults toggles tPA breakdown visibility', async () => {
   const { getInputs } = await import('../js/state.js');
   const inputs = getInputs();
   const { updateDrugDefaults } = await import('../js/drugs.js');
-
-  inputs.def_tnk.value = '';
-  inputs.def_tpa.value = '';
+  const tpaBreakdown = document.getElementById('tpaBreakdown');
 
   inputs.drugType.value = 'tnk';
   updateDrugDefaults();
-  assert.strictEqual(inputs.drugConc.value, '5');
+  assert.strictEqual(tpaBreakdown.style.display, 'none');
 
   inputs.drugType.value = 'tpa';
   updateDrugDefaults();
-  assert.strictEqual(inputs.drugConc.value, '1');
+  assert.strictEqual(tpaBreakdown.style.display, 'grid');
 });


### PR DESCRIPTION
## Summary
- remove manual concentration input and rely on fixed defaults for TNK (5 mg/ml) and tPA (1 mg/ml)
- drop drug concentration from state, storage, and summary; adjust dose calculations accordingly
- update tests for new fixed-concentration logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c33218c6908320b82f7cf8fa89924f