### PR TITLE
Configure Supabase globals and GitHub Pages deploy

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,3 @@
+# Production environment variables.
+# Pakeiskite <project-ref> į savo Supabase projekto identifikatorių.
+API_BASE=https://<project-ref>.functions.supabase.co

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,42 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run lint
+      - run: npm run build
+
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm ci
+      - name: Build with production env
+        run: |
+          set -a
+          source .env.production
+          set +a
+          npm run build
+      - name: Paruošti GitHub Pages paketą
+        run: |
+          rm -rf dist
+          mkdir -p dist
+          cp index.html dist/
+          cp manifest.json dist/
+          cp sw.js dist/
+          mkdir -p dist/css
+          cp css/style.css dist/css/
+          cp -R js dist/
+          cp -R icons dist/
+          cp -R locales dist/
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: dist

--- a/README.md
+++ b/README.md
@@ -161,6 +161,19 @@ loading the scripts:
 </script>
 ```
 
+### GitHub Pages deployment
+
+- Pushes to `main` trigger the CI workflow, which now runs `npm run build` and
+  publishes the contents of `dist/` to the `gh-pages` branch. Configure GitHub
+  Pages to serve from that branch (root folder).
+- The deploy job sources values from `.env.production` before building. Update
+  `API_BASE` inside that file—or define it in your repository/Pages environment
+  variables—to match your Supabase Functions project URL
+  (`https://<project-ref>.functions.supabase.co`).
+- `index.html` defines `window.API_BASE` and `window.DISABLE_ANALYTICS = true`
+  before the application loads. Adjust those assignments if you need analytics
+  or a different API endpoint at runtime.
+
 ## Google Drive export
 
 Enable the **Upload to Drive** button to save summaries directly to Google Drive:

--- a/index.html
+++ b/index.html
@@ -1799,6 +1799,12 @@ Kontraindikacijos trombektomijai</summary>
   </div>
 
     <script>
+      // Supabase Functions API: pakeiskite <project-ref> į savo projekto identifikatorių.
+      window.API_BASE =
+        window.API_BASE || 'https://<project-ref>.functions.supabase.co';
+      window.DISABLE_ANALYTICS = true;
+    </script>
+    <script>
       // OAuth nustatymas: pakeiskite į savo Google Cloud kliento ID, jei naudojate kitą aplinką.
       window.GOOGLE_CLIENT_ID =
         '881217612703-61htpop9nkimqftl50920vfbmou4nq5i.apps.googleusercontent.com';

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -20,6 +20,17 @@
   </head>
   <body>
     {% block content %}{% endblock %}
+    <script>
+      // Supabase Functions API: pakeiskite <project-ref> į savo projekto identifikatorių.
+      window.API_BASE =
+        window.API_BASE || 'https://<project-ref>.functions.supabase.co';
+      window.DISABLE_ANALYTICS = true;
+    </script>
+    <script>
+      // OAuth nustatymas: pakeiskite į savo Google Cloud kliento ID, jei naudojate kitą aplinką.
+      window.GOOGLE_CLIENT_ID =
+        '881217612703-61htpop9nkimqftl50920vfbmou4nq5i.apps.googleusercontent.com';
+    </script>
     <script type="module" src="js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the Supabase Functions base URL and disable analytics before the app script loads while keeping the Google OAuth helper
- ensure the layout template emits the same globals on every build and add a production env file for the API base configuration
- extend CI to run the build, package static assets, and deploy them to the gh-pages branch plus document the GitHub Pages setup in the README

## Testing
- npm test
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ccda2b9f588320823d0f1c7645e2d5