### PR TITLE
Dynamically translate complications

### DIFF
--- a/js/i18n.js
+++ b/js/i18n.js
@@ -30,7 +30,7 @@ function applyTranslations() {
   });
 }
 
-async function setLanguage(lang) {
+export async function setLanguage(lang) {
   await loadLang(lang);
   applyTranslations();
 }

--- a/js/summary.js
+++ b/js/summary.js
@@ -2,12 +2,6 @@ import { getInputs } from './state.js';
 import { showToast } from './toast.js';
 import { t } from './i18n.js';
 
-const compMap = {
-  bleeding: t('comp_bleeding'),
-  allergy: t('comp_allergy'),
-  other: t('comp_other'),
-};
-
 export function collectSummaryData(payload) {
   const get = (v) => (v !== undefined && v !== null && v !== '' ? v : null);
   const formatBp = (sys, dia) => {
@@ -203,7 +197,11 @@ export function summaryTemplate({
     if (complications) {
       const compList = complications
         .split('; ')
-        .map((c) => compMap[c] || c)
+        .map((code) => {
+          const key = 'comp_' + code;
+          const translated = t(key);
+          return translated === key ? code : translated;
+        })
         .join('; ');
       lines.push(`- ${compList}`);
     }

--- a/test/complicationsLanguage.test.js
+++ b/test/complicationsLanguage.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+// Ensure complications are translated after language change
+
+test('complications translate after language change', async () => {
+  const origFetch = global.fetch;
+  global.fetch = async (url) => {
+    const match = url.toString().match(/locales\/(\w+)\.json$/);
+    if (match) {
+      const lang = match[1];
+      const translations = {
+        lt: {
+          comp_bleeding: 'Kraujavimas',
+          comp_allergy: 'Alergija',
+        },
+        en: {
+          comp_bleeding: 'Bleeding',
+          comp_allergy: 'Allergy',
+        },
+      };
+      return { ok: true, json: async () => translations[lang] };
+    }
+    return origFetch(url);
+  };
+
+  const { setLanguage } = await import('../js/i18n.js');
+  await setLanguage('lt');
+  const { summaryTemplate } = await import('../js/summary.js');
+
+  const data = {
+    patient: {
+      personal: null,
+      name: null,
+      dob: null,
+      age: null,
+      weight: null,
+      bp: null,
+      inr: null,
+      nih0: null,
+      independent: null,
+    },
+    times: {
+      gmp: null,
+      lkw: null,
+      door: null,
+      decision: null,
+      thrombolysis: null,
+    },
+    drugs: {
+      type: 'tnk',
+      totalDose: null,
+      totalVol: null,
+      bolus: null,
+      infusion: null,
+    },
+    decision: null,
+    department: null,
+    bpMeds: [],
+    activation: {
+      lkw: null,
+      drugs: [],
+      params: {},
+      symptoms: [],
+    },
+    arrivalSymptoms: null,
+    arrivalContra: null,
+    arrivalMtContra: null,
+    complications: 'bleeding; allergy',
+    compTime: null,
+  };
+
+  const ltSummary = summaryTemplate(data);
+  assert(ltSummary.includes('KOMPLIKACIJOS:\n- Kraujavimas; Alergija'));
+
+  await setLanguage('en');
+  const enSummary = summaryTemplate(data);
+  assert(enSummary.includes('Bleeding; Allergy'));
+
+  global.fetch = origFetch;
+});


### PR DESCRIPTION
## Summary
- remove static complication translation map and translate codes on demand
- expose `setLanguage` and add test for complication translations after language change

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7e3390fc08320ac369d38b2ba5b16