### PR TITLE
fix: encode LKW description newline in locales

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,5 @@
 {
-  "LKW": "Last known well – the time when the patient was last known without stroke symptoms. The app uses this to compute intervals like LKW to thrombolysis for treatment decisions.",
+  "LKW": "Last known well – the time when the patient was last known without stroke symptoms.\nThe app uses this to compute intervals like LKW to thrombolysis for treatment decisions.",
   "settings": "Settings",
   "copy": "Copy",
   "export_pdf": "PDF",

--- a/locales/lt.json
+++ b/locales/lt.json
@@ -1,5 +1,5 @@
 {
-  "LKW": "Paskutinį kartą matytas sveikas – laikas, kai pacientas paskutinį kartą buvo be insulto simptomų. Programėlė šį laiką naudoja apskaičiuodama intervalus, tokius kaip nuo LKW iki trombolizės, sprendimams dėl gydymo.",
+  "LKW": "Paskutinį kartą matytas sveikas – laikas, kai pacientas paskutinį kartą buvo be insulto simptomų. Programėlė šį laiką\nnaudoja apskaičiuodama intervalus, tokius kaip nuo LKW iki trombolizės, sprendimams dėl gydymo.",
   "settings": "Nustatymai",
   "copy": "Kopijuoti",
   "export_pdf": "PDF",


### PR DESCRIPTION
## Summary
- replace raw newline in LKW translation with escaped `\n`
- mirror change in English locale

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3c8a3b08320bf06c75330b9bad1