### PR TITLE
Migrate patient IDs to UUID strings

### DIFF
--- a/server/migrations/20240401000000_change_patient_id_to_text.js
+++ b/server/migrations/20240401000000_change_patient_id_to_text.js
@@ -1,0 +1,45 @@
+export async function up(knex) {
+  await knex.schema.alterTable('patients', (table) => {
+    table.dropPrimary();
+  });
+
+  await knex.raw(
+    `ALTER TABLE patients
+      ALTER COLUMN patient_id DROP DEFAULT,
+      ALTER COLUMN patient_id TYPE text USING patient_id::text`
+  );
+
+  await knex.raw('ALTER TABLE patients ALTER COLUMN patient_id SET NOT NULL');
+  await knex.raw('DROP SEQUENCE IF EXISTS patients_patient_id_seq');
+
+  await knex.schema.alterTable('patients', (table) => {
+    table.primary(['patient_id']);
+  });
+}
+
+export async function down(knex) {
+  await knex.schema.alterTable('patients', (table) => {
+    table.dropPrimary();
+  });
+
+  await knex.raw('CREATE SEQUENCE IF NOT EXISTS patients_patient_id_seq');
+
+  await knex.raw(
+    `ALTER TABLE patients
+      ALTER COLUMN patient_id TYPE integer USING NULLIF(patient_id, '')::integer,
+      ALTER COLUMN patient_id SET DEFAULT nextval('patients_patient_id_seq'),
+      ALTER COLUMN patient_id SET NOT NULL`
+  );
+
+  await knex.raw(
+    `SELECT setval(
+      'patients_patient_id_seq',
+      COALESCE((SELECT MAX(patient_id) FROM patients), 0),
+      true
+    )`
+  );
+
+  await knex.schema.alterTable('patients', (table) => {
+    table.primary(['patient_id']);
+  });
+}

--- a/test/syncRoundTrip.test.js
+++ b/test/syncRoundTrip.test.js
@@ -1,5 +1,6 @@
 import { test, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
 import './jsdomSetup.js';
 
 process.env.NODE_ENV = 'test';
@@ -31,7 +32,7 @@ test(
       pool.nextPatientId = 1;
     }
 
-    const patientId = '123';
+    const patientId = randomUUID();
     const localPatient = {
       patientId,
       name: 'Test Pacientas',


### PR DESCRIPTION
## Summary
- convert the patients table primary key to a text-based identifier so UUIDs can be stored and still upsert on conflict
- generate UUID identifiers in the browser/server code paths and keep the fake PG pool compatible with string IDs
- refresh API persistence and sync round-trip tests to exercise randomUUID inserts and updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb9b368fd88320a60cfb35845c6426