### PR TITLE
Add Supabase edge functions for patients and events

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,41 @@ npm run build
 
 For additional database setup details and Docker Compose instructions, see [docs/postgres.md](docs/postgres.md), including the [Using Supabase](docs/postgres.md#using-supabase) section for managed databases.
 
+## Supabase Edge Functions
+
+Mirror the Express patient and analytics endpoints with Supabase Edge Functions when you want a fully serverless deployment.
+
+1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and authenticate against your project.
+2. Configure the secrets required by both functions (replace the placeholders with your values):
+
+   ```sh
+   supabase secrets set \
+     SUPABASE_URL="https://<project-ref>.supabase.co" \
+     SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
+   ```
+
+3. Deploy both functions:
+
+   ```sh
+   supabase functions deploy patients events
+   ```
+
+4. After deployment the functions are available at:
+
+   - `https://<project-ref>.functions.supabase.co/patients`
+   - `https://<project-ref>.functions.supabase.co/events`
+
+   Replace `<project-ref>` with your Supabase project reference (see **Project Settings → General**).
+
+5. Test them with curl:
+
+   ```sh
+   curl https://<project-ref>.functions.supabase.co/patients
+   curl -X POST https://<project-ref>.functions.supabase.co/events \
+     -H 'Content-Type: application/json' \
+     -d '[{"event":"demo","payload":{"ok":true}}]'
+   ```
+
 ## Database setup
 
 Create a `.env` file in the project root with your database connection string:

--- a/supabase/functions/events/index.ts
+++ b/supabase/functions/events/index.ts
@@ -1,0 +1,87 @@
+import { createClient } from 'npm:@supabase/supabase-js';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+if (!supabaseUrl || !serviceRoleKey) {
+  console.error('Missing required SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables');
+  throw new Error('Supabase environment variables are not set');
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+const corsHeaders: HeadersInit = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function jsonResponse(status: number, body: unknown, extraHeaders: HeadersInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+      ...extraHeaders,
+    },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        ...corsHeaders,
+        'Access-Control-Allow-Methods': 'OPTIONS, POST',
+      },
+    });
+  }
+
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' }, {
+      Allow: 'OPTIONS, POST',
+      'Access-Control-Allow-Methods': 'OPTIONS, POST',
+    });
+  }
+
+  let events: unknown;
+  try {
+    events = await req.json();
+  } catch (_error) {
+    return jsonResponse(400, { error: 'Invalid JSON body' });
+  }
+
+  if (!Array.isArray(events) || events.length === 0) {
+    return jsonResponse(400, { error: 'Events payload must be a non-empty array' });
+  }
+
+  const normalizedEvents: { event: string; payload: unknown }[] = [];
+  for (let index = 0; index < events.length; index += 1) {
+    const entry = events[index];
+    if (typeof entry !== 'object' || entry === null) {
+      return jsonResponse(400, { error: `Invalid event at index ${index}` });
+    }
+
+    const { event, payload } = entry as { event?: unknown; payload?: unknown };
+    if (typeof event !== 'string' || event.trim() === '') {
+      return jsonResponse(400, { error: `Invalid event name at index ${index}` });
+    }
+
+    normalizedEvents.push({
+      event: event.trim(),
+      payload: payload ?? null,
+    });
+  }
+
+  try {
+    const { error } = await supabase.from('events').insert(normalizedEvents);
+    if (error) throw error;
+  } catch (error) {
+    console.error('Error inserting events', error);
+    return jsonResponse(500, { error: 'Internal server error' });
+  }
+
+  return jsonResponse(201, { inserted: normalizedEvents.length });
+});

--- a/supabase/functions/patients/index.ts
+++ b/supabase/functions/patients/index.ts
@@ -1,0 +1,143 @@
+import { createClient } from 'npm:@supabase/supabase-js';
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL');
+const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY');
+
+if (!supabaseUrl || !serviceRoleKey) {
+  console.error('Missing required SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY environment variables');
+  throw new Error('Supabase environment variables are not set');
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey, {
+  auth: { persistSession: false },
+});
+
+const corsHeaders: HeadersInit = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+/**
+ * Create a JSON response with shared CORS headers.
+ */
+function jsonResponse(status: number, body: unknown, extraHeaders: HeadersInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...corsHeaders,
+      ...extraHeaders,
+    },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, {
+      status: 204,
+      headers: {
+        ...corsHeaders,
+        'Access-Control-Allow-Methods': 'OPTIONS, GET, POST',
+      },
+    });
+  }
+
+  if (req.method === 'GET') {
+    const { data, error } = await supabase
+      .from('patients')
+      .select('*')
+      .order('last_updated', { ascending: false });
+
+    if (error) {
+      console.error('Error fetching patients', error);
+      return jsonResponse(500, { error: 'Internal server error' });
+    }
+
+    return jsonResponse(200, data ?? []);
+  }
+
+  if (req.method === 'POST') {
+    let body: unknown;
+    try {
+      body = await req.json();
+    } catch (_error) {
+      return jsonResponse(400, { error: 'Invalid JSON body' });
+    }
+
+    if (typeof body !== 'object' || body === null) {
+      return jsonResponse(400, { error: 'Invalid request body' });
+    }
+
+    const payload = body as Record<string, unknown>;
+    const {
+      patient_id: snakeId,
+      patientId: camelId,
+      name,
+      payload: bodyPayload,
+      data,
+      last_updated: snakeLastUpdated,
+      lastUpdated: camelLastUpdated,
+    } = payload;
+
+    if (typeof name !== 'string' || name.trim() === '') {
+      return jsonResponse(400, { error: 'Invalid patient name' });
+    }
+
+    const resolvedPatientId = snakeId ?? camelId;
+    if (
+      resolvedPatientId !== undefined &&
+      resolvedPatientId !== null &&
+      `${resolvedPatientId}`.trim() === ''
+    ) {
+      return jsonResponse(400, { error: 'Invalid patient_id' });
+    }
+
+    const resolvedPayload = bodyPayload ?? data;
+    if (typeof resolvedPayload !== 'object' || resolvedPayload === null) {
+      return jsonResponse(400, { error: 'Invalid payload' });
+    }
+
+    const resolvedLastUpdated = snakeLastUpdated ?? camelLastUpdated ?? null;
+    let normalizedLastUpdated: string;
+    if (resolvedLastUpdated === null) {
+      normalizedLastUpdated = new Date().toISOString();
+    } else {
+      const parsedLastUpdated = new Date(String(resolvedLastUpdated));
+      if (Number.isNaN(parsedLastUpdated.getTime())) {
+        return jsonResponse(400, { error: 'Invalid last_updated value' });
+      }
+      normalizedLastUpdated = parsedLastUpdated.toISOString();
+    }
+
+    const normalizedPatientId =
+      resolvedPatientId !== undefined && resolvedPatientId !== null
+        ? `${resolvedPatientId}`.trim()
+        : crypto.randomUUID();
+
+    const { data: upserted, error } = await supabase
+      .from('patients')
+      .upsert(
+        {
+          patient_id: normalizedPatientId,
+          name: name.trim(),
+          payload: resolvedPayload,
+          last_updated: normalizedLastUpdated,
+        },
+        { onConflict: 'patient_id' }
+      )
+      .select()
+      .single();
+
+    if (error) {
+      console.error('Error upserting patient', error);
+      return jsonResponse(500, { error: 'Internal server error' });
+    }
+
+    return jsonResponse(201, upserted);
+  }
+
+  return jsonResponse(405, { error: 'Method not allowed' }, {
+    Allow: 'OPTIONS, GET, POST',
+    'Access-Control-Allow-Methods': 'OPTIONS, GET, POST',
+  });
+});


### PR DESCRIPTION
## Summary
- add Supabase Edge Functions for patients and events with service role client initialization and CORS handling
- implement patient GET/POST logic with validation and upsert plus event batch insert mirroring Express API
- document deployment, secrets configuration, and public URLs for the new functions in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc701aaf308320a95bdf3a800d4ff3