### PR TITLE
Add complications tab and summary support

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,18 @@
 </span><span class="tab-label">Sprendimas</span></a
   >
   <a
+    id="complications-tab"
+    href="#complications"
+    data-section="complications"
+    class="tab btn"
+    role="tab"
+    ><span class="tab-icon" aria-hidden="true">
+
+<svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 36 36"><path fill="#FFCC4D" d="M2.653 35C.811 35-.001 33.662.847 32.027L16.456 1.972c.849-1.635 2.238-1.635 3.087 0l15.609 30.056c.85 1.634.037 2.972-1.805 2.972H2.653z"/><path fill="#231F20" d="M15.583 28.953c0-1.333 1.085-2.418 2.419-2.418 1.333 0 2.418 1.085 2.418 2.418 0 1.334-1.086 2.419-2.418 2.419-1.334 0-2.419-1.085-2.419-2.419zm.186-18.293c0-1.302.961-2.108 2.232-2.108 1.241 0 2.233.837 2.233 2.108v11.938c0 1.271-.992 2.108-2.233 2.108-1.271 0-2.232-.807-2.232-2.108V10.66z"/></svg>
+
+</span><span class="tab-label">Komplikacijos</span></a
+  >
+  <a
     id="summarySec-tab"
     href="#summarySec"
     data-section="summarySec"
@@ -1673,6 +1685,77 @@ Kontraindikacijos trombektomijai</summary>
             </form>
           </section>
 
+
+                <!-- Komplikacijos -->
+        <section
+          id="complications"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="complications-tab"
+        >
+          <h2>Komplikacijos</h2>
+          <form>
+            <fieldset>
+              <legend>Komplikacijos</legend>
+              <div class="grid-3">
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="bleeding" />
+                  Kraujavimas</label
+                >
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="allergy" />
+                  Alergija</label
+                >
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="other" />
+                  Kita</label
+                >
+              </div>
+            </fieldset>
+            <div class="mt-10">
+              <label for="t_complication">Laikas</label>
+              
+<div class="row">
+  <div class="input-group">
+    <input
+      id="t_complication"
+      class="time-input"
+      type="datetime-local"
+      placeholder="YYYY-MM-DD HH:MM"
+      step="60"
+    />
+      
+      <button
+        type="button"
+        class="btn ghost"
+        data-now="t_complication"
+        aria-label="Dabar"
+      >
+        Dabar
+      </button>
+      
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepdown="t_complication"
+      aria-label="−5 min"
+    >
+      −5
+    </button>
+    <button
+      type="button"
+      class="btn ghost"
+      data-stepup="t_complication"
+      aria-label="+5 min"
+    >
+      +5
+    </button>
+  </div>
+</div>
+
+            </div>
+          </form>
+        </section>
 
                 <!-- Santrauka HIS sistemai -->
         <section

--- a/js/state.js
+++ b/js/state.js
@@ -45,6 +45,8 @@ const selectorMap = {
   def_tnk: ['#def_tnk'],
   def_tpa: ['#def_tpa'],
   t_thrombolysis: ['#t_thrombolysis'],
+  complication: ['input[name="complication"]', true],
+  t_complication: ['#t_complication'],
   autosave: ['#autosave'],
   summary: ['#summary'],
   patientSelect: ['#patientSelect'],

--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -67,6 +67,13 @@ export const FIELD_DEFS = [
   { key: 'tpa_infusion', selector: 'tpaInf' },
   { key: 't_thrombolysis', selector: 't_thrombolysis' },
   {
+    key: 'complications',
+    selector: 'complication',
+    get: getCheckboxList,
+    set: setCheckboxList,
+  },
+  { key: 't_complication', selector: 't_complication' },
+  {
     key: 'ct_result',
     selector: 'ct_result',
     get: getRadioValue,

--- a/js/summary.js
+++ b/js/summary.js
@@ -65,6 +65,8 @@ export function collectSummaryData(payload) {
   const arrivalSymptoms = get(payload.arrival_symptoms);
   const arrivalContra = get(payload.arrival_contra);
   const arrivalMtContra = get(payload.arrival_mt_contra);
+  const complications = get(payload.complications);
+  const compTime = get(payload.t_complication);
   const decision = payload.d_decision || null;
   return {
     patient,
@@ -76,6 +78,8 @@ export function collectSummaryData(payload) {
     arrivalSymptoms,
     arrivalContra,
     arrivalMtContra,
+    complications,
+    compTime,
   };
 }
 
@@ -89,6 +93,8 @@ export function summaryTemplate({
   arrivalSymptoms,
   arrivalContra,
   arrivalMtContra,
+  complications,
+  compTime,
 }) {
   const lines = [];
   lines.push('PACIENTAS:');
@@ -181,6 +187,12 @@ export function summaryTemplate({
   if (arrivalMtContra) {
     lines.push('KONTRAINDIKACIJOS MTE:');
     lines.push(`- ${arrivalMtContra}`);
+  }
+
+  if (complications || compTime) {
+    lines.push('KOMPLIKACIJOS:');
+    if (complications) lines.push(`- ${complications}`);
+    if (compTime) lines.push(`- Laikas: ${compTime}`);
   }
 
   lines.push('SPRENDIMAS:');

--- a/templates/index.njk
+++ b/templates/index.njk
@@ -14,6 +14,7 @@
         {% include "sections/nihss.njk" %}
         {% include "sections/thrombolysis.njk" %}
         {% include "sections/decision.njk" %}
+        {% include "sections/complications.njk" %}
         {% include "sections/summary.njk" %}
         {% include "partials/settings.njk" %}
         {% include "partials/footer.njk" %}

--- a/templates/partials/nav.njk
+++ b/templates/partials/nav.njk
@@ -48,6 +48,14 @@
     ><span class="tab-icon" aria-hidden="true">{{ icon('decision') | safe }}</span><span class="tab-label">Sprendimas</span></a
   >
   <a
+    id="complications-tab"
+    href="#complications"
+    data-section="complications"
+    class="tab btn"
+    role="tab"
+    ><span class="tab-icon" aria-hidden="true">{{ icon('warning') | safe }}</span><span class="tab-label">Komplikacijos</span></a
+  >
+  <a
     id="summarySec-tab"
     href="#summarySec"
     data-section="summarySec"

--- a/templates/sections/complications.njk
+++ b/templates/sections/complications.njk
@@ -1,0 +1,32 @@
+        <!-- Komplikacijos -->
+        <section
+          id="complications"
+          class="card hidden"
+          role="tabpanel"
+          aria-labelledby="complications-tab"
+        >
+          <h2>Komplikacijos</h2>
+          <form>
+            <fieldset>
+              <legend>Komplikacijos</legend>
+              <div class="grid-3">
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="bleeding" />
+                  Kraujavimas</label
+                >
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="allergy" />
+                  Alergija</label
+                >
+                <label class="pill"
+                  ><input type="checkbox" name="complication" value="other" />
+                  Kita</label
+                >
+              </div>
+            </fieldset>
+            <div class="mt-10">
+              <label for="t_complication">Laikas</label>
+              {{ timeInput('t_complication') }}
+            </div>
+          </form>
+        </section>

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -70,6 +70,7 @@ test('copySummary builds data object and copies formatted text', async () => {
       bolus: null,
       infusion: null,
     },
+    decision: 'Taikoma IVT, indikacijų MTE nenustatyta',
     bpMeds: [
       {
         time: '10:00',
@@ -96,7 +97,8 @@ test('copySummary builds data object and copies formatted text', async () => {
     arrivalSymptoms: 'Dešinės rankos silpnumas',
     arrivalContra: null,
     arrivalMtContra: null,
-    decision: 'Taikoma IVT, indikacijų MTE nenustatyta',
+    complications: null,
+    compTime: null,
   });
 
   const expected = summaryTemplate(data);


### PR DESCRIPTION
## Summary
- add Komplikacijos section with checkboxes and timestamp
- show Komplikacijos tab in navigation and include section in main template
- store and render complications in summary

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c39e24c90c8320b255b1bbde85f144