### PR TITLE
Rename CTA result to KTA result

### DIFF
--- a/index.html
+++ b/index.html
@@ -1142,12 +1142,12 @@ Kontraindikacijos trombektomijai</summary>
               >
             </fieldset>
             <fieldset>
-              <legend>CTA rezultatas</legend>
+              <legend>KTA rezultatas</legend>
               <label class="pill"
-                ><input type="radio" name="cta_result" value="none" /> Be okliuzijos</label
+                ><input type="radio" name="kta_result" value="none" /> Be okliuzijos</label
               >
               <label class="pill"
-                ><input type="radio" name="cta_result" value="lvo" /> Didelės arterijos okliuzija</label
+                ><input type="radio" name="kta_result" value="lvo" /> Didelės arterijos okliuzija</label
               >
             </fieldset>
             <fieldset>

--- a/js/state.js
+++ b/js/state.js
@@ -34,7 +34,7 @@ const selectorMap = {
   arrival_contra: ['input[name="arrival_contra"]', true],
   arrival_mt_contra: ['input[name="arrival_mt_contra"]', true],
   ct_result: ['input[name="ct_result"]', true],
-  cta_result: ['input[name="cta_result"]', true],
+  kta_result: ['input[name="kta_result"]', true],
   perf_core: ['#perf_core'],
   perf_penumbra: ['#perf_penumbra'],
   drugType: ['#drug_type'],

--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -80,8 +80,8 @@ export const FIELD_DEFS = [
     set: setRadioValue,
   },
   {
-    key: 'cta_result',
-    selector: 'cta_result',
+    key: 'kta_result',
+    selector: 'kta_result',
     get: getRadioValue,
     set: (nodes, value) => setRadioValue(nodes, value || ''),
   },

--- a/templates/sections/imaging.njk
+++ b/templates/sections/imaging.njk
@@ -17,12 +17,12 @@
               >
             </fieldset>
             <fieldset>
-              <legend>CTA rezultatas</legend>
+              <legend>KTA rezultatas</legend>
               <label class="pill"
-                ><input type="radio" name="cta_result" value="none" /> Be okliuzijos</label
+                ><input type="radio" name="kta_result" value="none" /> Be okliuzijos</label
               >
               <label class="pill"
-                ><input type="radio" name="cta_result" value="lvo" /> Didelės arterijos okliuzija</label
+                ><input type="radio" name="kta_result" value="lvo" /> Didelės arterijos okliuzija</label
               >
             </fieldset>
             <fieldset>


### PR DESCRIPTION
## Summary
- rename imaging CTA result field to KTA result
- align state selector and storage mapping with new `kta_result` field
- regenerate `index.html`

## Testing
- `npm run build`
- `npm test`
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_68c3a941005c8320afdb1ef80b6db8fd