### PR TITLE
Disable thrombolysis start when patient not independent

### DIFF
--- a/js/drugControls.js
+++ b/js/drugControls.js
@@ -18,10 +18,17 @@ export function setupDrugControls(inputs) {
       (n) => n.checked && n.value === 'bleed',
     );
     startThrombolysisBtn.dataset.ctBleed = ctBleed ? 'true' : 'false';
+    const independenceRestriction = Boolean(
+      inputs.p_independent?.some((n) => n.checked && n.value === 'no'),
+    );
+    startThrombolysisBtn.dataset.independentInvalid = independenceRestriction
+      ? 'true'
+      : 'false';
     const startDisabled =
       requirementsInvalid ||
       startThrombolysisBtn.dataset.lkwDisabled === 'true' ||
-      ctBleed;
+      ctBleed ||
+      independenceRestriction;
     startThrombolysisBtn.disabled = startDisabled;
     startThrombolysisBtn.toggleAttribute('disabled', startDisabled);
   };
@@ -42,6 +49,9 @@ export function setupDrugControls(inputs) {
     toggleStartBtn();
   });
   inputs.ct_result?.forEach((el) =>
+    el.addEventListener('change', toggleStartBtn),
+  );
+  inputs.p_independent?.forEach((el) =>
     el.addEventListener('change', toggleStartBtn),
   );
 

--- a/test/lkwThrombolysisButton.test.js
+++ b/test/lkwThrombolysisButton.test.js
@@ -58,3 +58,32 @@ test('startThrombolysis button disables on CT bleed', () => {
   assert.equal(startBtn.disabled, true);
   assert.equal(startBtn.hasAttribute('disabled'), true);
 });
+
+test('startThrombolysis button disables when patient not independent', () => {
+  const inputs = getInputs();
+  setupDrugControls(inputs);
+
+  inputs.weight.value = '75';
+  inputs.weight.dispatchEvent(new Event('input', { bubbles: true }));
+  inputs.drugType.value = 'tnk';
+  inputs.drugType.dispatchEvent(new Event('change', { bubbles: true }));
+
+  const startBtn = document.getElementById('startThrombolysis');
+
+  const independentYes = inputs.p_independent.find((o) => o.value === 'yes');
+  independentYes.checked = true;
+  independentYes.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, false);
+  assert.equal(startBtn.hasAttribute('disabled'), false);
+
+  const independentNo = inputs.p_independent.find((o) => o.value === 'no');
+  independentNo.checked = true;
+  independentNo.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, true);
+  assert.equal(startBtn.hasAttribute('disabled'), true);
+
+  independentYes.checked = true;
+  independentYes.dispatchEvent(new Event('change', { bubbles: true }));
+  assert.equal(startBtn.disabled, false);
+  assert.equal(startBtn.hasAttribute('disabled'), false);
+});


### PR DESCRIPTION
## Summary
- disable the "Trombolizės pradžia" button when the independence question is answered "Ne"
- listen to independence radio button changes alongside existing requirements to keep the UI in sync
- add a unit test covering the new restriction and verifying the button re-enables when "Taip" is selected

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c961c8485883208ad1fb37f2012ad3