### PR TITLE
Refactor time utilities with normalizePair

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -14,6 +14,17 @@ export function parseValidDate(value) {
   return isNaN(date.getTime()) ? null : date;
 }
 
+export function normalizePair(start, end) {
+  if (!start || !end) return null;
+  const s = parseValidDate(start);
+  let e = parseValidDate(end);
+  if (!s || !e) return null;
+  if (e < s) {
+    e = new Date(e.getTime() + 864e5);
+  }
+  return { s, e };
+}
+
 export function setNow(id) {
   const el = document.getElementById(id);
   if (!el) return;
@@ -27,20 +38,16 @@ export function setNow(id) {
 }
 
 export function sleepMidpoint(start, end) {
-  if (!start || !end) return '';
-  const s = parseValidDate(start);
-  let e = parseValidDate(end);
-  if (!s || !e) return '';
-  if (e < s) e = new Date(e.getTime() + 864e5);
+  const pair = normalizePair(start, end);
+  if (!pair) return '';
+  const { s, e } = pair;
   const mid = new Date((s.getTime() + e.getTime()) / 2);
   return toLocalInputValue(mid);
 }
 
 export function diffMinutes(start, end) {
-  if (!start || !end) return NaN;
-  const s = parseValidDate(start);
-  let e = parseValidDate(end);
-  if (!s || !e) return NaN;
-  if (e < s) e = new Date(e.getTime() + 864e5);
+  const pair = normalizePair(start, end);
+  if (!pair) return NaN;
+  const { s, e } = pair;
   return Math.round((e.getTime() - s.getTime()) / 60000);
 }

--- a/test/time.test.js
+++ b/test/time.test.js
@@ -33,6 +33,21 @@ test('setNow sets local HH:MM and triggers change', async () => {
   global.Date = RealDate;
 });
 
+test('normalizePair normalizes overnight ranges', async () => {
+  const { normalizePair } = await import('../js/time.js');
+  const pair = normalizePair('2024-01-01T22:00', '2024-01-01T06:00');
+  assert.ok(pair);
+  assert.equal(pair.s.getTime(), new Date('2024-01-01T22:00').getTime());
+  assert.equal(pair.e.getTime(), new Date('2024-01-02T06:00').getTime());
+});
+
+test('normalizePair returns null for missing or invalid input', async () => {
+  const { normalizePair } = await import('../js/time.js');
+  assert.equal(normalizePair('', '2024-01-01T06:00'), null);
+  assert.equal(normalizePair('bad', '2024-01-01T06:00'), null);
+  assert.equal(normalizePair('2024-01-01T22:00', 'bad'), null);
+});
+
 test('sleepMidpoint computes midpoint across midnight', async () => {
   const { sleepMidpoint } = await import('../js/time.js');
   const start = '2024-01-01T22:00';


### PR DESCRIPTION
## Summary
- add a normalizePair helper to centralize date parsing and overnight adjustments
- refactor sleepMidpoint and diffMinutes to reuse the helper
- expand time utility tests to cover normalizePair scenarios and regression cases

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c846e4d104832095f578f3d31535f4