### PR TITLE
refactor: build complication map on demand

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -2,11 +2,13 @@ import { getInputs } from './state.js';
 import { showToast } from './toast.js';
 import { t } from './i18n.js';
 
-const compMap = {
-  bleeding: t('comp_bleeding'),
-  allergy: t('comp_allergy'),
-  other: t('comp_other'),
-};
+function buildCompMap() {
+  return {
+    bleeding: t('comp_bleeding'),
+    allergy: t('comp_allergy'),
+    other: t('comp_other'),
+  };
+}
 
 export function collectSummaryData(payload) {
   const get = (v) => (v !== undefined && v !== null && v !== '' ? v : null);
@@ -199,6 +201,7 @@ export function summaryTemplate({
   }
 
   if (complications || compTime) {
+    const compMap = buildCompMap();
     lines.push('KOMPLIKACIJOS:');
     if (complications) {
       const compList = complications


### PR DESCRIPTION
## Summary
- generate complication translation map inside `summaryTemplate`
- verify translations reinitialize correctly in `copySummary.test`

## Testing
- `npm test --silent`
- `ESLINT_USE_FLAT_CONFIG=false npx eslint -c .eslintrc.cjs js/summary.js test/copySummary.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68c6b6f6f75c83209121d7d6f45f3d52