### PR TITLE
Add OAuth client ID inline configuration

### DIFF
--- a/index.html
+++ b/index.html
@@ -1798,6 +1798,11 @@ Kontraindikacijos trombektomijai</summary>
     </div>
   </div>
 
+    <script>
+      // OAuth nustatymas: pakeiskite į savo Google Cloud kliento ID, jei naudojate kitą aplinką.
+      window.GOOGLE_CLIENT_ID =
+        '881217612703-61htpop9nkimqftl50920vfbmou4nq5i.apps.googleusercontent.com';
+    </script>
     <script type="module" src="js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the configured Google OAuth client ID before loading the main app script so Drive export can initialize

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cac170506c83209c6b9e924a6ee1f7