### PR TITLE
Persist disable sync flag on failure and add regression test

### DIFF
--- a/js/sync.js
+++ b/js/sync.js
@@ -203,6 +203,10 @@ export async function syncPatients() {
       consecutiveSyncFails >= MAX_CONSECUTIVE_SYNC_FAILS
     ) {
       window.disableSync = true;
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('disableSync', 'true');
+      }
+      syncEnableLocalBtnState();
       showToast(t('local_storage_enabled'), { type: 'info' });
     }
   } else {
@@ -263,6 +267,15 @@ export async function restorePatients() {
   }
 }
 
+function syncEnableLocalBtnState() {
+  if (typeof document === 'undefined') return;
+  const enableLocalBtn = document.getElementById('enableLocalBtn');
+  if (!enableLocalBtn) return;
+  const disabled = Boolean(window.disableSync);
+  enableLocalBtn.checked = disabled;
+  enableLocalBtn.setAttribute('aria-checked', String(disabled));
+}
+
 if (typeof window !== 'undefined') {
   window.addEventListener('online', () => {
     syncPatients();
@@ -276,13 +289,12 @@ if (typeof document !== 'undefined') {
   });
   const enableLocalBtn = document.getElementById('enableLocalBtn');
   if (enableLocalBtn) {
-    enableLocalBtn.checked = window.disableSync;
-    enableLocalBtn.setAttribute('aria-checked', window.disableSync);
+    syncEnableLocalBtnState();
     enableLocalBtn.addEventListener('change', () => {
       const enabled = enableLocalBtn.checked;
-      enableLocalBtn.setAttribute('aria-checked', enabled);
       window.disableSync = enabled;
       localStorage.setItem('disableSync', String(enabled));
+      syncEnableLocalBtnState();
       if (enabled) {
         showToast(t('local_storage_enabled'), { type: 'info' });
       } else {

--- a/test/sync.test.js
+++ b/test/sync.test.js
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './jsdomSetup.js';
+
+const LS_KEY = 'insultoKomandaPatients_v1';
+
+function seedPatient() {
+  const patientId = 'demo';
+  const patient = {
+    patientId,
+    name: 'Test Pacientas',
+    created: '2024-01-01T00:00:00.000Z',
+    lastUpdated: '2024-01-01T00:00:00.000Z',
+    needsSync: true,
+    data: { version: 1, data: { foo: 'bar' } },
+  };
+  localStorage.setItem(LS_KEY, JSON.stringify({ [patientId]: patient }));
+}
+
+test(
+  'sync disables after three consecutive failures and stays disabled after reload',
+  { concurrency: false },
+  async () => {
+    localStorage.clear();
+    navigator.onLine = true;
+    window.disableSync = false;
+    seedPatient();
+
+    const originalFetch = global.fetch;
+
+    let failCalls = 0;
+    global.fetch = async () => {
+      failCalls += 1;
+      return { ok: false, status: 500 };
+    };
+
+    try {
+      const { syncPatients } = await import('../js/sync.js?consecutiveFails');
+      for (let i = 0; i < 3; i += 1) {
+        await syncPatients();
+      }
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    assert.equal(failCalls, 3);
+    assert.equal(window.disableSync, true);
+    assert.equal(localStorage.getItem('disableSync'), 'true');
+
+    const toggle = document.getElementById('enableLocalBtn');
+    assert.ok(toggle);
+    assert.equal(toggle.checked, true);
+    assert.equal(toggle.getAttribute('aria-checked'), 'true');
+
+    toggle.checked = false;
+    toggle.setAttribute('aria-checked', 'false');
+    window.disableSync = false;
+
+    let postReloadCalls = 0;
+    const originalFetchAfter = global.fetch;
+    global.fetch = async () => {
+      postReloadCalls += 1;
+      return { ok: true, status: 200 };
+    };
+
+    try {
+      const { syncPatients: syncAfterReload } = await import(
+        '../js/sync.js?afterReload'
+      );
+      assert.equal(window.disableSync, true);
+      const toggleAfter = document.getElementById('enableLocalBtn');
+      assert.ok(toggleAfter);
+      assert.equal(toggleAfter.checked, true);
+      assert.equal(toggleAfter.getAttribute('aria-checked'), 'true');
+
+      await syncAfterReload();
+      assert.equal(postReloadCalls, 0);
+    } finally {
+      global.fetch = originalFetchAfter;
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- persist the disableSync flag to localStorage when automatic disablement occurs and refresh the toggle UI via a helper
- centralize enableLocal toggle synchronization so it stays aligned with window.disableSync
- add a regression test that simulates three consecutive sync failures and verifies the flag survives a reload

## Testing
- npm test -- test/sync.test.js
- node --test


------
https://chatgpt.com/codex/tasks/task_e_68cbd14ff9588320a5c48058217555c2