### PR TITLE
Share PostgreSQL TLS configuration between server and migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Requires Node.js 20 or later and access to a PostgreSQL database.
    npm run migrate
    ```
 
+   The migration command reuses the server's TLS auto-detection, so it works
+   with a local PostgreSQL instance and Supabase-hosted databases without extra
+   flags. Set `DATABASE_SSL=true` only when you need to force TLS manually.
+
 3. **Run the test suite** _(optional but recommended)_
 
    ```sh

--- a/server/dbConfig.js
+++ b/server/dbConfig.js
@@ -1,0 +1,32 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const TRUE_VALUES = ['1', 'true', 'yes', 'on'];
+
+/**
+ * Build a shared PostgreSQL configuration that mirrors the runtime server logic.
+ * Automatically enables TLS when DATABASE_SSL is truthy or when the URL looks
+ * like a Supabase connection string.
+ */
+export function buildPgConfig() {
+  const connectionString = process.env.DATABASE_URL;
+  if (typeof connectionString !== 'string' || connectionString.trim() === '') {
+    throw new Error('DATABASE_URL environment variable is required');
+  }
+
+  const sslFlag = process.env.DATABASE_SSL;
+  const isSupabase = connectionString.includes('supabase.co');
+
+  let enableSsl;
+  if (typeof sslFlag === 'string' && sslFlag.trim() !== '') {
+    enableSsl = TRUE_VALUES.includes(sslFlag.trim().toLowerCase());
+  } else {
+    enableSsl = isSupabase;
+  }
+
+  return {
+    connectionString,
+    ...(enableSsl ? { ssl: { rejectUnauthorized: false } } : {}),
+  };
+}

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,8 @@ import express from 'express';
 import pg from 'pg';
 import dotenv from 'dotenv';
 
+import { buildPgConfig } from './dbConfig.js';
+
 dotenv.config();
 
 let pool;
@@ -74,23 +76,7 @@ if (process.env.NODE_ENV === 'test') {
 
   pool = new FakePool();
 } else {
-  const connectionString = process.env.DATABASE_URL;
-  const sslFlag = process.env.DATABASE_SSL;
-  const isSupabase =
-    typeof connectionString === 'string' && connectionString.includes('supabase.co');
-
-  let enableSsl;
-  if (typeof sslFlag === 'string' && sslFlag.trim() !== '') {
-    enableSsl = ['1', 'true', 'yes', 'on'].includes(sslFlag.trim().toLowerCase());
-  } else {
-    enableSsl = isSupabase;
-  }
-
-  const poolConfig = {
-    connectionString,
-    ...(enableSsl ? { ssl: { rejectUnauthorized: false } } : {}),
-  };
-
+  const poolConfig = buildPgConfig();
   pool = new pg.Pool(poolConfig);
 }
 

--- a/server/knexfile.js
+++ b/server/knexfile.js
@@ -2,6 +2,8 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
+import { buildPgConfig } from './dbConfig.js';
+
 dotenv.config();
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,7 +11,7 @@ const __dirname = path.dirname(__filename);
 
 export default {
   client: 'pg',
-  connection: process.env.DATABASE_URL,
+  connection: buildPgConfig(),
   migrations: {
     directory: path.join(__dirname, 'migrations'),
   },


### PR DESCRIPTION
## Summary
- add a shared PostgreSQL config helper that keeps the Supabase-aware TLS logic
- point the Express pool and Knex migrations at the shared helper
- document that `npm run migrate` works against local and Supabase instances without extra flags

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0303f4a08320beb160f60b4395fd