### PR TITLE
Remove duplicate CT result fieldset

### DIFF
--- a/index.html
+++ b/index.html
@@ -1487,17 +1487,6 @@ Kontraindikacijos trombektomijai</summary>
               </ul>
               <div id="bpEntries" class="mt-10"></div>
             </div>
-            <fieldset class="mt-10">
-              <legend>KT rezultatas</legend>
-              <div class="grid-2">
-                <label class="pill"
-                  ><input type="radio" name="ct_result" value="clear" /> Be kraujavimo</label
-                >
-                <label class="pill"
-                  ><input type="radio" name="ct_result" value="bleed" /> Kraujavimas</label
-                >
-              </div>
-            </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div>
               <label for="drug_type">Vaistas</label>

--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -98,17 +98,6 @@
               </ul>
               <div id="bpEntries" class="mt-10"></div>
             </div>
-            <fieldset class="mt-10">
-              <legend>KT rezultatas</legend>
-              <div class="grid-2">
-                <label class="pill"
-                  ><input type="radio" name="ct_result" value="clear" /> Be kraujavimo</label
-                >
-                <label class="pill"
-                  ><input type="radio" name="ct_result" value="bleed" /> Kraujavimas</label
-                >
-              </div>
-            </fieldset>
             <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
             <div>
               <label for="drug_type">Vaistas</label>


### PR DESCRIPTION
## Summary
- remove CT result fieldset from thrombolysis section to avoid duplication
- rebuild static index.html to reflect template changes

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c3a43a103c8320877d41499767bd3f