### PR TITLE
Ensure sync preference defaults to enabled

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -16,7 +16,7 @@ let consecutiveSyncFails = 0;
 
 if (typeof window !== 'undefined') {
   const saved = localStorage.getItem('disableSync');
-  window.disableSync = saved !== 'false';
+  window.disableSync = saved === 'true';
 }
 
 function buildServerPayload(id, record) {

--- a/test/disableSync.test.js
+++ b/test/disableSync.test.js
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+const LS_KEY = 'insultoKomandaPatients_v1';
+
+function seedPatient() {
+  const patientId = 'demo';
+  const patient = {
+    patientId,
+    name: 'Test Pacientas',
+    created: '2024-01-01T00:00:00.000Z',
+    lastUpdated: '2024-01-01T00:00:00.000Z',
+    needsSync: true,
+    data: { version: 1, data: { foo: 'bar' } },
+  };
+  localStorage.setItem(LS_KEY, JSON.stringify({ [patientId]: patient }));
+}
+
+test(
+  'stored disableSync="false" keeps sync enabled after reload',
+  { concurrency: false },
+  async () => {
+    localStorage.clear();
+    navigator.onLine = true;
+    localStorage.setItem('disableSync', 'false');
+    seedPatient();
+
+    const { syncPatients } = await import('../js/sync.js?persistFalse');
+    assert.equal(window.disableSync, false);
+    assert.equal(localStorage.getItem('disableSync'), 'false');
+
+    const calls = [];
+    const originalFetch = global.fetch;
+    global.fetch = async (url, options = {}) => {
+      calls.push({ url, method: options.method });
+      return { ok: true, status: 200 };
+    };
+
+    try {
+      await syncPatients();
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].url.endsWith('/patients'));
+  },
+);
+
+test(
+  'syncPatients runs on first load when sync has never been disabled',
+  { concurrency: false },
+  async () => {
+    localStorage.clear();
+    navigator.onLine = true;
+    seedPatient();
+
+    const { syncPatients } = await import('../js/sync.js?firstLoadCheck');
+    assert.equal(window.disableSync, false);
+
+    const calls = [];
+    const originalFetch = global.fetch;
+    global.fetch = async (url, options = {}) => {
+      calls.push({ url, method: options.method });
+      return { ok: true, status: 200 };
+    };
+
+    try {
+      await syncPatients();
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(calls.length, 1);
+    assert.ok(calls[0].url.endsWith('/patients'));
+  },
+);


### PR DESCRIPTION
## Summary
- only treat the stored disableSync flag as enabled when the saved value is "true"
- add regression tests to cover the stored preference and initial sync behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbc7800ac88320a74b06c6dd8eeceb