### PR TITLE
Add Supabase client config placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/mydb
 DATABASE_SSL=false
 # Supabase deployments usually require TLS – set to true when using the managed URL
 PORT=3000
+
+# Supabase client configuration
+SUPABASE_PROJECT_URL=https://gpyqtvisuddacmojuzxd.supabase.co
+SUPABASE_ANONPUBLIC=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdweXF0dmlzdWRkYWNtb2p1enhkIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTgxMzEyNDIsImV4cCI6MjA3MzcwNzI0Mn0.-6mP_-WBaCIa5zJQltrAgujQKqozJQLir2P7nYfo4_4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Requires Node.js 20 or later and access to a PostgreSQL database.
    - `DATABASE_URL` – PostgreSQL connection string
    - `DATABASE_SSL` – set to `true` to force TLS (defaults to automatic Supabase detection)
    - `PORT` – optional HTTP port (defaults to `3000`)
+   - `SUPABASE_PROJECT_URL` – optional, expose your Supabase project URL to the client
+   - `SUPABASE_ANONPUBLIC` – optional, Supabase anon (public) key for client SDKs
 
 2. **Install dependencies and run migrations**
 


### PR DESCRIPTION
## Summary
- add Supabase project URL and anon key placeholders to the sample environment file
- document the new optional Supabase variables in the configuration instructions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb088a1dbc83208cdbb3cf111e2875