### PR TITLE
Prevent mirrored radio change recursion

### DIFF
--- a/js/storage/fields.js
+++ b/js/storage/fields.js
@@ -212,14 +212,26 @@ if (typeof document !== 'undefined') {
     document.querySelectorAll('input[name="p_independent"]'),
   );
   function mirror(src, target) {
-    src.forEach((el) => {
-      el.addEventListener('change', () => {
-        if (!el.checked) return;
+    let isSyncing = false;
+
+    function sync(el) {
+      if (!el.checked || isSyncing) return;
+      isSyncing = true;
+      try {
         target.forEach((t) => {
-          t.checked = t.value === el.value;
-          t.dispatchEvent(new Event('change', { bubbles: true }));
+          const shouldCheck = t.value === el.value;
+          if (t.checked !== shouldCheck) {
+            t.checked = shouldCheck;
+            t.dispatchEvent(new Event('change', { bubbles: true }));
+          }
         });
-      });
+      } finally {
+        isSyncing = false;
+      }
+    }
+
+    src.forEach((el) => {
+      el.addEventListener('change', () => sync(el));
     });
   }
   mirror(aNodes, pNodes);


### PR DESCRIPTION
## Summary
- avoid recursive dispatch loops when mirroring independent radio buttons
- only dispatch change events when the target radio state actually changes
- guard each mirror pair with a re-entrancy flag to ignore programmatic updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbf37af01483209c27a8ead2328d93