### PR TITLE
style: increase pill label contrast

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -194,9 +194,9 @@
   gap: 8px;
   margin-bottom: 8px;
   padding: 6px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid color-mix(in srgb, var(--line), var(--ink) 30%);
   border-radius: 999px;
-  background: var(--card);
+  background: color-mix(in srgb, var(--card), var(--ink) 10%);
   color: var(--ink);
   font-weight: 700;
 }


### PR DESCRIPTION
## Summary
- lighten pill label background and border so pill labels stand out from the page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7fcbf2aac8320a83a7a1770a78b12