### PR TITLE
Add department selection to stroke decision flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -1671,6 +1671,16 @@ Kontraindikacijos trombektomijai</summary>
                   >
                 </div>
               </fieldset>
+            <fieldset class="mt-10">
+              <legend>Stacionarizacijos skyrius</legend>
+              <label for="d_department">Stacionarizacijos skyrius</label>
+              <select id="d_department" name="d_department">
+                <option value="">Pasirinkite skyrių</option>
+                <option value="Neurologijos skyrius">Neurologijos skyrius</option>
+                <option value="Reanimacija">Reanimacija</option>
+                <option value="Kitas">Kitas</option>
+              </select>
+            </fieldset>
             </form>
           </section>
 

--- a/js/state.js
+++ b/js/state.js
@@ -27,6 +27,7 @@ const selectorMap = {
   door: ['#t_door'],
   d_time: ['#d_time'],
   d_decision: ['input[name="d_decision"]', true],
+  d_department: ['#d_department'],
   lkw_type: ['input[name="lkw_type"]', true],
   sleep_start: ['#t_sleep_start'],
   sleep_end: ['#t_sleep_end'],

--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -60,6 +60,7 @@ export const FIELD_DEFS = [
     get: getRadioValue,
     set: (nodes, value) => setRadioValue(nodes, value || ''),
   },
+  { key: 'd_department', selector: 'd_department' },
   { key: 'drug_type', selector: 'drugType', default: 'tnk' },
   { key: 'dose_total', selector: 'doseTotal' },
   { key: 'dose_volume', selector: 'doseVol' },

--- a/js/summary.js
+++ b/js/summary.js
@@ -68,11 +68,13 @@ export function collectSummaryData(payload) {
   const complications = get(payload.complications);
   const compTime = get(payload.t_complication);
   const decision = payload.d_decision || null;
+  const department = payload.d_department || null;
   return {
     patient,
     times,
     drugs,
     decision,
+    department,
     bpMeds,
     activation,
     arrivalSymptoms,
@@ -88,6 +90,7 @@ export function summaryTemplate({
   times,
   drugs,
   decision,
+  department,
   bpMeds,
   activation,
   arrivalSymptoms,
@@ -197,6 +200,7 @@ export function summaryTemplate({
 
   lines.push('SPRENDIMAS:');
   lines.push(`- ${decision ?? '—'}`);
+  lines.push(`- Stacionarizacija: ${department ?? '—'}`);
   return lines.join('\n');
 }
 

--- a/templates/sections/decision.njk
+++ b/templates/sections/decision.njk
@@ -54,6 +54,16 @@
                   >
                 </div>
               </fieldset>
+            <fieldset class="mt-10">
+              <legend>Stacionarizacijos skyrius</legend>
+              <label for="d_department">Stacionarizacijos skyrius</label>
+              <select id="d_department" name="d_department">
+                <option value="">Pasirinkite skyrių</option>
+                <option value="Neurologijos skyrius">Neurologijos skyrius</option>
+                <option value="Reanimacija">Reanimacija</option>
+                <option value="Kitas">Kitas</option>
+              </select>
+            </fieldset>
             </form>
           </section>
 

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -30,6 +30,7 @@ test('copySummary builds data object and copies formatted text', async () => {
   inputs.lkw.value = '2024-01-01T07:00';
   inputs.door.value = '2024-01-01T08:00';
   inputs.d_time.value = '2024-01-01T08:40';
+  inputs.d_department.value = 'Neurologijos skyrius';
   inputs.t_thrombolysis.value = '2024-01-01T09:00';
   inputs.a_warfarin.checked = true;
   inputs.a_glucose.value = '5';
@@ -71,6 +72,7 @@ test('copySummary builds data object and copies formatted text', async () => {
       infusion: null,
     },
     decision: 'Taikoma IVT, indikacijų MTE nenustatyta',
+    department: 'Neurologijos skyrius',
     bpMeds: [
       {
         time: '10:00',

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -38,6 +38,7 @@ test('summaryTemplate generates summary text correctly', async () => {
   inputs.lkw.value = '2024-01-01T07:00';
   inputs.door.value = '2024-01-01T08:00';
   inputs.d_time.value = '2024-01-01T08:40';
+  inputs.d_department.value = 'Neurologijos skyrius';
   inputs.drugType.value = 'tnk';
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
@@ -72,4 +73,5 @@ test('summaryTemplate generates summary text correctly', async () => {
   assert(
     summary.includes('SPRENDIMAS:\n- Taikoma IVT, indikacijų MTE nenustatyta'),
   );
+  assert(summary.includes('- Stacionarizacija: Neurologijos skyrius'));
 });


### PR DESCRIPTION
## Summary
- allow selecting a hospitalization department in decision step
- persist `d_department` and include it in generated summary text
- test summary and copy features for department line

## Testing
- `npm test`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint js/state.js js/storage/fields.js js/summary.js test/copySummary.test.js test/summaryTemplate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c3bf9b70f083208bd322640cc758a4