### PR TITLE
Add imaging results to summary output

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -69,6 +69,12 @@ export function collectSummaryData(payload) {
   const compTime = get(payload.t_complication);
   const decision = payload.d_decision || null;
   const department = payload.d_department || null;
+  const imaging = {
+    ct: get(payload.ct_result),
+    kta: get(payload.kta_result),
+    perfCore: get(payload.perf_core),
+    perfPenumbra: get(payload.perf_penumbra),
+  };
   return {
     patient,
     times,
@@ -82,6 +88,7 @@ export function collectSummaryData(payload) {
     arrivalMtContra,
     complications,
     compTime,
+    imaging,
   };
 }
 
@@ -98,6 +105,7 @@ export function summaryTemplate({
   arrivalMtContra,
   complications,
   compTime,
+  imaging = {},
 }) {
   const lines = [];
   lines.push('PACIENTAS:');
@@ -141,6 +149,26 @@ export function summaryTemplate({
       paramParts.push(`Temp: ${activation.params.temp}`);
     if (paramParts.length)
       lines.push(`- GMP parametrai: ${paramParts.join(', ')}`);
+  }
+
+  const ctMap = {
+    clear: 'Be kraujavimo',
+    bleed: 'Kraujavimas',
+  };
+  const ktaMap = {
+    none: 'Be okliuzijos',
+    lvo: 'Didelės arterijos okliuzija',
+  };
+  const perfParts = [];
+  if (imaging.perfCore)
+    perfParts.push(`Infarkto branduolys ${imaging.perfCore} ml`);
+  if (imaging.perfPenumbra)
+    perfParts.push(`Penumbra ${imaging.perfPenumbra} ml`);
+  if (imaging.ct || imaging.kta || perfParts.length) {
+    lines.push('VAIZDINIAI TYRIMAI:');
+    if (imaging.ct) lines.push(`- KT: ${ctMap[imaging.ct] || imaging.ct}`);
+    if (imaging.kta) lines.push(`- KTA: ${ktaMap[imaging.kta] || imaging.kta}`);
+    if (perfParts.length) lines.push(`- Perfuzija: ${perfParts.join(', ')}`);
   }
 
   lines.push('LAIKAI:');

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "lint-staged": {
     "{js,test}/**/*.js": [
       "prettier --write",
-      "ESLINT_USE_FLAT_CONFIG=false eslint"
+      "env ESLINT_USE_FLAT_CONFIG=false eslint"
     ]
   },
   "dependencies": {

--- a/test/copySummary.test.js
+++ b/test/copySummary.test.js
@@ -111,6 +111,12 @@ test('copySummary builds data object and copies formatted text', async () => {
     arrivalMtContra: null,
     complications: null,
     compTime: null,
+    imaging: {
+      ct: null,
+      kta: null,
+      perfCore: null,
+      perfPenumbra: null,
+    },
   });
 
   const expected = summaryTemplate(data);

--- a/test/summaryTemplate.test.js
+++ b/test/summaryTemplate.test.js
@@ -16,6 +16,16 @@ test('summaryTemplate generates summary text correctly', async () => {
   document.querySelector('input[name="a_lkw"][value="<4.5"]').checked = true;
   document.querySelector('input[name="a_face"]').checked = true;
   document.querySelector('input[name="a_speech"]').checked = true;
+  const ctClear = document.querySelector(
+    'input[name="ct_result"][value="clear"]',
+  );
+  ctClear.checked = true;
+  ctClear.dispatchEvent(new Event('change', { bubbles: true }));
+  const ktaLvo = document.querySelector(
+    'input[name="kta_result"][value="lvo"]',
+  );
+  ktaLvo.checked = true;
+  ktaLvo.dispatchEvent(new Event('change', { bubbles: true }));
 
   const bpEntries = document.getElementById('bpEntries');
   bpEntries.innerHTML = `<div class="bp-entry"><strong>Nifedipinas</strong><input value="10:00" /><div class="input-group flex-nowrap"><input value="25" data-unit="mg" placeholder="mg" /><span class="unit">mg</span></div><div class="input-group flex-nowrap bp-after"><input name="bp_sys_after" value="150" /><input name="bp_dia_after" value="90" /></div><input value="požymai" /></div>`;
@@ -42,6 +52,8 @@ test('summaryTemplate generates summary text correctly', async () => {
   inputs.drugType.value = 'tnk';
   inputs.doseTotal.value = '20';
   inputs.doseVol.value = '4';
+  inputs.perf_core.value = '12';
+  inputs.perf_penumbra.value = '80';
 
   const data = collectSummaryData(getPayload());
   const summary = summaryTemplate(data);
@@ -70,6 +82,11 @@ test('summaryTemplate generates summary text correctly', async () => {
   );
   assert(summary.includes('SIMPTOMAI:\n- Dešinės rankos silpnumas'));
   assert(!summary.includes('Veido paralyžius'));
+  assert(
+    summary.includes(
+      'VAIZDINIAI TYRIMAI:\n- KT: Be kraujavimo\n- KTA: Didelės arterijos okliuzija\n- Perfuzija: Infarkto branduolys 12 ml, Penumbra 80 ml',
+    ),
+  );
   assert(
     summary.includes('SPRENDIMAS:\n- Taikoma IVT, indikacijų MTE nenustatyta'),
   );


### PR DESCRIPTION
## Summary
- include CT and CTA findings plus perfusion metrics in the generated patient summary so imaging results are visible
- extend automated tests to validate the imaging block and updated data structure in the summary
- adjust the lint-staged eslint command to run via `env` for compatibility with the pre-commit hook

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c920b39c38832090cc77fb721a1ce5