### PR TITLE
Refactor summary handlers to reuse update helper

### DIFF
--- a/js/summaryHandlers.js
+++ b/js/summaryHandlers.js
@@ -10,6 +10,20 @@ import { getPayload } from './storage.js';
 import { showToast } from './toast.js';
 import { t } from './i18n.js';
 
+/**
+ * Atnaujina santraukos lauką pagal aktyvų pacientą arba paskutinį įrašą.
+ * @param {object|null} patient
+ * @param {{ summary?: HTMLTextAreaElement|null }} inputs
+ * @returns {object}
+ */
+function updateSummary(patient, inputs) {
+  const data = collectSummaryData(patient || getPayload());
+  const text = summaryTemplate(data);
+  if (inputs.summary) inputs.summary.value = text;
+  if (patient) patient.summary = text;
+  return data;
+}
+
 export function setupSummaryHandlers(inputs) {
   if (document.readyState === 'loading') {
     document.addEventListener(
@@ -25,15 +39,12 @@ export function setupSummaryHandlers(inputs) {
 
   summaryEl.addEventListener('focus', () => {
     const patient = getActivePatient();
-    const data = collectSummaryData(patient || getPayload());
-    const text = summaryTemplate(data);
-    inputs.summary.value = text;
-    if (patient) patient.summary = text;
+    updateSummary(patient, inputs);
   });
 
   document.getElementById('copySummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
-    const data = collectSummaryData(patient || getPayload());
+    const data = updateSummary(patient, inputs);
     copySummary(data)
       .then((text) => {
         if (patient) patient.summary = text;
@@ -44,20 +55,14 @@ export function setupSummaryHandlers(inputs) {
 
   document.getElementById('exportSummaryBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
-    const data = collectSummaryData(patient || getPayload());
-    const text = summaryTemplate(data);
-    inputs.summary.value = text;
-    if (patient) patient.summary = text;
+    const data = updateSummary(patient, inputs);
     exportSummaryPDF(data);
     showToast(t('summary_exported'), { type: 'success' });
   });
 
   document.getElementById('exportDriveBtn')?.addEventListener('click', () => {
     const patient = getActivePatient();
-    const data = collectSummaryData(patient || getPayload());
-    const text = summaryTemplate(data);
-    inputs.summary.value = text;
-    if (patient) patient.summary = text;
+    const data = updateSummary(patient, inputs);
     exportSummaryToDrive(data);
   });
 }


### PR DESCRIPTION
## Summary
- add an updateSummary helper to centralize collecting data and updating the textarea
- reuse the helper across focus, copy, and export handlers to keep patient data in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c840f747f8832097533a83f9fa68f0