### PR TITLE
Add configurable SSL support for Supabase

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL=postgres://user:password@localhost:5432/mydb
+DATABASE_SSL=false
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Requires Node.js 20 or later and access to a PostgreSQL database.
    ```
 
    - `DATABASE_URL` – PostgreSQL connection string
+   - `DATABASE_SSL` – set to `true` to force TLS (defaults to automatic Supabase detection)
    - `PORT` – optional HTTP port (defaults to `3000`)
 
 2. **Install dependencies and run migrations**
@@ -59,10 +60,22 @@ Create a `.env` file in the project root with your database connection string:
 
 ```sh
 DATABASE_URL=postgres://user:password@host:5432/dbname
+DATABASE_SSL=false
 ```
 
-Replace `user`, `password`, `host`, and `dbname` with your own PostgreSQL credentials.  
+Replace `user`, `password`, `host`, and `dbname` with your own PostgreSQL credentials.
 You may also set `PORT` to choose the server's HTTP port (default: `3000`).
+
+### Supabase smoke test
+
+Use this quick checklist to verify connectivity against a Supabase-hosted database:
+
+1. In Supabase, create a new project and copy the **connection string** from the **Project Settings → Database** page.
+2. In `.env`, set `DATABASE_URL` to that string and add `DATABASE_SSL=true` (or leave it unset; Supabase URLs are auto-detected).
+3. Run `npm install` (first time) and `npm run migrate` to create the required tables.
+4. Start the API with `npm start` and confirm `Server listening on port …` appears without SSL errors.
+5. Trigger a round-trip by sending a test request, e.g. `curl http://localhost:3000/api/patients` and expect an empty JSON array (`[]`).
+6. Stop the server with `Ctrl+C` once verification is complete.
 
 ## Client synchronization
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -35,6 +35,7 @@ Configure `.env` to point at the running container:
 
 ```
 DATABASE_URL=postgres://postgres:postgres@localhost:5432/stroke
+DATABASE_SSL=false
 ```
 
 Run migrations to create the required tables:

--- a/server/index.js
+++ b/server/index.js
@@ -74,9 +74,24 @@ if (process.env.NODE_ENV === 'test') {
 
   pool = new FakePool();
 } else {
-  pool = new pg.Pool({
-    connectionString: process.env.DATABASE_URL,
-  });
+  const connectionString = process.env.DATABASE_URL;
+  const sslFlag = process.env.DATABASE_SSL;
+  const isSupabase =
+    typeof connectionString === 'string' && connectionString.includes('supabase.co');
+
+  let enableSsl;
+  if (typeof sslFlag === 'string' && sslFlag.trim() !== '') {
+    enableSsl = ['1', 'true', 'yes', 'on'].includes(sslFlag.trim().toLowerCase());
+  } else {
+    enableSsl = isSupabase;
+  }
+
+  const poolConfig = {
+    connectionString,
+    ...(enableSsl ? { ssl: { rejectUnauthorized: false } } : {}),
+  };
+
+  pool = new pg.Pool(poolConfig);
 }
 
 async function withClient(handler) {


### PR DESCRIPTION
## Summary
- enable optional TLS for the production pg pool when Supabase is detected or DATABASE_SSL=true
- document the DATABASE_SSL environment flag and add a Supabase connectivity smoke test checklist
- update the example env file and Postgres doc to clarify local TLS defaults

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68caff4772508320b51957ee22edfc1f