### PR TITLE
Wrap thrombolysis calculator in fieldset

### DIFF
--- a/templates/sections/thrombolysis.njk
+++ b/templates/sections/thrombolysis.njk
@@ -101,39 +101,41 @@
               </ul>
               <div id="bpEntries" class="mt-10"></div>
             </div>
-            <h3 class="mt-20">Trombolitiko skaičiuoklė</h3>
-            <div>
-              <label for="drug_type">Vaistas</label>
-              <select id="drug_type">
-                <option value="tnk">
-                  Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
-                </option>
-                <option value="tpa">
-                  Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
-                  per 60 min
-                </option>
-              </select>
-            </div>
-            <div class="grid-2 mt-10">
+            <fieldset class="mt-20">
+              <legend>Trombolitiko skaičiuoklė</legend>
               <div>
-                <label for="dose_total">Bendra dozė (mg)</label>
-                <input id="dose_total" type="number" step="1" readonly />
+                <label for="drug_type">Vaistas</label>
+                <select id="drug_type">
+                  <option value="tnk">
+                    Tenekteplazė (TNK) – 0,25 mg/kg (max 25 mg), bolius
+                  </option>
+                  <option value="tpa">
+                    Alteplazė (tPA) – 0,9 mg/kg (max 90 mg), 10% bolius + 90%
+                    per 60 min
+                  </option>
+                </select>
               </div>
-              <div>
-                <label for="dose_volume">Tūris (ml)</label>
-                <input id="dose_volume" type="number" step="1" readonly />
+              <div class="grid-2 mt-10">
+                <div>
+                  <label for="dose_total">Bendra dozė (mg)</label>
+                  <input id="dose_total" type="number" step="1" readonly />
+                </div>
+                <div>
+                  <label for="dose_volume">Tūris (ml)</label>
+                  <input id="dose_volume" type="number" step="1" readonly />
+                </div>
               </div>
-            </div>
-            <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
-              <div>
-                <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
-                <input id="tpa_bolus" type="text" readonly />
+              <div id="tpaBreakdown" class="grid-2 mt-10 hidden">
+                <div>
+                  <label for="tpa_bolus">Bolius 10% (mg / ml)</label>
+                  <input id="tpa_bolus" type="text" readonly />
+                </div>
+                <div>
+                  <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
+                  <input id="tpa_infusion" type="text" readonly />
+                </div>
               </div>
-              <div>
-                <label for="tpa_infusion">Infuzija 90% per 60 min (mg / ml / ml/val)</label>
-                <input id="tpa_infusion" type="text" readonly />
-              </div>
-            </div>
+            </fieldset>
             <div class="section-actions mt-10">
               <span class="mini"
                 >Pastaba: klinikiniai sprendimai remiasi vietinėmis gairėmis. Ši


### PR DESCRIPTION
## Summary
- wrap thrombolysis dose calculator controls in a fieldset with legend

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c3ef516f688320a79b1ccea950b0bd