### PR TITLE
Normalize patient sync payloads and add round-trip testing

### DIFF
--- a/test/apiPersistence.test.js
+++ b/test/apiPersistence.test.js
@@ -1,4 +1,4 @@
-import { test, before, after } from 'node:test';
+import { test, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 process.env.NODE_ENV = 'test';
@@ -17,38 +17,85 @@ after(() => {
   server.close();
 });
 
-test('POST /api/patients inserts a patient record', async () => {
-  const res = await fetch(`${baseUrl}/api/patients`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: 'Alice', payload: { foo: 'bar' } }),
-  });
-  assert.equal(res.status, 201);
-  const body = await res.json();
-  assert.equal(body.name, 'Alice');
-
-  const { rows } = await pool.query('SELECT * FROM patients');
-  assert.equal(rows.length, 1);
-  assert.equal(rows[0].name, 'Alice');
+beforeEach(() => {
+  if (pool.patients) {
+    pool.patients = [];
+    pool.nextPatientId = 1;
+  }
+  if (pool.events) {
+    pool.events = [];
+    pool.nextEventId = 1;
+  }
 });
 
-test('POST /api/events stores analytics events', async () => {
-  const res = await fetch(`${baseUrl}/api/events`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify([
-      { event: 'load', payload: { a: 1 } },
-      { event: 'click', payload: { b: 2 } },
-    ]),
-  });
-  assert.equal(res.status, 201);
-  const body = await res.json();
-  assert.equal(body.inserted, 2);
+test(
+  'POST /api/patients inserts a patient record',
+  { concurrency: false },
+  async () => {
+    const res = await fetch(`${baseUrl}/api/patients`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Alice', payload: { foo: 'bar' } }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.name, 'Alice');
 
-  const { rows } = await pool.query('SELECT * FROM events');
-  assert.equal(rows.length, 2);
-  assert.deepEqual(
-    rows.map((r) => r.event),
-    ['load', 'click'],
-  );
-});
+    const { rows } = await pool.query('SELECT * FROM patients');
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].name, 'Alice');
+  },
+);
+
+test(
+  'POST /api/patients accepts camelCase identifiers and data payload',
+  { concurrency: false },
+  async () => {
+    const res = await fetch(`${baseUrl}/api/patients`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        patientId: '42',
+        name: 'Bob',
+        data: { version: 1, data: { foo: 'baz' } },
+        lastUpdated: '2024-02-02T00:00:00.000Z',
+      }),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(String(body.patient_id), '42');
+    assert.deepEqual(body.payload, { version: 1, data: { foo: 'baz' } });
+    assert.equal(body.name, 'Bob');
+    assert.equal(body.last_updated.slice(0, 19), '2024-02-02T00:00:00');
+
+    const { rows } = await pool.query('SELECT * FROM patients');
+    assert.equal(rows.length, 1);
+    assert.equal(String(rows[0].patient_id), '42');
+    assert.deepEqual(rows[0].payload, { version: 1, data: { foo: 'baz' } });
+  },
+);
+
+test(
+  'POST /api/events stores analytics events',
+  { concurrency: false },
+  async () => {
+    const res = await fetch(`${baseUrl}/api/events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify([
+        { event: 'load', payload: { a: 1 } },
+        { event: 'click', payload: { b: 2 } },
+      ]),
+    });
+    assert.equal(res.status, 201);
+    const body = await res.json();
+    assert.equal(body.inserted, 2);
+
+    const { rows } = await pool.query('SELECT * FROM events');
+    assert.equal(rows.length, 2);
+    assert.deepEqual(
+      rows.map((r) => r.event),
+      ['load', 'click'],
+    );
+  },
+);

--- a/test/restorePatients.test.js
+++ b/test/restorePatients.test.js
@@ -18,6 +18,7 @@ test('restorePatients merges array responses using patient_id', async () => {
   localStorage.clear();
   setLocal({ local1: { name: 'Local', lastUpdated: '2020-01-01' } });
   navigator.onLine = true;
+  window.disableSync = false;
 
   const remotePatients = [
     {
@@ -27,6 +28,7 @@ test('restorePatients merges array responses using patient_id', async () => {
     },
   ];
 
+  const origFetch = global.fetch;
   global.fetch = async () => ({
     status: 200,
     ok: true,
@@ -34,10 +36,13 @@ test('restorePatients merges array responses using patient_id', async () => {
   });
 
   await restorePatients();
+  global.fetch = origFetch;
 
   const stored = getLocal();
   assert.ok(stored.local1);
   assert.ok(stored.remote1);
   assert.equal(stored.remote1.name, 'Remote');
   assert.equal(stored.remote1.needsSync, false);
+  assert.equal(stored.remote1.patientId, 'remote1');
+  assert.equal(stored.remote1.lastUpdated, '2024-01-01');
 });

--- a/test/syncRoundTrip.test.js
+++ b/test/syncRoundTrip.test.js
@@ -1,0 +1,90 @@
+import { test, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+process.env.NODE_ENV = 'test';
+
+const { app, pool } = await import('../server/index.js');
+
+let server;
+let baseUrl;
+
+const LS_KEY = 'insultoKomandaPatients_v1';
+
+before(() => {
+  server = app.listen(0);
+  baseUrl = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => {
+  server.close();
+});
+
+test(
+  'syncPatients + restorePatients round-trip preserves schema payload',
+  { concurrency: false },
+  async () => {
+    navigator.onLine = true;
+    localStorage.clear();
+    if (pool.patients) {
+      pool.patients = [];
+      pool.nextPatientId = 1;
+    }
+
+    const patientId = '123';
+    const localPatient = {
+      patientId,
+      name: 'Test Pacientas',
+      created: '2024-01-01T00:00:00.000Z',
+      lastUpdated: '2024-01-02T00:00:00.000Z',
+      needsSync: true,
+      data: {
+        version: 1,
+        data: {
+          foo: 'bar',
+          nested: { value: 5 },
+        },
+      },
+    };
+
+    localStorage.setItem(LS_KEY, JSON.stringify({ [patientId]: localPatient }));
+
+    const previousApiBase = process.env.API_BASE;
+    process.env.API_BASE = `${baseUrl}/api`;
+    localStorage.setItem('disableSync', 'false');
+    const { syncPatients, restorePatients } = await import(
+      '../js/sync.js?roundtrip'
+    );
+    window.disableSync = false;
+
+    await syncPatients();
+
+    const storedAfterSync = JSON.parse(localStorage.getItem(LS_KEY));
+    assert.equal(storedAfterSync[patientId].needsSync, false);
+
+    const { rows } = await pool.query('SELECT * FROM patients');
+    assert.equal(rows.length, 1);
+    assert.equal(String(rows[0].patient_id), patientId);
+    assert.equal(rows[0].name, 'Test Pacientas');
+    assert.deepEqual(rows[0].payload, localPatient.data);
+
+    localStorage.clear();
+
+    await restorePatients();
+
+    const restored = JSON.parse(localStorage.getItem(LS_KEY));
+    assert.ok(restored[patientId]);
+    assert.equal(restored[patientId].patientId, patientId);
+    assert.equal(restored[patientId].name, 'Test Pacientas');
+    assert.deepEqual(restored[patientId].data, localPatient.data);
+    assert.equal(restored[patientId].needsSync, false);
+    assert.equal(
+      restored[patientId].lastUpdated.slice(0, 19),
+      '2024-01-02T00:00:00',
+    );
+
+    if (previousApiBase === undefined) delete process.env.API_BASE;
+    else process.env.API_BASE = previousApiBase;
+    localStorage.removeItem('disableSync');
+  },
+);


### PR DESCRIPTION
## Summary
- normalize outgoing patient sync requests to use patient_id/payload/last_updated keys and convert server responses back into local schema
- teach the patient API handler and fake pool to accept camelCase identifiers, payload/data aliases, and preserve provided timestamps
- expand coverage with a full sync round-trip test plus adjustments to persistence tests and restore expectations

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb0f088d7c8320b3a7ed018e766a1b