### PR TITLE
Set default Supabase project URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ For additional database setup details and Docker Compose instructions, see [docs
 Mirror the Express patient and analytics endpoints with Supabase Edge Functions when you want a fully serverless deployment.
 
 1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli) and authenticate against your project.
-2. Configure the secrets required by both functions (replace the placeholders with your values):
+2. Configure the secrets required by both functions (update the service role key and adjust the URL only if you deploy to a different Supabase project):
 
    ```sh
    supabase secrets set \
-     SUPABASE_URL="https://<project-ref>.supabase.co" \
+     SUPABASE_URL="https://gpyqtvisuddacmojuzxd.supabase.co" \
      SUPABASE_SERVICE_ROLE_KEY="<service-role-key>"
    ```
 
@@ -81,16 +81,14 @@ Mirror the Express patient and analytics endpoints with Supabase Edge Functions 
 
 4. After deployment the functions are available at:
 
-   - `https://<project-ref>.functions.supabase.co/patients`
-   - `https://<project-ref>.functions.supabase.co/events`
-
-   Replace `<project-ref>` with your Supabase project reference (see **Project Settings → General**).
+   - `https://gpyqtvisuddacmojuzxd.functions.supabase.co/patients`
+   - `https://gpyqtvisuddacmojuzxd.functions.supabase.co/events`
 
 5. Test them with curl:
 
    ```sh
-   curl https://<project-ref>.functions.supabase.co/patients
-   curl -X POST https://<project-ref>.functions.supabase.co/events \
+   curl https://gpyqtvisuddacmojuzxd.functions.supabase.co/patients
+   curl -X POST https://gpyqtvisuddacmojuzxd.functions.supabase.co/events \
      -H 'Content-Type: application/json' \
      -d '[{"event":"demo","payload":{"ok":true}}]'
    ```
@@ -169,7 +167,7 @@ loading the scripts:
 - The deploy job sources values from `.env.production` before building. Update
   `API_BASE` inside that file—or define it in your repository/Pages environment
   variables—to match your Supabase Functions project URL
-  (`https://<project-ref>.functions.supabase.co`).
+  (`https://gpyqtvisuddacmojuzxd.functions.supabase.co`).
 - `index.html` defines `window.API_BASE` and `window.DISABLE_ANALYTICS = true`
   before the application loads. Adjust those assignments if you need analytics
   or a different API endpoint at runtime.

--- a/index.html
+++ b/index.html
@@ -1799,9 +1799,9 @@ Kontraindikacijos trombektomijai</summary>
   </div>
 
     <script>
-      // Supabase Functions API: pakeiskite <project-ref> į savo projekto identifikatorių.
+      // Supabase Functions API numatytasis URL (gpyqtvisuddacmojuzxd projektas).
       window.API_BASE =
-        window.API_BASE || 'https://<project-ref>.functions.supabase.co';
+        window.API_BASE || 'https://gpyqtvisuddacmojuzxd.functions.supabase.co';
       window.DISABLE_ANALYTICS = true;
     </script>
     <script>

--- a/templates/layout.njk
+++ b/templates/layout.njk
@@ -21,9 +21,9 @@
   <body>
     {% block content %}{% endblock %}
     <script>
-      // Supabase Functions API: pakeiskite <project-ref> į savo projekto identifikatorių.
+      // Supabase Functions API numatytasis URL (gpyqtvisuddacmojuzxd projektas).
       window.API_BASE =
-        window.API_BASE || 'https://gpyqtvisuddacmojuzxd.supabase.co';
+        window.API_BASE || 'https://gpyqtvisuddacmojuzxd.functions.supabase.co';
       window.DISABLE_ANALYTICS = true;
     </script>
     <script>


### PR DESCRIPTION
## Summary
- set the default `window.API_BASE` to the gpyqtvisuddacmojuzxd Supabase Edge Functions domain
- document the project-specific Supabase URL and endpoints in the README for quick setup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cce5fb8cc08320b07277987d6ee7b8