### PR TITLE
Document Supabase configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgres://user:password@localhost:5432/mydb
+# Supabase example: DATABASE_URL=postgresql://<project>.supabase.co:5432/postgres?sslmode=require
 DATABASE_SSL=false
+# Supabase deployments usually require TLS – set to true when using the managed URL
 PORT=3000

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To build optimized assets run:
 npm run build
 ```
 
-For additional database setup details and using Docker Compose for a local PostgreSQL instance, see [docs/postgres.md](docs/postgres.md).
+For additional database setup details and Docker Compose instructions, see [docs/postgres.md](docs/postgres.md), including the [Using Supabase](docs/postgres.md#using-supabase) section for managed databases.
 
 ## Database setup
 

--- a/docs/postgres.md
+++ b/docs/postgres.md
@@ -49,3 +49,25 @@ When finished, stop the container with:
 ```sh
 docker compose down
 ```
+
+## Using Supabase
+
+Supabase offers managed PostgreSQL instances that work with the same
+connection string format:
+
+1. In the Supabase dashboard, open **Project Settings → Database** and copy
+   the **Connection string** in `URI` format. It will look similar to
+   `postgresql://USER:PASSWORD@db.<project>.supabase.co:5432/postgres?sslmode=require`.
+2. Update your `.env` file so `DATABASE_URL` matches the Supabase string. Keep
+   `sslmode=require` on the URL or set `DATABASE_SSL=true` to force TLS when
+   the URL omits explicit parameters.
+3. Install dependencies if you have not already and run the migrations against
+   the Supabase database:
+
+   ```sh
+   npm install
+   npm run migrate
+   ```
+
+The migration script auto-detects the TLS settings, so no additional flags are
+required beyond the connection string.


### PR DESCRIPTION
## Summary
- note Supabase-specific connection string and TLS guidance in `.env.example`
- add Supabase setup instructions and migration steps to the PostgreSQL docs
- reference the new Supabase section from the README for a consistent install flow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb05fd64d48320a3c799ffe1cf457a